### PR TITLE
Adding fill method to MOAIGrid. 

### DIFF
--- a/src/moaicore/MOAIGrid.cpp
+++ b/src/moaicore/MOAIGrid.cpp
@@ -37,6 +37,24 @@ int MOAIGrid::_clearTileFlags ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	fill
+	@text	Set all tiles to a single value
+
+	@in		MOAIGrid self
+	@in		number value
+	@out	nil
+*/
+int MOAIGrid::_fill ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIGrid, "UN" )
+
+	u32 value	= state.GetValue < u32 >( 2, 1 );
+	
+	self->Fill ( value );
+	
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /**	@name	getTile
 	@text	Returns the value of a given tile.
 
@@ -226,6 +244,13 @@ int MOAIGrid::_toggleTileFlags ( lua_State* L ) {
 //================================================================//
 
 //----------------------------------------------------------------//
+void MOAIGrid::Fill ( u32 value ) {
+
+	this->mTiles.Fill ( value );
+	return;
+}
+
+//----------------------------------------------------------------//
 u32 MOAIGrid::GetTile ( int xTile, int yTile ) {
 
 	MOAICellCoord coord ( xTile, yTile );
@@ -268,6 +293,7 @@ void MOAIGrid::RegisterLuaFuncs ( MOAILuaState& state ) {
 
 	luaL_Reg regTable [] = {
 		{ "clearTileFlags",		_clearTileFlags },
+		{ "fill",				_fill },
 		{ "getTile",			_getTile },
 		{ "getTileFlags",		_getTileFlags },
 		{ "setRow",				_setRow },

--- a/src/moaicore/MOAIGrid.h
+++ b/src/moaicore/MOAIGrid.h
@@ -22,6 +22,7 @@ private:
 
 	//----------------------------------------------------------------//
 	static int		_clearTileFlags		( lua_State* L );
+	static int		_fill				( lua_State* L );
 	static int		_getTile			( lua_State* L );
 	static int		_getTileFlags		( lua_State* L );
 	static int		_setRow				( lua_State* L );
@@ -42,6 +43,7 @@ public:
 	u32				GetTile				( int xTile, int yTile );
 					MOAIGrid			();
 					~MOAIGrid			();
+	void			Fill				( u32 value );
 	void			RegisterLuaClass	( MOAILuaState& state );
 	void			RegisterLuaFuncs	( MOAILuaState& state );
 	void			RowFromString		( u32 rowID, cc8* str );


### PR DESCRIPTION
I find myself needing to fill MOAIGrid with a single Non-zero value. I like this better than iterating over the grid in Lua or streaming the tiles in. 

I've tested it in my game and with a the deck/tilemap-animated sample. Also tried to break it by using on an MOAIGrid without calling grid:setSize first, but it's working fine.

This is my first contribution to a open source repo, and I'm not exactly sure of the etiquette. Does a change like this warrant an example in the samples folder?
