### PR TITLE
Fix moaienv doc

### DIFF
--- a/src/moaicore/MOAIEnvironment.h
+++ b/src/moaicore/MOAIEnvironment.h
@@ -80,6 +80,7 @@
 			<li>verticalResolution</li>
 			<li>horizontalResolution</li>
 			<li>udid</li>
+			<li>openUdid</li>
 			</ul>
 			</p>
 	

--- a/src/moaicore/MOAIEnvironment.h
+++ b/src/moaicore/MOAIEnvironment.h
@@ -77,8 +77,8 @@
 			<li>osVersion</li>
 			<li>resourceDirectory</li>
 			<li>screenDpi</li>
-			<li>screenHeight</li>
-			<li>screenWidth</li>
+			<li>verticalResolution</li>
+			<li>horizontalResolution</li>
 			<li>udid</li>
 			</ul>
 			</p>


### PR DESCRIPTION
The doxygen documentation for `MOAIEnvironment` is stale with respect to the valid keys. This syncs the list in the doxygen documentation with the actual `#define`d fields.
