### PR TITLE
Script node apply of attributes should unpack attribute id or it will not be applied

### DIFF
--- a/src/moaicore/MOAIScriptNode.cpp
+++ b/src/moaicore/MOAIScriptNode.cpp
@@ -48,6 +48,7 @@ int MOAIScriptNode::_setCallback ( lua_State* L ) {
 
 //----------------------------------------------------------------//
 bool MOAIScriptNode::ApplyAttrOp ( u32 attrID, MOAIAttrOp& attrOp, u32 op ) {
+	attrID = UNPACK_ATTR(attrID);
 
 	if ( attrID < this->mAttributes.Size ()) {
 		this->mAttributes [ attrID ] = attrOp.Apply ( this->mAttributes [ attrID ], op, MOAIAttrOp::ATTR_READ_WRITE );


### PR DESCRIPTION
Found this bug while trying to pull an attribute from a box2d body. The pull gets triggered correctly but the attribute value is never written because of the array range check with a masked value.

I'm new to the MOAI source and C++ engines in general so I'm not absolutely sure what I've done here, but I think its correct.
