### PR TITLE
Add support for collideConnected flag to MOAIBox2DWorld::_addRopeJoint

### DIFF
--- a/src/moaicore/MOAIBox2DWorld.cpp
+++ b/src/moaicore/MOAIBox2DWorld.cpp
@@ -441,6 +441,7 @@ int	MOAIBox2DWorld::_addRevoluteJoint ( lua_State* L ) {
  @opt		number anchorAY		in units, in world coordinates, converted to meters
  @opt		number anchorBX		in units, in world coordinates, converted to meters
  @opt		number anchorBY		in units, in world coordinates, converted to meters
+ @opt		number collideConnected		Default value is false		
  @out	MOAIBox2DJoint joint
  */
 int	MOAIBox2DWorld::_addRopeJoint ( lua_State* L ) {
@@ -464,6 +465,8 @@ int	MOAIBox2DWorld::_addRopeJoint ( lua_State* L ) {
 
 	jointDef.localAnchorB.x	= state.GetValue < float >( 7, 0 ) * self->mUnitsToMeters;
 	jointDef.localAnchorB.y	= state.GetValue < float >( 8, 0 ) * self->mUnitsToMeters;
+
+	jointDef.collideConnected = state.GetValue < bool >( 9, false );
 	
 	jointDef.bodyA = bodyA->mBody;
 	jointDef.bodyB = bodyB->mBody;


### PR DESCRIPTION
Distance joints support the collideConnected flag already, but rope
joints do not. This is very useful functionality to have and the default is confusing without the presence of the flag, requiring the user to look up the default behavior in the Box2D documents.
