### PR TITLE
Log file-open failures

### DIFF
--- a/src/moaicore/MOAIFont.cpp
+++ b/src/moaicore/MOAIFont.cpp
@@ -445,7 +445,7 @@ MOAITextureBase* MOAIFont::GetGlyphTexture ( MOAIGlyph& glyph ) {
 //----------------------------------------------------------------//
 void MOAIFont::Init ( cc8* filename ) {
 
-	if ( USFileSys::CheckFileExists ( filename )) {
+	if ( MOAILogMessages::CheckFileExists ( filename )) {
 		this->mFilename = USFileSys::GetAbsoluteFilePath ( filename );
 	}
 }

--- a/src/moaicore/MOAIImage.cpp
+++ b/src/moaicore/MOAIImage.cpp
@@ -1346,6 +1346,8 @@ void MOAIImage::Load ( cc8* filename, u32 transform ) {
 	if ( stream.OpenRead ( filename )) {
 		this->Load ( stream, transform );
 		stream.Close ();
+	} else {
+		MOAILog ( NULL, MOAILogMessages::MOAI_FileOpenError_S, filename );
 	}
 }
 

--- a/src/moaicore/MOAILogMessages.cpp
+++ b/src/moaicore/MOAILogMessages.cpp
@@ -80,6 +80,7 @@ void MOAILogMessages::RegisterDefaultLogMessages () {
 		
 		log.RegisterLogMessage ( MOAI_BadCast_DS,						MOAILogMgr::LOG_ERROR,		"Bad cast at position %d: unexpected '%s'" );
 		log.RegisterLogMessage ( MOAI_FileNotFound_S,					MOAILogMgr::LOG_ERROR,		"File not found: %s" );
+		log.RegisterLogMessage ( MOAI_FileOpenError_S,			MOAILogMgr::LOG_ERROR,	"Couldn't open file: '%s'" );
 		log.RegisterLogMessage ( MOAI_FunctionDeprecated_S,				MOAILogMgr::LOG_WARNING,	"WARNING: Function '%s' has been deprecated." );
 		log.RegisterLogMessage ( MOAI_IndexNoReserved,					MOAILogMgr::LOG_ERROR,		"Nothing reserved" );
 		log.RegisterLogMessage ( MOAI_IndexOutOfRange_DDD,				MOAILogMgr::LOG_ERROR,		"Index %d is out of acceptable range [%d, %d]" );

--- a/src/moaicore/MOAILogMessages.h
+++ b/src/moaicore/MOAILogMessages.h
@@ -22,6 +22,7 @@ public:
 	enum {
 		MOAI_BadCast_DS,
 		MOAI_FileNotFound_S,
+		MOAI_FileOpenError_S,
 		MOAI_FunctionDeprecated_S,
 		MOAI_IndexNoReserved,
 		MOAI_IndexOutOfRange_DDD,

--- a/src/moaicore/MOAITexture.cpp
+++ b/src/moaicore/MOAITexture.cpp
@@ -151,7 +151,7 @@ void MOAITexture::Init ( MOAIImage& image, int srcX, int srcY, int width, int he
 void MOAITexture::Init ( cc8* filename, u32 transform, cc8* debugname ) {
 
 	this->Clear ();
-	if ( USFileSys::CheckFileExists ( filename )) {
+	if ( MOAILogMessages::CheckFileExists ( filename )) {
 		
 		this->mFilename = USFileSys::GetAbsoluteFilePath ( filename );
 		if ( debugname ) {

--- a/src/moaiext-untz/MOAIUntzSound.cpp
+++ b/src/moaiext-untz/MOAIUntzSound.cpp
@@ -140,7 +140,11 @@ int MOAIUntzSound::_load ( lua_State* L ) {
 		self->mFilename = filename;
 		self->mInMemory = loadIntoMemory;
 		//printf ( "creating sound: %s - %s\n", self->mFilename.str(), (loadIntoMemory) ? "in memory" : "not in memory" );
-		self->mSound = UNTZ::Sound::create ( filename, loadIntoMemory );
+		if ( MOAILogMessages::CheckFileExists ( filename )) {
+			self->mSound = UNTZ::Sound::create ( filename, loadIntoMemory );
+		} else {
+			self->mSound = NULL;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
I added some error messages in cases where a file isn't found or can't be opened. It's nice to know right away when this is the case instead of silent failure and then wondering why an image isn't being displayed, sound being played, etc.

Where possible I tried to check whether the file was actually opened successfully, instead of checking for file existence before trying to open it. The latter approach can miss some corner cases such as if the file has incorrect permissions.
