### PR TITLE
Add canOpenURL to iOS and Android.

### DIFF
--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -16,6 +16,8 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings.Secure;
+import android.content.pm.PackageManager;
+import android.content.ComponentName;
 
 import java.lang.reflect.Method;
 import java.lang.Runtime;
@@ -369,7 +371,7 @@ public class Moai {
 		for ( Class < ? > theClass : sAvailableClasses ) {
 
 			executeMethod ( theClass, null, "onPause", new Class < ? > [] { }, new Object [] { });
-		}		
+		}	
 	}
 
 	//----------------------------------------------------------------//
@@ -563,7 +565,28 @@ public class Moai {
 
 		sActivity.startActivity ( new Intent ( Intent.ACTION_VIEW, Uri.parse ( url )));
 	}
-		
+	
+	//----------------------------------------------------------------//
+	public static boolean canOpenURL ( String url ) {
+
+		try {
+			PackageManager pm = sActivity.getPackageManager();
+
+			Intent intent = new Intent ( Intent.ACTION_VIEW, Uri.parse ( url ) );
+			ComponentName cn = intent.resolveActivity( pm );
+
+			if ( cn == null )
+				return false;
+
+			MoaiLog.i ( "getPackage() = "+cn.getPackageName()+" class="+cn.getClassName() );
+			return true;
+		}
+		catch ( Exception e) {
+			MoaiLog.e ( "Error checking package ", e);
+			return false;
+		}
+	}
+
 	//----------------------------------------------------------------//
 	public static void share ( String prompt, String subject, String text ) {
 

--- a/src/moaiext-android/MOAIAppAndroid.cpp
+++ b/src/moaiext-android/MOAIAppAndroid.cpp
@@ -51,6 +51,45 @@ int MOAIAppAndroid::_openURL ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	canOpenURL
+	@text	Return true if the device has an app installed that can open the URL.
+	
+	@in		string	url				The URL to check.
+	@out 	boolean
+*/
+int MOAIAppAndroid::_canOpenURL ( lua_State* L ) {
+	
+	MOAILuaState state ( L );
+	
+	cc8* url = lua_tostring ( state, 1 );
+	
+	JNI_GET_ENV ( jvm, env );
+
+	JNI_GET_JSTRING ( url, jurl );
+
+	jclass moai = env->FindClass ( "com/ziplinegames/moai/Moai" );
+    if ( moai == NULL ) {
+
+		USLog::Print ( "MOAIAppAndroid: Unable to find java class %s", "com/ziplinegames/moai/Moai" );
+    } else {
+
+    	jmethodID canOpenURL = env->GetStaticMethodID ( moai, "canOpenURL", "(Ljava/lang/String;)Z" );
+    	if ( canOpenURL == NULL ) {
+
+			USLog::Print ( "MOAIAppAndroid: Unable to find static java method %s", "canOpenURL" );
+    	} else {
+
+			jboolean jsuccess = ( jboolean )env->CallStaticBooleanMethod ( moai, canOpenURL, jurl );	
+			lua_pushboolean( state, jsuccess );
+			return 1;
+		}
+	}
+	
+	return 0;
+}
+
+
+//----------------------------------------------------------------//
 int MOAIAppAndroid::_setListener ( lua_State* L ) {
 	
 	MOAILuaState state ( L );
@@ -132,6 +171,7 @@ void MOAIAppAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 
 	luaL_Reg regTable [] = {
 		{ "openURL",		_openURL },
+		{ "canOpenURL",		_canOpenURL },
 		{ "setListener",	_setListener },
 		{ "share",			_share },
 		{ NULL, NULL }

--- a/src/moaiext-android/MOAIAppAndroid.h
+++ b/src/moaiext-android/MOAIAppAndroid.h
@@ -32,6 +32,7 @@ private:
 	
 	//----------------------------------------------------------------//
 	static int	_openURL		( lua_State* L );
+	static int	_canOpenURL		( lua_State* L );
 	static int	_setListener	( lua_State* L );
 	static int	_share			( lua_State* L );
 

--- a/src/moaiext-iphone/MOAISafariIOS.h
+++ b/src/moaiext-iphone/MOAISafariIOS.h
@@ -20,6 +20,7 @@ private:
 
 	//----------------------------------------------------------------//
 	static int	_openURL			( lua_State* L );
+	static int	_canOpenURL			( lua_State* L );
 	static int	_openURLWithParams	( lua_State* L );
 
 public:

--- a/src/moaiext-iphone/MOAISafariIOS.mm
+++ b/src/moaiext-iphone/MOAISafariIOS.mm
@@ -32,6 +32,31 @@ int MOAISafariIOS::_openURL ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	canOpenURL
+ @text	Return true if iOS will handle the passed URL.
+ 
+ @in	string url
+ @out	boolean
+ */
+int MOAISafariIOS::_canOpenURL ( lua_State* L ) {
+	
+	MOAILuaState state ( L );
+	
+	cc8* url = state.GetValue < cc8* >( 1, "" );
+	
+	if ( url && url [ 0 ] != '\0' ) {
+		
+		lua_pushboolean (state, [[ UIApplication sharedApplication ] canOpenURL:[ NSURL URLWithString:[ NSString stringWithFormat: @"%s", url ]]]);
+		return 1;
+		
+	}
+	
+	lua_pushnil( state );
+	
+	return 1;
+}
+
+//----------------------------------------------------------------//
 /**	@name	openURLWithParams
 	@text	Open the native device web browser at the specified URL
 			with the specified list of query string parameters.
@@ -87,6 +112,7 @@ void MOAISafariIOS::RegisterLuaClass ( MOAILuaState& state ) {
 	
 	luaL_Reg regTable [] = {
 		{ "openURL",			_openURL },
+		{ "canOpenURL",			_canOpenURL }, 
 		{ "openURLWithParams",	_openURLWithParams },
 		{ NULL, NULL }
 	};


### PR DESCRIPTION
- Add MOAISafariIOS.canOpenURL
- Add MOAIAppAndroid.canOpenURL

These methods can be used to check if an app is installed that will handle the URL's protocol.  I am using them to test if the Facebook native App is installed, with the URL fb://home
