### PR TITLE
FMod MusicSystem integration

### DIFF
--- a/src/moaicore/MOAIFmodMusicEntity.cpp
+++ b/src/moaicore/MOAIFmodMusicEntity.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include <moaicore/MOAIFmodMusicEntity.h>
+
+// register member functions
+void MOAIFmodMusicEntity::RegisterLuaFuncs(MOAILuaState& state) {
+
+	// call any initializers for base classes here:
+	// MOAIFooBase::RegisterLuaFuncs ( state );
+
+	// here are the instance methods:
+	luaL_Reg regTable [] = {
+		{ "getID", _getID },
+		{ "getName", _getName },
+		{ NULL, NULL }
+	};
+
+	luaL_register ( state, 0, regTable );
+}
+
+int MOAIFmodMusicEntity::_getID(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicEntity, "U")
+		state.Push(self->mID);
+	return 1;
+}
+
+int MOAIFmodMusicEntity::_getName(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicEntity, "U")
+		state.Push(self->mName);
+	return 1;
+}

--- a/src/moaicore/MOAIFmodMusicEntity.h
+++ b/src/moaicore/MOAIFmodMusicEntity.h
@@ -1,0 +1,52 @@
+#ifndef MOAIFMODMUSICENTITY__H
+#define MOAIFMODMUSICENTITY__H
+
+#include <moaicore/MOAILua.h>
+#include "fmodinc/fmod.hpp"
+#include "fmoddesignerinc/fmod_event.hpp"
+
+class MOAIFmodMusicEntity :
+	public virtual MOAILuaObject {
+
+friend class MOAIFmodMusicSystem;
+
+private:
+
+	static int _getID(lua_State* L);
+	static int _getName(lua_State* L);
+
+	FMOD_MUSIC_ID mID;
+	const char* mName;
+
+public:
+	DECL_LUA_FACTORY(MOAIFmodMusicEntity)
+
+	MOAIFmodMusicEntity() : mID(0), mName(0) {
+		// register all classes MOAIFoo derives from
+		// we need this for custom RTTI implementation
+		RTTI_BEGIN
+			RTTI_EXTEND ( MOAILuaObject )
+		
+			// and any other objects from multiple inheritance...
+			// RTTI_EXTEND ( MOAIFooBase )
+		RTTI_END
+	}
+	MOAIFmodMusicEntity(const FMOD_MUSIC_ITERATOR& it) : mID(it.value->id), mName(it.value->name) {
+		// register all classes MOAIFoo derives from
+		// we need this for custom RTTI implementation
+		RTTI_BEGIN
+			RTTI_EXTEND ( MOAILuaObject )
+		
+			// and any other objects from multiple inheritance...
+			// RTTI_EXTEND ( MOAIFooBase )
+		RTTI_END
+	}
+	~MOAIFmodMusicEntity() {}
+	
+	void RegisterLuaFuncs(MOAILuaState& state);
+	
+	
+	
+};
+
+#endif

--- a/src/moaicore/MOAIFmodMusicInfo.cpp
+++ b/src/moaicore/MOAIFmodMusicInfo.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include <moaicore/MOAIFmodMusicInfo.h>
+
+// register member functions
+void MOAIFmodMusicInfo::RegisterLuaFuncs(MOAILuaState& state) {
+
+	// call any initializers for base classes here:
+	// MOAIFooBase::RegisterLuaFuncs ( state );
+
+	// here are the instance methods:
+	luaL_Reg regTable [] = {
+		{ "getID", _starving },
+		{ "getName", _allSamplesLoaded },
+		{ NULL, NULL }
+	};
+
+	luaL_register ( state, 0, regTable );
+}
+
+int MOAIFmodMusicInfo::_starving(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicInfo, "U")
+		state.Push(self->mStarving);
+	return 1;
+}
+
+int MOAIFmodMusicInfo::_allSamplesLoaded(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicInfo, "U")
+		state.Push(self->mAllSamplesLoaded);
+	return 1;
+}

--- a/src/moaicore/MOAIFmodMusicInfo.h
+++ b/src/moaicore/MOAIFmodMusicInfo.h
@@ -1,0 +1,56 @@
+#ifndef MOAIFMODMUSICINFO__H
+#define MOAIFMODMUSICINFO__H
+
+#include <moaicore/MOAILua.h>
+#include "fmodinc/fmod.hpp"
+#include "fmoddesignerinc/fmod_event.hpp"
+
+class MOAIFmodMusicInfo :
+	public virtual MOAILuaObject {
+
+friend class MOAIFmodMusicSystem;
+
+private:
+
+	static int _starving(lua_State* L);
+	static int _allSamplesLoaded(lua_State* L);
+
+	FMOD_BOOL mStarving;
+	FMOD_BOOL mAllSamplesLoaded;
+
+
+public:
+	DECL_LUA_FACTORY(MOAIFmodMusicInfo)
+
+	MOAIFmodMusicInfo() : mStarving(false), mAllSamplesLoaded(false) {
+		// register all classes MOAIFoo derives from
+		// we need this for custom RTTI implementation
+		RTTI_BEGIN
+			RTTI_EXTEND ( MOAILuaObject )
+		
+			// and any other objects from multiple inheritance...
+			// RTTI_EXTEND ( MOAIFooBase )
+		RTTI_END
+	}
+
+	MOAIFmodMusicInfo(FMOD_MUSIC_INFO info) : mStarving(info.starving), mAllSamplesLoaded(info.all_samples_loaded) {
+		// register all classes MOAIFoo derives from
+		// we need this for custom RTTI implementation
+		RTTI_BEGIN
+			RTTI_EXTEND ( MOAILuaObject )
+		
+			// and any other objects from multiple inheritance...
+			// RTTI_EXTEND ( MOAIFooBase )
+		RTTI_END
+	}
+
+	
+	~MOAIFmodMusicInfo() {}
+	
+	void RegisterLuaFuncs(MOAILuaState& state);
+	
+	
+	
+};
+
+#endif

--- a/src/moaicore/MOAIFmodMusicSystem.cpp
+++ b/src/moaicore/MOAIFmodMusicSystem.cpp
@@ -1,0 +1,602 @@
+// Copyright (c) 2010-2011 Zipline Games, Inc. All Rights Reserved.
+// http://getmoai.com
+
+#include "pch.h"
+#include <moaicore/MOAIFmodMusicSystem.h>
+#include <moaicore/MOAIFmodMusicEntity.h>
+#include <moaicore/MOAIFmodMusicInfo.h>
+#include <moaicore/MOAIFmodReverbChannelproperties.h>
+#include <iostream>
+
+//================================================================//
+// lua
+//================================================================//
+
+// example static function
+//int MOAIFmodMusicSystem::_classHello ( lua_State* L ) {
+//	UNUSED ( L );
+//	
+//	printf ( "MOAIFmodMusicSystem class!\n" );
+//	
+//	return 0;
+//}
+
+
+void FmodErrorCheck(FMOD_RESULT result)	// this is an error handling function
+{						// for FMOD errors
+	if (result != FMOD_OK)
+	{
+		std::cout << "FMOD error! (" << result << ") " << FMOD_ErrorString(result) << std::endl;
+		exit(-1);
+	}
+}
+
+
+MOAIFmodMusicSystem::MOAIFmodMusicSystem() : mSoundSystem(0), mEventSystem(0) {
+
+	
+	//FmodErrorCheck(mEventSystem->init(64, FMOD_INIT_NORMAL, 0, FMOD_EVENT_INIT_NORMAL));
+	// register all classes MOAIFoo derives from
+	// we need this for custom RTTI implementation
+	RTTI_BEGIN
+		RTTI_EXTEND(MOAIFmodMusicSystem)
+		
+		// and any other objects from multiple inheritance...
+		// RTTI_EXTEND ( MOAIFooBase )
+	RTTI_END
+
+	//FmodErrorCheck(FMOD::EventSystem_Create(&mEventSystem));
+}
+
+MOAIFmodMusicSystem::~MOAIFmodMusicSystem() {
+}
+
+int MOAIFmodMusicSystem::_freeSoundData(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UB")
+	bool waitUntilReady	= state.GetValue<bool>(2, false);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->freeSoundData(waitUntilReady);
+
+		if(res == FMOD_OK) {
+			std::cout << "sound data freed" << std::endl;
+		}
+		else {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+
+	return 0;
+}
+
+
+int MOAIFmodMusicSystem::_getCues(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "US")
+	const char* filter = state.GetValue<const char*>(2, "");
+
+	if(self->mSoundSystem) {
+		FMOD_MUSIC_ITERATOR* it;
+		FMOD_RESULT res = self->mSoundSystem->getCues(it, filter);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodMusicEntity* e = new MOAIFmodMusicEntity(*it);
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			e->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getInfo(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+	
+	if(self->mSoundSystem) {
+		FMOD_MUSIC_INFO info;
+
+		FMOD_RESULT res = self->mSoundSystem->getInfo(&info);
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodMusicInfo* i = new MOAIFmodMusicInfo(info);
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			i->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+
+	return 0;
+}
+
+//int MOAIFmodMusicSystem::_getMemoryInfo(lua_State* L) {
+//	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+//	
+//	// not implemented so far
+//	// dont think this method is needed at MOAI side
+//
+//	if(self->mSoundSystem) {
+//
+//	}
+//	else {
+//		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+//	}
+//
+//	return 0;
+//}
+
+int MOAIFmodMusicSystem::_getMute(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+
+	if(self->mSoundSystem) {
+		bool* mute;
+		FMOD_RESULT res = self->mSoundSystem->getMute(mute);
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+		else {
+			state.Push(mute);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getNextCue(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "US")
+	const char* filter = state.GetValue<const char*>(2, "");
+
+	if(self->mSoundSystem) {
+		FMOD_MUSIC_ITERATOR* it;
+		FMOD_RESULT res = self->mSoundSystem->getNextCue(it);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodMusicEntity* e = new MOAIFmodMusicEntity(*it);
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			e->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getNextParameter(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "US")
+	const char* filter = state.GetValue<const char*>(2, "");
+
+	if(self->mSoundSystem) {
+		FMOD_MUSIC_ITERATOR* it;
+		FMOD_RESULT res = self->mSoundSystem->getNextParameter(it);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodMusicEntity* e = new MOAIFmodMusicEntity(*it);
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			e->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getParameterValue(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UN")
+	
+	FMOD_MUSIC_PARAM_ID id = state.GetValue<FMOD_MUSIC_PARAM_ID>(2, 0);
+	if(self->mSoundSystem) {
+		float* parameter;
+		FMOD_RESULT res = self->mSoundSystem->getParameterValue(id, parameter);
+
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			state.Push(*parameter);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+
+}
+
+int MOAIFmodMusicSystem::_getParameters(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "US")
+	const char* filter = state.GetValue<const char*>(2, 0);
+
+	if(self->mSoundSystem) {
+		FMOD_MUSIC_ITERATOR* it;
+		FMOD_RESULT res = self->mSoundSystem->getParameters(it, filter);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodMusicEntity* e = new MOAIFmodMusicEntity(*it);
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			e->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getPaused(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UB")
+
+	if(self->mSoundSystem) {
+		bool* paused;
+		FMOD_RESULT res = self->mSoundSystem->getPaused(paused);
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+		else {
+			state.Push(paused);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getReverbProperties(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+	if(self->mSoundSystem) {
+		FMOD_REVERB_CHANNELPROPERTIES* props;
+		FMOD_RESULT res = self->mSoundSystem->getReverbProperties(props);
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			MOAIFmodReverbChannelproperties* p = new MOAIFmodReverbChannelproperties;
+			p->mDirect = props->Direct;
+			p->mRoom = props->Room;
+			p->mFlags = props->Flags;
+			// BindToLua does all the work for us here
+			// dont delete e, Lua takes care of it now!
+			p->BindToLua(state);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getVolume(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UN")
+	
+	FMOD_MUSIC_PARAM_ID id = state.GetValue<FMOD_MUSIC_PARAM_ID>(2, 0);
+	if(self->mSoundSystem) {
+		float* volume;
+		FMOD_RESULT res = self->mSoundSystem->getVolume(volume);
+
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+			return 0;
+		}
+		else {
+			state.Push(*volume);
+			return 1;
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_loadSoundData(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UNN")
+	
+	// FMOD_EVENT_RESOURCE is an enum
+	// we get it as a number (int) from MOAI
+	int resource = state.GetValue<int>(2, 0);
+	FMOD_EVENT_MODE mode = state.GetValue<FMOD_EVENT_MODE>(3,0);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->loadSoundData(static_cast<FMOD_EVENT_RESOURCE>(resource), mode);
+
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+// TODO
+// dependend on MusicPrompt
+int MOAIFmodMusicSystem::_prepareCue(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UNU")
+
+	FMOD_MUSIC_CUE_ID id = state.GetValue<FMOD_MUSIC_CUE_ID>(2,0);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->promptCue(id);
+
+		//MOAIFmodMusicPrompt* p = state.GetValue(2, NULL);
+		//self->mSoundSystem->prepareCue(id, fmodpointertoprompt, need from MOAIFmodMusicPrompt class
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_promptCue(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UN")
+	FMOD_MUSIC_CUE_ID id = state.GetValue<FMOD_MUSIC_CUE_ID>(2,0);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->promptCue(id);
+
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_reset(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->reset();
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+// TODO
+int MOAIFmodMusicSystem::_setCallback(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+	if(self->mSoundSystem) {
+
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_setMute(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UB")
+
+	bool mute = state.GetValue<bool>(2, false);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->setMute(mute);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_setParameterValue(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UN")
+
+	FMOD_MUSIC_PARAM_ID id = state.GetValue<FMOD_MUSIC_PARAM_ID>(2, 0);
+	float parameter = state.GetValue<float>(3, 0.0f);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->setParameterValue(id, parameter);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_setPaused(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UB")
+
+	bool paused = state.GetValue<bool>(2, false);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->setPaused(paused);
+		
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+
+int MOAIFmodMusicSystem::_setReverbProperties(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UNNN")
+
+	int direct = state.GetValue<int>(2, 0);
+	int room = state.GetValue<int>(3, 0);
+	int flags = state.GetValue<int>(4, 0);
+
+	if(self->mSoundSystem) {
+		FMOD_REVERB_CHANNELPROPERTIES p;
+		p.Direct = direct;
+		p.Room = room;
+		p.Flags = flags;
+		p.ConnectionPoint = 0;
+
+		FMOD_RESULT res = self->mSoundSystem->setReverbProperties(&p);
+
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+
+int MOAIFmodMusicSystem::_setVolume(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UN")
+
+	float volume = state.GetValue(2, 0.0f);
+
+	if(self->mSoundSystem) {
+		FMOD_RESULT res = self->mSoundSystem->setVolume(volume);
+		if(res != FMOD_OK) {
+			FmodErrorCheck(res);
+		}
+	}
+	else {
+		std::cout << "soundsystem not initialized yet, cannot call method" << std::endl;
+	}
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_setEventSystem(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UU")
+
+	self->mEventSystem = reinterpret_cast<MOAIFmodEventSystem*>(state.GetUserData(2, NULL));
+
+	return 0;
+}
+
+int MOAIFmodMusicSystem::_getEventSystem(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "U")
+
+	// bind MOAIFmodEventSystem to LUA.. needs MOAIFmodEventSystem class
+	return 1;
+}
+
+
+int MOAIFmodMusicSystem::_addMusicPrompt(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodMusicSystem, "UU")
+
+	MOAIFmodMusicPrompt* p = reinterpret_cast<MOAIFmodMusicPrompt*>(state.GetUserData(2, NULL));
+	self->mPrompts.push_back(p);
+}
+
+// register static functions and constants
+void MOAIFmodMusicSystem::RegisterLuaClass(MOAILuaState& state) {
+
+	// call any initializers for base classes here:
+	// MOAIFooBase::RegisterLuaClass ( state );
+
+	// also register constants:
+	// state.SetField ( -1, "FOO_CONST", ( u32 )FOO_CONST );
+
+	// here are the class methods:
+	//luaL_Reg regTable [] = {
+	//	{ NULL, NULL }
+	//};
+
+	//luaL_register ( state, 0, regTable );
+}
+
+// register member functions
+void MOAIFmodMusicSystem::RegisterLuaFuncs(MOAILuaState& state) {
+
+	// call any initializers for base classes here:
+	// MOAIFooBase::RegisterLuaFuncs ( state );
+
+	// here are the instance methods:
+	luaL_Reg regTable [] = {
+		{ "freeSoundData", _freeSoundData },
+		{ "getCues", _getCues },
+		{ "getInfo", _getInfo },
+		//{ "getMemoryInfo", _getMemoryInfo },
+		{ "getMute", _getMute },
+		{ "getNextCue", _getNextCue },
+		{ "getNextParameter", _getNextParameter },
+		{ "getParameterValue", _getParameterValue },
+		{ "getParameters", _getParameters },
+		{ "getPaused", _getPaused },
+		{ "getReverbProperties", _getReverbProperties },
+		{ "getVolume", _getVolume },
+		{ "loadSoundData", _loadSoundData },
+		{ "prepareCue", _prepareCue },
+		{ "promptCue", _promptCue },
+		{ "reset", _reset },
+		//{ "setCallback", _setCallback },
+		{ "setMute", _setMute },
+		{ "setParameterValue", _setParameterValue },
+		{ "setPaused", _setPaused },
+		{ "setReverbProperties", _setReverbProperties },
+		{ "setVolume", _setVolume },
+		{ "setEventSystem", _setEventSystem},
+		{ "getEventSystem", _getEventSystem},
+		{ "addMusicPrompt", _addMusicPrompt},
+		{ NULL, NULL }
+	};
+
+	luaL_register ( state, 0, regTable );
+}
+

--- a/src/moaicore/MOAIFmodMusicSystem.h
+++ b/src/moaicore/MOAIFmodMusicSystem.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2012 Lukas Oberbichler & Christian Ondracek
+
+#ifndef MOAIFMODMUSICSYSTEM__H
+#define MOAIFMODMUSICSYSTEM__H
+
+#include <moaicore/MOAILua.h>
+#include "fmodinc/fmod.hpp"
+#include "fmodinc/fmod_errors.h"
+#include "fmoddesignerinc/fmod_event.hpp"
+#include <vector>
+
+//================================================================//
+// MOAIFmodMusicSystem
+//================================================================//
+
+// lua c++ function wrapper returns 0 if no value is returned to lua
+// and 1 if a value is returned to lua
+// the actual value return is set by lua_push....()
+
+class MOAIFmodEventSystem;
+class MOAIFmodMusicPrompt;
+
+class MOAIFmodMusicSystem :
+	public virtual MOAILuaObject {
+private:
+	static int _freeSoundData(lua_State* L);
+	static int _getCues(lua_State* L);
+	static int _getInfo(lua_State* L);
+	static int _getMemoryInfo(lua_State* L);
+	static int _getMute(lua_State* L);
+	static int _getNextCue(lua_State* L);
+	static int _getNextParameter(lua_State* L);
+	static int _getParameterValue(lua_State* L);
+	static int _getParameters(lua_State* L);
+	static int _getPaused(lua_State* L);
+	static int _getReverbProperties(lua_State* L);
+	static int _getVolume(lua_State* L);
+	static int _loadSoundData(lua_State* L);
+	static int _prepareCue(lua_State* L);
+	static int _promptCue(lua_State* L);
+	static int _reset(lua_State* L);
+	static int _setCallback(lua_State* L);
+	static int _setMute(lua_State* L);
+	static int _setParameterValue(lua_State* L);
+	static int _setPaused(lua_State* L);
+	static int _setReverbProperties(lua_State* L);
+	static int _setVolume(lua_State* L);
+	static int _setEventSystem(lua_State* L);
+	static int _getEventSystem(lua_State* L);
+	static int _addMusicPrompt(lua_State* L);
+
+	FMOD::MusicSystem* mSoundSystem;
+	//FMOD::EventSystem* mEventSystem;
+
+	MOAIFmodEventSystem* mEventSystem;
+	std::vector<MOAIFmodMusicPrompt*> mPrompts;
+
+public:
+	
+	DECL_LUA_FACTORY(MOAIFmodMusicSystem)
+
+	//----------------------------------------------------------------//
+	MOAIFmodMusicSystem();
+	~MOAIFmodMusicSystem();
+	void RegisterLuaClass(MOAILuaState& state);
+	void RegisterLuaFuncs(MOAILuaState& state);
+};
+
+#endif

--- a/src/moaicore/MOAIFmodReverbChannelproperties.cpp
+++ b/src/moaicore/MOAIFmodReverbChannelproperties.cpp
@@ -1,0 +1,38 @@
+#include "pch.h"
+
+#include <moaicore/MOAIFmodReverbChannelproperties.h>
+
+// register member functions
+void MOAIFmodReverbChannelproperties::RegisterLuaFuncs(MOAILuaState& state) {
+
+	// call any initializers for base classes here:
+	// MOAIFooBase::RegisterLuaFuncs ( state );
+
+	// here are the instance methods:
+	luaL_Reg regTable [] = {
+		{ "getDirect", _getDirect },
+		{ "getRoom", _getRoom },
+		{ "getFlags", _getFlags },
+		{ NULL, NULL }
+	};
+
+	luaL_register ( state, 0, regTable );
+}
+
+int MOAIFmodReverbChannelproperties::_getDirect(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodReverbChannelproperties, "U")
+		state.Push(self->mDirect);
+	return 1;
+}
+
+int MOAIFmodReverbChannelproperties::_getRoom(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodReverbChannelproperties, "U")
+		state.Push(self->mRoom);
+	return 1;
+}
+
+int MOAIFmodReverbChannelproperties::_getFlags(lua_State* L) {
+	MOAI_LUA_SETUP(MOAIFmodReverbChannelproperties, "U")
+		state.Push(self->mFlags);
+	return 1;
+}

--- a/src/moaicore/MOAIFmodReverbChannelproperties.h
+++ b/src/moaicore/MOAIFmodReverbChannelproperties.h
@@ -1,0 +1,44 @@
+#ifndef MOAIFMODREVERBCHANNELPROPERTIES__H
+#define MOAIFMODREVERBCHANNELPROPERTIES__H
+
+#include <moaicore/MOAILua.h>
+#include "fmodinc/fmod.hpp"
+
+class MOAIFmodReverbChannelproperties :
+	public virtual MOAILuaObject {
+
+friend class MOAIFmodMusicSystem;
+
+private:
+
+	static int _getDirect(lua_State* L);
+	static int _getRoom(lua_State* L);
+	static int _getFlags(lua_State* L);
+
+	int mDirect;
+    int mRoom;
+    unsigned int mFlags;
+	// not used just there for the sake of completeness
+	FMOD::DSP* mConnectionPoint;
+
+public:
+	DECL_LUA_FACTORY(MOAIFmodReverbChannelproperties)
+
+	MOAIFmodReverbChannelproperties() : mDirect(0), mRoom(0), mFlags(0), mConnectionPoint(0) {
+		// register all classes MOAIFoo derives from
+		// we need this for custom RTTI implementation
+		RTTI_BEGIN
+			RTTI_EXTEND (MOAILuaObject)
+		
+			// and any other objects from multiple inheritance...
+			// RTTI_EXTEND ( MOAIFooBase )
+		RTTI_END
+	}
+	
+	~MOAIFmodReverbChannelproperties() {}
+	
+	void RegisterLuaFuncs(MOAILuaState& state);
+
+};
+
+#endif

--- a/src/moaicore/fmoddesignerinc/fmod_event.h
+++ b/src/moaicore/fmoddesignerinc/fmod_event.h
@@ -1,0 +1,1246 @@
+/*$ preserve start $*/
+
+/* ============================================================================================ */
+/* FMOD Ex - Main C/C++ event/data driven system header file.                                   */
+/* Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.                                   */
+/*                                                                                              */
+/* This header is the base header for all other FMOD EventSystem headers. If you are            */
+/* programming in C use this exclusively, or if you are programming C++ use this in             */
+/* conjunction with FMOD_EVENT.HPP                                                              */
+/* ============================================================================================ */
+
+#ifndef __FMOD_EVENT_H__
+#define __FMOD_EVENT_H__
+
+#ifndef _FMOD_H
+#include "fmod.h"
+#endif
+
+/*
+    FMOD EventSystem version number.  Check this against FMOD::EventSystem::getVersion.
+    0xaaaabbcc -> aaaa = major version number.  bb = minor version number.  cc = development version number.
+*/
+
+#define FMOD_EVENT_VERSION 0x00044000
+
+/*
+    FMOD event types
+*/
+
+typedef struct FMOD_EVENTSYSTEM     FMOD_EVENTSYSTEM;
+typedef struct FMOD_EVENTPROJECT    FMOD_EVENTPROJECT;
+typedef struct FMOD_EVENTGROUP      FMOD_EVENTGROUP;
+typedef struct FMOD_EVENTCATEGORY   FMOD_EVENTCATEGORY;
+typedef struct FMOD_EVENT           FMOD_EVENT;
+typedef struct FMOD_EVENTPARAMETER  FMOD_EVENTPARAMETER;
+typedef struct FMOD_EVENTREVERB     FMOD_EVENTREVERB;
+typedef struct FMOD_EVENTQUEUE      FMOD_EVENTQUEUE;
+typedef struct FMOD_EVENTQUEUEENTRY FMOD_EVENTQUEUEENTRY;
+typedef struct FMOD_MUSICPROMPT     FMOD_MUSICPROMPT;
+typedef struct FMOD_MUSICSYSTEM     FMOD_MUSICSYSTEM;
+typedef unsigned int                FMOD_EVENT_INITFLAGS;
+typedef unsigned int                FMOD_EVENT_MODE;
+typedef unsigned int                FMOD_EVENT_STATE;
+typedef unsigned int                FMOD_MUSIC_ID;
+typedef FMOD_MUSIC_ID               FMOD_MUSIC_CUE_ID;
+typedef FMOD_MUSIC_ID               FMOD_MUSIC_PARAM_ID;
+
+
+/*
+[DEFINE]
+[
+    [NAME]
+    FMOD_EVENT_INITFLAGS
+
+    [DESCRIPTION]   
+    Initialization flags.  Use them with EventSystem::init in the eventflags parameter to change various behaviour.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    EventSystem::init
+    EventSystem::getEventByGUID
+    FMOD_EVENT_SOUNDDEFINFO
+    FMOD_EVENT_CALLBACKTYPE
+]
+*/
+#define FMOD_EVENT_INIT_NORMAL                            0x00000000 /* All platforms - Initialize normally */
+#define FMOD_EVENT_INIT_USER_ASSETMANAGER                 0x00000001 /* All platforms - All wave data loading/freeing will be referred back to the programmer through the FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_CREATE/FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_RELEASE callback */
+#define FMOD_EVENT_INIT_FAIL_ON_MAXSTREAMS                0x00000002 /* All platforms - Events will fail if "Max streams" was reached when playing streamed banks, instead of going virtual. */
+#define FMOD_EVENT_INIT_DONTUSENAMES                      0x00000004 /* All platforms - All event/eventgroup/eventparameter/eventcategory/eventreverb names will be discarded on load. Use getXXXByIndex to access them. This may potentially save a lot of memory at runtime. */
+#define FMOD_EVENT_INIT_UPPERCASE_FILENAMES               0x00000008 /* All platforms - All FSB filenames will be translated to upper case before being used. */
+#define FMOD_EVENT_INIT_LOWERCASE_FILENAMES               0x00000080 /* All platforms - All FSB filenames will be translated to lower case before being used. */
+#define FMOD_EVENT_INIT_SEARCH_PLUGINS                    0x00000010 /* All platforms - Search the current directory for dsp/codec plugins on EventSystem::init. */
+#define FMOD_EVENT_INIT_USE_GUIDS                         0x00000020 /* All platforms - Build an event GUID table when loading FEVs so that EventSystem::getEventByGUID can be used. */
+#define FMOD_EVENT_INIT_DETAILED_SOUNDDEF_INFO            0x00000040 /* All platforms - Pass an FMOD_EVENT_SOUNDDEFINFO struct to FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_SELECTINDEX callbacks rather than just the sound definition name (uses more memory for sound definition waveform names). */
+#define FMOD_EVENT_INIT_RESETPARAMSTOMINIMUM              0x00000100 /* All platforms - Reset parameters to minimum value when getting an event instance instead of using the INFO_ONLY event's values. */
+#define FMOD_EVENT_INIT_ELEVATION_AFFECTS_LISTENER_ANGLE  0x00000200 /* All platforms - The listener angle event parameters will be affected by elevation, and not just horizontal components. */
+#define FMOD_EVENT_INIT_DONTUSELOWMEM                     0x00000400 /* All platforms - Instruct the event system to NOT use FMOD_LOWMEM when it opens .FSB files. Specify this flag if you need access to the names of individual subsounds in loaded .FSB files. Specifying this flag will make the event system use more memory. */
+
+/* [DEFINE_END] */
+
+
+/*
+[DEFINE]
+[
+    [NAME] 
+    FMOD_EVENT_MODE
+
+    [DESCRIPTION]   
+    Event data loading bitfields. Bitwise OR them together for controlling how event data is loaded.
+
+    [REMARKS]
+    FMOD_EVENT_NONBLOCKING_THREAD0-4.  This flag extends FMOD_EVENT_NONBLOCKING to allow multiple asynchronous loads to happen on different threads at the same time.<br>
+    FMOD_EVENT_NONBLOCKING by itself will always execute on thread 0 by default.  Up to 5 simultaneous threads for loading at once are supported.<br>
+    Only 1 flag should be specified at a time.  If multiple flags are specified an FMOD_ERR_INVALID_PARAM error will be returned.<br>
+    FMOD_EVENT_NONBLOCKING_THREAD0-4 can be specified without the FMOD_EVENT_NONBLOCKING flag being used (it automatically includes it)
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    EventGroup::loadEventData
+    EventGroup::getEvent
+    EventGroup::getEventByIndex
+]
+*/
+#define FMOD_EVENT_DEFAULT               0x00000000  /* FMOD_EVENT_DEFAULT specifies default loading behaviour i.e. event data for the whole group is NOT cached and the function that initiated the loading process will block until loading is complete. */
+#define FMOD_EVENT_NONBLOCKING           0x00000001  /* For loading event data asynchronously. FMOD will use a thread to load the data.  Use Event::getState to find out when loading is complete. */
+#define FMOD_EVENT_ERROR_ON_DISKACCESS   0x00000002  /* For EventGroup::getEvent / EventGroup::getEventByIndex.  If EventGroup::loadEventData has accidently been forgotten this flag will return an FMOD_ERR_FILE_UNWANTED if the getEvent function tries to load data. */
+#define FMOD_EVENT_INFOONLY              0x00000004  /* For EventGroup::getEvent / EventGroup::getEventByIndex.  Don't allocate instances or load data, just get a handle to allow user to get information from the event. */
+#define FMOD_EVENT_USERDSP               0x00000008  /* For EventGroup::getEvent / EventGroup::getEventByIndex.  Tells FMOD that you plan to add your own DSP effects to this event's ChannelGroup at runtime. Omitting this flag will yield a small memory gain. */
+
+#define FMOD_EVENT_NONBLOCKING_THREAD0   (FMOD_EVENT_NONBLOCKING)               /* FMOD_EVENT_NONBLOCKING, execute on thread 0.  See remarks. (default) */
+#define FMOD_EVENT_NONBLOCKING_THREAD1   (FMOD_EVENT_NONBLOCKING | 0x00010000)  /* FMOD_EVENT_NONBLOCKING, execute on thread 1.  See remarks. */
+#define FMOD_EVENT_NONBLOCKING_THREAD2   (FMOD_EVENT_NONBLOCKING | 0x00020000)  /* FMOD_EVENT_NONBLOCKING, execute on thread 2.  See remarks. */
+#define FMOD_EVENT_NONBLOCKING_THREAD3   (FMOD_EVENT_NONBLOCKING | 0x00040000)  /* FMOD_EVENT_NONBLOCKING, execute on thread 3.  See remarks. */
+#define FMOD_EVENT_NONBLOCKING_THREAD4   (FMOD_EVENT_NONBLOCKING | 0x00080000)  /* FMOD_EVENT_NONBLOCKING, execute on thread 4.  See remarks. */
+/* [DEFINE_END] */
+
+
+/*
+[DEFINE]
+[
+    [NAME] 
+    FMOD_EVENT_STATE
+
+    [DESCRIPTION]   
+    These values describe what state an event is in.
+
+    [REMARKS]    
+    The flags below can be combined to set multiple states at once.  Use bitwise AND operations to test for these.
+    An example of a combined flag set would be FMOD_EVENT_STATE_READY | FMOD_EVENT_STATE_PLAYING.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    Event::getState
+    FMOD_EVENT_MODE
+]
+*/
+#define FMOD_EVENT_STATE_READY           0x00000001  /* Event is ready to play. */
+#define FMOD_EVENT_STATE_LOADING         0x00000002  /* Loading in progress. */
+#define FMOD_EVENT_STATE_ERROR           0x00000004  /* Failed to open - file not found, out of memory etc.  See return value of Event::getState for what happened. */
+#define FMOD_EVENT_STATE_PLAYING         0x00000008  /* Event has been started.  This will still be true even if there are no sounds active.  Event::stop must be called or the event must stop itself using a 'one shot and stop event' parameter mode. */
+#define FMOD_EVENT_STATE_CHANNELSACTIVE  0x00000010  /* Event has active voices.  Use this if you want to detect if sounds are playing in the event or not. */
+#define FMOD_EVENT_STATE_INFOONLY        0x00000020  /* Event was loaded with the FMOD_EVENT_INFOONLY flag. */
+#define FMOD_EVENT_STATE_STARVING        0x00000040  /* Event is streaming but not being fed data in time, so may be stuttering. */
+#define FMOD_EVENT_STATE_NEEDSTOLOAD     0x00000080  /* Event still needs to load wavebank data. */
+/* [DEFINE_END] */
+
+
+/*
+[ENUM]
+[
+	[DESCRIPTION]
+    Property indices for Event::getPropertyByIndex.
+    
+	[REMARKS]        
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+	[SEE_ALSO]
+    Event::getPropertyByIndex
+]
+*/
+typedef enum
+{
+    FMOD_EVENTPROPERTY_NAME = 0,                        /* Type : char *    - (<b>Readonly</b>) Name of event. */
+    FMOD_EVENTPROPERTY_VOLUME,                          /* Type : float     - Relative volume of event. */
+    FMOD_EVENTPROPERTY_VOLUMERANDOMIZATION,             /* Type : float     - Random deviation in volume of event. */
+    FMOD_EVENTPROPERTY_PITCH,                           /* Type : float     - Relative pitch of event in raw underlying units. */
+    FMOD_EVENTPROPERTY_PITCH_OCTAVES,                   /* Type : float     - Relative pitch of event in octaves. */
+    FMOD_EVENTPROPERTY_PITCH_SEMITONES,                 /* Type : float     - Relative pitch of event in semitones. */
+    FMOD_EVENTPROPERTY_PITCH_TONES,                     /* Type : float     - Relative pitch of event in tones. */
+    FMOD_EVENTPROPERTY_PITCHRANDOMIZATION,              /* Type : float     - Random deviation in pitch of event in raw underlying units. */
+    FMOD_EVENTPROPERTY_PITCHRANDOMIZATION_OCTAVES,      /* Type : float     - Random deviation in pitch of event in octaves. */
+    FMOD_EVENTPROPERTY_PITCHRANDOMIZATION_SEMITONES,    /* Type : float     - Random deviation in pitch of event in semitones. */
+    FMOD_EVENTPROPERTY_PITCHRANDOMIZATION_TONES,        /* Type : float     - Random deviation in pitch of event in tones. */
+    FMOD_EVENTPROPERTY_PRIORITY,                        /* Type : int       - Playback priority of event. */
+    FMOD_EVENTPROPERTY_MAX_PLAYBACKS,                   /* Type : int       - (<b>Readonly</b>) Maximum simultaneous playbacks of event. */
+    FMOD_EVENTPROPERTY_MAX_PLAYBACKS_BEHAVIOR,          /* Type : int       - 1 = steal oldest, 2 = steal newest, 3 = steal quietest, 4 = just fail, 5 = just fail if quietest. */
+    FMOD_EVENTPROPERTY_MODE,                            /* Type : FMOD_MODE - Either FMOD_3D or FMOD_2D. */
+    FMOD_EVENTPROPERTY_3D_IGNORE_GEOMETRY,              /* Type : int       - Ignore geometry for that event. 1 = yes,  0 = no. */
+    FMOD_EVENTPROPERTY_3D_ROLLOFF,                      /* Type : FMOD_MODE - Either FMOD_3D_INVERSEROLLOFF, FMOD_3D_LINEARROLLOFF, FMOD_3D_LINEARSQUAREROLLOFF, or none for custom rolloff. */
+    FMOD_EVENTPROPERTY_3D_MINDISTANCE,                  /* Type : float     - Minimum 3d distance of event. */
+    FMOD_EVENTPROPERTY_3D_MAXDISTANCE,                  /* Type : float     - Maximum 3d distance of event.  Means different things depending on EVENTPROPERTY_3D_ROLLOFF. If event has custom rolloff, setting FMOD_EVENTPROPERTY_3D_MAXDISTANCE will scale the range of all distance parameters in this event e.g. set this property to 2.0 to double the range of all distance parameters, set it to 0.5 to halve the range of all distance parameters. */
+    FMOD_EVENTPROPERTY_3D_POSITION,                     /* Type : FMOD_MODE - Either FMOD_3D_HEADRELATIVE or FMOD_3D_WORLDRELATIVE. */
+    FMOD_EVENTPROPERTY_3D_CONEINSIDEANGLE,              /* Type : float     - Event cone inside angle.  0 to 360. */
+    FMOD_EVENTPROPERTY_3D_CONEOUTSIDEANGLE,             /* Type : float     - Event cone outside angle.  0 to 360. */
+    FMOD_EVENTPROPERTY_3D_CONEOUTSIDEVOLUME,            /* Type : float     - Event cone outside volume.  0 to 1.0. */
+    FMOD_EVENTPROPERTY_3D_DOPPLERSCALE,                 /* Type : float     - Doppler scale where 0 = no doppler, 1.0 = normal doppler, 2.0 = double doppler etc. */
+    FMOD_EVENTPROPERTY_3D_SPEAKERSPREAD,                /* Type : float     - Angle of spread for stereo/mutlichannel source. 0 to 360. */
+    FMOD_EVENTPROPERTY_3D_PANLEVEL,                     /* Type : float     - 0 = sound pans according to speaker levels, 1 = sound pans according to 3D position. */
+    FMOD_EVENTPROPERTY_SPEAKER_L,                       /* Type : float     - 2D event volume for front left speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_C,                       /* Type : float     - 2D event volume for front center speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_R,                       /* Type : float     - 2D event volume for front right speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_LS,                      /* Type : float     - 2D event volume for side left speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_RS,                      /* Type : float     - 2D event volume for side right speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_LR,                      /* Type : float     - 2D event volume for back left speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_RR,                      /* Type : float     - 2D event volume for back right speaker. */
+    FMOD_EVENTPROPERTY_SPEAKER_LFE,                     /* Type : float     - 2D event volume for low frequency speaker. */
+    FMOD_EVENTPROPERTY_REVERBWETLEVEL,                  /* Type : float     - Reverb gain for this event where 0 = full reverb, -60 = no reverb. */
+    FMOD_EVENTPROPERTY_ONESHOT,                         /* Type : int       - Oneshot event - stops when no channels playing. 1 = yes, it's a oneshot  0 = no. it's not a oneshot. */
+    FMOD_EVENTPROPERTY_FADEIN,                          /* Type : int       - Time in milliseconds over which to fade this event in when programmer starts it. 0 = no fade in. Cannot be set while the event is playing. */
+    FMOD_EVENTPROPERTY_FADEOUT,                         /* Type : int       - Time in milliseconds over which to fade this event out when programmer stops it. 0 = no fade out. Cannot be set while the event is playing. */
+    FMOD_EVENTPROPERTY_REVERBDRYLEVEL,                  /* Type : float     - Dry reverb gain for this event where 0 = full dry, -60 = no dry. */
+    FMOD_EVENTPROPERTY_TIMEOFFSET,                      /* Type : float     - Time offset of sound start in seconds. */
+    FMOD_EVENTPROPERTY_SPAWNINTENSITY,                  /* Type : float     - Multiplier for spawn frequency of all sounds in this event. */
+    FMOD_EVENTPROPERTY_SPAWNINTENSITY_RANDOMIZATION,    /* Type : float     - Random deviation in spawn intensity of event. */
+    FMOD_EVENTPROPERTY_WII_CONTROLLERSPEAKERS,          /* Type : int       - Wii only. Use FMOD_WII_CONTROLLER flags defined in fmodwii.h to set which Wii Controller Speaker(s) to play this event on. */
+	FMOD_EVENTPROPERTY_3D_POSRANDOMIZATION_MIN,         /* Type : unsigned int   - Minimum radius of random deviation in the 3D position of event. */
+	FMOD_EVENTPROPERTY_3D_POSRANDOMIZATION_MAX,         /* Type : unsigned int   - Maximum radius of random deviation in the 3D position of event. */
+    FMOD_EVENTPROPERTY_EVENTTYPE,                       /* Type : int       - (<b>Readonly</b>) 0 = simple event, 1 = complex event */
+    FMOD_EVENTPROPERTY_STEAL_PRIORITY,                  /* Type : int       - 0 to 10000.  How important this event is in relation to other events in the project. This event will never steal an event with a higher steal priority than this. */
+    FMOD_EVENTPROPERTY_EFFECTS_AFFECT_REVERB,           /* Type : int       - 0 = default (no), 1 = yes.  Alternate routing for reverb path of an event so it goes from the layer dsp unit instead of the channel. */
+    FMOD_EVENTPROPERTY_WILL_TERMINATE,                  /* Type : int       - (<b>Readonly</b>) 0 = no, 1 = yes, 2 = unknown (current event state is too complex).  Whether this event will terminate (stop playing) by itself. If called on an event instance with this_instance = true, the prediction is based on the current state of that instance. This means parameter values, keyoffs etc. come into play. */
+    FMOD_EVENTPROPERTY_DSPCLOCKSTART_HI,                /* Type : unsigned int - High 32 bits of a 64 bit DSP clock value, for a start time for any sound in this event. */
+    FMOD_EVENTPROPERTY_DSPCLOCKSTART_LO,                /* Type : unsigned int - Low 32 bits of a 64 bit DSP clock value, for a start time for any sound in this event. */
+    FMOD_EVENTPROPERTY_3D_AUTO_DISTANCE_FILTERING,      /* Type : int       - 0 = default (no), 1 = yes. Whether to automaically apply the distance effect to sounds in this event. */
+    FMOD_EVENTPROPERTY_3D_AUTO_DISTANCE_CENTER_FREQ,    /* Type : float     - 10 to 22050. The center frequency for the distance effect.*/
+    FMOD_EVENTPROPERTY_USER_BASE                        /* User created events start from here onwards. */
+} FMOD_EVENT_PROPERTY;
+
+
+/*
+[ENUM]
+[
+	[DESCRIPTION]
+    Event property types.
+    
+	[REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+	[SEE_ALSO]
+    Event::getPropertyByIndex
+    Event::getPropertyInfo
+]
+*/
+typedef enum
+{
+    FMOD_EVENTPROPERTY_TYPE_INT = 0,                     /* Property is an int, unsigned int or other type of equivalent sizee e.g. FMOD_MODE. */
+    FMOD_EVENTPROPERTY_TYPE_FLOAT,                      /* Property is a float. */
+    FMOD_EVENTPROPERTY_TYPE_STRING                      /* Property is a char *. */
+} FMOD_EVENTPROPERTY_TYPE;
+
+
+/*
+[ENUM]
+[
+	[DESCRIPTION]
+    Pitch units for Event::setPitch and EventCategory::setPitch.
+    
+	[REMARKS]        
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+	[SEE_ALSO]
+    Event::setPitch
+    EventCategory::setPitch
+]
+*/
+typedef enum
+{
+    FMOD_EVENT_PITCHUNITS_RAW = 0,      /* Pitch is specified in raw underlying units. */
+    FMOD_EVENT_PITCHUNITS_OCTAVES,      /* Pitch is specified in units of octaves. */
+    FMOD_EVENT_PITCHUNITS_SEMITONES,    /* Pitch is specified in units of semitones. */
+    FMOD_EVENT_PITCHUNITS_TONES         /* Pitch is specified in units of tones. */
+} FMOD_EVENT_PITCHUNITS;
+
+
+/*
+[ENUM]
+[
+	[DESCRIPTION]
+    Flags to pass to EventGroup::loadEventData to determine what to load at the time of calling.
+    
+	[REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+	[SEE_ALSO]
+    EventGroup::loadEventData
+]
+*/
+typedef enum
+{
+    FMOD_EVENT_RESOURCE_STREAMS_AND_SAMPLES,  /* Open all streams and load all banks into memory, under this group (recursive) */
+    FMOD_EVENT_RESOURCE_STREAMS,              /* Open all streams under this group (recursive).  No samples are loaded. */
+    FMOD_EVENT_RESOURCE_SAMPLES               /* Load all banks into memory, under this group (recursive).  No streams are opened. */
+} FMOD_EVENT_RESOURCE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These callback types are used with FMOD_EVENT_CALLBACK.
+
+    [REMARKS]
+    <b>Note!</b> Currently the user must call EventSystem::update for these callbacks to trigger!<p>
+
+    When the event callback is called, 'param1' and 'param2' mean different things depending on the type of callback. Here is an explanation of what these parameters
+    mean in what context :<p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SYNCPOINT</b>
+    <p>
+    param1 = (char *) name of sync point<br>
+    param2 = (unsigned int) PCM offset of sync point.<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SYNCPOINT callback is generated from 'markers' embedded in .wav files.
+    These can be created by placing 'markers' in the original source wavs using a tool such as Sound Forge or Cooledit.
+    The wavs are then compiled into .FSB files when compiling the audio data using the FMOD designer tool.
+    Callbacks will be automatically generated at the correct place in the timeline when these markers are encountered
+    which makes it useful for synchronization, lip syncing etc.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_START</b>
+    <p>
+    param1 = (char *) name of sound definition being started<br>
+    param2 = (int) index of wave being started inside sound definition (ie for multi wave sound definitions)<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_START callback is generated each time a sound definition is played in an event.
+    This happens every time a sound definition starts due to the event parameter entering the region specified in the 
+    layer created by the sound designer.
+    This also happens when sounds are randomly respawned using the random respawn feature in the sound definition 
+    properties in FMOD designer.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_END</b>
+    <p>
+    param1 = (char *) name of sound definition being stopped<br>
+    param2 = (int) index of wave being stopped inside sound definition (ie for multi wave sound definitions)<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_END callback is generated when a one-shot sound definition inside an event ends, 
+    or when a looping sound definition stops due to the event parameter leaving the region specified in the layer created 
+    by the sound designer.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_STOLEN</b>
+    <p>
+    param1 = 0<br>
+    param2 = 0<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_STOLEN callback is generated when a getEventXXX call needs to steal an event instance that is in use because 
+    the event's "Max playbacks" has been exceeded. This callback is called before the event is stolen and before the event 
+    is stopped (if it is playing). An FMOD_EVENT_CALLBACKTYPE_EVENTFINISHED callback will be generated when the stolen event is stopped i.e. <b>after</b>
+    the FMOD_EVENT_CALLBACKTYPE_STOLEN. If the callback function returns FMOD_ERR_EVENT_FAILED, the event will <b>not</b>
+    be stolen, and the returned value will be passed back as the return value of the getEventXXX call that triggered the steal attempt.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_EVENTFINISHED</b>
+    <p>
+    param1 = 0<br>
+    param2 = 0<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_EVENTFINISHED callback is generated whenever an event is stopped for any reason including when the user
+    calls Event::stop().
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_NET_MODIFIED</b>
+    <p>
+    param1 = (FMOD_EVENT_PROPERTY) which property was modified<br>
+    param2 = (float) the new property value<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_NET_MODIFIED callback is generated when someone has connected to your running application with 
+    FMOD Designer and changed a property within this event, for example volume or pitch.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_CREATE</b>
+    <p>
+    param1 = (char *) name of sound definition<br>
+    param2 [in] = (int *) pointer to index of sound definition entry<br>
+    param2 [out] = (FMOD::Sound **) pointer to a valid lower level API FMOD Sound handle<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_CREATE callback is generated when a "programmer" sound needs to be loaded.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_RELEASE</b>
+    <p>
+    param1 = (char *) name of sound definition<br>
+    param2 = (FMOD::Sound *) the FMOD sound handle that was previously created in FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_CREATE<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_RELEASE callback is generated when a "programmer" sound needs to be unloaded.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_INFO</b>
+    <p>
+    param1 = (char *) name of sound definition<br>
+    param2 = (FMOD::Sound *) the FMOD sound handle that FMOD will use for this sound definition<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_INFO callback is generated when a sound definition is loaded. It can be used to find
+    information about the specific sound that will be played.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_EVENTSTARTED</b>
+    <p>
+    param1 = 0<br>
+    param2 = 0<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_EVENTSTARTED callback is generated whenever an event is started. This callback will be called before any sounds in the event have begun to play.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_SELECTINDEX</b>
+    <p>
+    param1 = (char *) name of sound definition if FMOD_EVENT_INIT_DETAILED_SOUNDDEF_INFO was not specified<br>
+    param1 = (FMOD_EVENT_SOUNDDEFINFO *) sound definition info struct if FMOD_EVENT_INIT_DETAILED_SOUNDDEF_INFO was specified<br>
+    param2 [in] = (int *) pointer to number of entries in this sound definition<br>
+    *param2 [out] = (int) index of sound definition entry to select<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_SELECTINDEX callback is generated when a sound definition entry needs to be chosen from a "ProgrammerSelected" sound definition.
+    <p>&nbsp;<p>
+
+    <b>FMOD_EVENT_CALLBACKTYPE_OCCLUSION</b>
+    <p>
+    param1 = (float *) pointer to a floating point direct value that can be read and modified after the geometry engine has calculated it for this event's channel.<br>
+    param2 = (float *) pointer to a floating point reverb value that can be read and modified after the geometry engine has calculated it for this event's channel.<br>
+    <p>
+    An FMOD_EVENT_CALLBACKTYPE_OCCLUSION callback is generated whenever an channel has its occlusion updated via the geometry system.
+    <p>&nbsp;<p>
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Event::setCallback
+    FMOD_EVENT_CALLBACK
+    FMOD_EVENT_SOUNDDEFINFO
+    FMOD_EVENT_INITFLAGS
+    EventSystem::update
+]
+*/
+typedef enum
+{
+    FMOD_EVENT_CALLBACKTYPE_SYNCPOINT,            /* Called when a syncpoint is encountered. Can be from wav file markers. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_START,       /* Called when a sound definition inside an event is triggered. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_END,         /* Called when a sound definition inside an event ends or is stopped. */
+    FMOD_EVENT_CALLBACKTYPE_STOLEN,               /* Called when a getEventXXX call steals an event instance that is in use. */
+    FMOD_EVENT_CALLBACKTYPE_EVENTFINISHED,        /* Called when an event is stopped for any reason. */
+    FMOD_EVENT_CALLBACKTYPE_NET_MODIFIED,         /* Called when a property of the event has been modified by a network-connected host. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_CREATE,      /* Called when a programmer sound definition entry is loaded. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_RELEASE,     /* Called when a programmer sound definition entry is unloaded. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_INFO,        /* Called when a sound definition entry is loaded. */
+    FMOD_EVENT_CALLBACKTYPE_EVENTSTARTED,         /* Called when an event is started. */
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_SELECTINDEX, /* Called when a sound definition entry needs to be chosen from a "ProgrammerSelected" sound definition. */
+    FMOD_EVENT_CALLBACKTYPE_OCCLUSION             /* Called when an event's channel is occluded with the geometry engine. */
+} FMOD_EVENT_CALLBACKTYPE;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing realtime information about a wavebank.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    EventSystem::getInfo
+    FMOD_EVENT_SYSTEMINFO
+]
+*/
+typedef struct FMOD_EVENT_WAVEBANKINFO
+{
+    char          name[256];             /* [out] Name of this wave bank. */
+    int           streamrefcnt;          /* [out] Number of stream references to this wave bank made by events in this event system. */
+    int           samplerefcnt;          /* [out] Number of sample references to this wave bank made by events in this event system. */
+    int           numstreams;            /* [out] Number of times this wave bank has been opened for streaming. */
+    int           maxstreams;            /* [out] Maximum number of times this wave bank will be opened for streaming. */
+    int           streamsinuse;          /* [out] Number of streams currently in use. */
+    unsigned int  streammemory;          /* [out] Amount of memory (in bytes) used by streams. */
+    unsigned int  samplememory;          /* [out] Amount of memory (in bytes) used by samples. */
+    int           type;                  /* [out] 0 = stream from disk, 1 = load into memory, 2 = decompress into memory. */
+} FMOD_EVENT_WAVEBANKINFO;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing realtime information about an event system.
+
+    [REMARKS]
+    On entry, numplayingevents should be set to the number of elements in the playingevents array. If the actual
+    number of playing events is greater than numplayingevents then the playingevents array will be filled with
+    numplayingevents entries and numplayingevents will be set to the actual number of playing events on exit.
+    In short, if numplayingevents on exit > numplayingevents on entry then the playingevents array wasn't large
+    enough and some events were unable to be added to the array.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    EventSystem::getInfo
+    EventProject::getInfo
+    FMOD_EVENT_WAVEBANKINFO
+]
+*/
+typedef struct FMOD_EVENT_SYSTEMINFO
+{
+#ifdef __cplusplus
+    FMOD_EVENT_SYSTEMINFO() : numevents(0), numinstances(0), maxwavebanks(0), wavebankinfo(0), numplayingevents(0), playingevents(0) {}
+#endif
+
+    int                      numevents;          /* [out] Total number of events in all event groups in this event system. */
+    int                      numinstances;       /* [out] Total number of event instances in all event groups in this event system. */
+    int                      maxwavebanks;       /* [in/out] Out, number of wavebanks loaded by the EventSystem.  In. Maximum size of array of wavebankinfo structures supplied by user.  Optional. */
+    FMOD_EVENT_WAVEBANKINFO *wavebankinfo;       /* [in] Pointer to array FMOD_EVENT_WAVEBANKINFO structures (max size defined by maxwavebanks).  FMOD will fill these in with detailed information on each wave bank. Optional. */
+    int                      numplayingevents;   /* [in/out] On entry, maximum number of entries in playingevents array. On exit, actual number of entries in playingevents array, or if playingevents is null, then it is just the number of currently playing events. Optional. */
+    FMOD_EVENT             **playingevents;      /* [in/out] Pointer to an array that will be filled with the event handles of all playing events. Optional. Specify 0 if not needed. Must be used in conjunction with numplayingevents. */
+    int                      numloadsqueued[5];  /* [out] Current number of sound banks queued for loading due to using FMOD_EVENT_NONBLOCKING flag.  Note there are 5 because there are 5 possible loading threads.  Add all values together for total. */
+} FMOD_EVENT_SYSTEMINFO;
+
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing realtime information about an event project.
+
+    [REMARKS]
+    On entry, numplayingevents should be set to the number of elements in the playingevents array. If the actual
+    number of playing events is greater than numplayingevents then the playingevents array will be filled with
+    numplayingevents entries and numplayingevents will be set to the actual number of playing events on exit.
+    In short, if numplayingevents on exit > numplayingevents on entry then the playingevents array wasn't large
+    enough and some events were unable to be added to the array.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    EventProject::getInfo
+    EventSystem::getInfo
+    FMOD_EVENT_WAVEBANKINFO
+]
+*/
+typedef struct FMOD_EVENT_PROJECTINFO
+{
+#ifdef __cplusplus
+    FMOD_EVENT_PROJECTINFO() : index(0), numevents(0), numinstances(0), maxwavebanks(0), wavebankinfo(0), numplayingevents(0), playingevents(0) {}
+#endif
+
+    int                      index;            /* [out] Index of the project. */
+    char                     name[256];        /* [out] Name of the project. */
+    int                      numevents;        /* [out] Total number of events in all event groups in this event project. */
+    int                      numinstances;     /* [out] Total number of event instances in all event groups in this event project. */
+    int                      maxwavebanks;     /* [in/out] Out, number of wavebanks loaded by the EventProject.  In. Maximum size of array of wavebankinfo structures supplied by user.  Optional. */
+    FMOD_EVENT_WAVEBANKINFO *wavebankinfo;     /* [in] Pointer to array FMOD_EVENT_WAVEBANKINFO structures (max size defined by maxwavebanks).  FMOD will fill these in with detailed information on each wave bank. Optional. */
+    int                      numplayingevents; /* [in/out] On entry, maximum number of entries in playingevents array. On exit, actual number of entries in playingevents array, or if playingevents is null, then it is just the number of currently playing events. Optional. */
+    FMOD_EVENT             **playingevents;    /* [in/out] Pointer to an array that will be filled with the event handles of all playing events. Optional. Specify 0 if not needed. Must be used in conjunction with numplayingevents. */
+
+} FMOD_EVENT_PROJECTINFO;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing extended information about an event.
+
+    [REMARKS]
+    This structure is optional!  Specify 0 or NULL in Event::getInfo if you don't need it!<br>
+    This structure has members that need to be initialized before Event::getInfo is called. Always initialize this structure before calling Event::getInfo!
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Event::getInfo
+    FMOD_GUID
+]
+*/
+typedef struct FMOD_EVENT_INFO
+{
+#ifdef __cplusplus
+    FMOD_EVENT_INFO() : memoryused(0), positionms(0), lengthms(0), channelsplaying(0), instancesactive(0), maxwavebanks(0), wavebankinfo(0), projectid(0), systemid(0), audibility(0), numinstances(0), instances(0), guid(0) {}
+#endif
+
+    int                      memoryused;        /* This member has been deprecated. */
+    int                      positionms;        /* [out] Time passed in playback of this event instance in milliseconds. */
+    int                      lengthms;          /* [out] Length in milliseconds of this event. Note: lengthms will be -1 if the length of the event can't be determined i.e. if it has looping sounds. */
+    int                      channelsplaying;   /* [out] Number of channels currently playing in this event instance. */
+    int                      instancesactive;   /* [out] Number of event instances currently in use. */
+    int                      maxwavebanks;      /* [in/out] Out, number of wavebanks refered to by this event.  In. Maximum size of array of wavebankinfo structures supplied by user.  Optional. */
+    FMOD_EVENT_WAVEBANKINFO *wavebankinfo;      /* [in] Pointer to array FMOD_EVENT_WAVEBANKINFO structures (max size defined by maxwavebanks).  FMOD will fill these in with detailed information on each wave bank. Optional. */
+    unsigned int             projectid;         /* [out] The runtime 'EventProject' wide unique identifier for this event. */
+    unsigned int             systemid;          /* [out] The runtime 'EventSystem' wide unique identifier for this event.  This is calculated when single or multiple projects are loaded. */
+    float                    audibility;        /* [out] current audibility of event. */
+    int                      numinstances;      /* [in/out] On entry, maximum number of entries in instances array. On exit, actual number of entries in instances array, or if instances is null, then it is just the number of instances of this event. Optional. */
+    FMOD_EVENT             **instances;         /* [in/out] Pointer to an array that will be filled with the current reference-counted event handles of all instances of this event. Optional. Specify 0 if not needed. Must be used in conjunction with numinstances. Note: Due to reference counting, the event instance handles returned here may be different between subsequent calls to this function. If you use these event handles, make sure your code is prepared for them to be invalid! */
+    FMOD_GUID               *guid;              /* [out] Pointer to a structure that will be filled with the event's GUID. Optional. Specify 0 if not needed. */
+
+} FMOD_EVENT_INFO;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    Sound definition entry types for FMOD_EVENT_SOUNDDEFINFO.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_EVENT_SOUNDDEFINFO
+    FMOD_EVENT_CALLBACK
+    FMOD_EVENT_CALLBACKTYPE
+]
+*/
+typedef enum
+{
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE_WAVETABLE,           /* Waveform. */
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE_OSCILLATOR,          /* Oscillator. */
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE_NULL,                /* "Don't play" entry. */
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE_PROGRAMMER           /* Programmer sound. */
+} FMOD_EVENT_SOUNDDEF_ENTRYTYPE;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing information about a sound definition.
+
+    [REMARKS]
+    This structure is passed as the param1 argument of all 
+    FMOD_EVENT_CALLBACKTYPE_SOUNDDEF_SELECTINDEX callbacks if
+    FMOD_EVENT_INIT_DETAILED_SOUNDDEF_INFO was passed to EventSystem::init.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_EVENT_CALLBACK
+    FMOD_EVENT_CALLBACKTYPE
+    EventSystem::init
+    FMOD_EVENT_INITFLAGS
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE
+]
+*/
+typedef struct FMOD_EVENT_SOUNDDEFINFO
+{
+#ifdef __cplusplus
+    FMOD_EVENT_SOUNDDEFINFO() : name(0), numentries(0), entrynames(0), entrytypes(0) {}
+#endif
+
+    char                    *name;              /* The name of the sound definition. */
+    int                      numentries;        /* The number of entries in the sound definition. */
+    const char             **entrynames;        /* The names of the entries in the sound definition (an array of size numentries). Note that entrynames[i] will be null if entrytypes[i] is not FMOD_EVENT_SOUNDDEF_ENTRYTYPE_WAVETABLE. */
+    FMOD_EVENT_SOUNDDEF_ENTRYTYPE *entrytypes;  /* The types of the entries in the sound definition (an array of size numentries). */
+
+} FMOD_EVENT_SOUNDDEFINFO;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Use this structure with EventSystem::load when more control is needed over loading.
+
+    [REMARKS]
+    This structure is optional!  Specify 0 or NULL in EventSystem::load if you don't need it!<br>
+    <br>
+    Members marked with [in] mean the user sets the value before passing it to the function.<br>
+    Members marked with [out] mean FMOD sets the value to be used after the function exits.<br>
+    Use sounddefentrylimit to limit the number of sound definition entries - and therefore the amount of wave data - loaded for each sound definition. This feature allows the programmer to implement a "low detail" setting at runtime without needing a seperate "low detail" set of assets.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    EventSystem::load
+]
+*/
+typedef struct FMOD_EVENT_LOADINFO
+{
+#ifdef __cplusplus
+    FMOD_EVENT_LOADINFO() : size(0), encryptionkey(0), sounddefentrylimit(0), loadfrommemory_length(0), override_category_vals(0), sizeof_instancepool_simple(0) {}
+#endif
+
+    unsigned int  size;                         /* [in] Size of this structure.  This is used so the structure can be expanded in the future and still work on older versions of FMOD Ex. */
+    char         *encryptionkey;                /* [in] Optional. Specify 0 to ignore. Key, or 'password' to decrypt a bank.  A sound designer may have encrypted the audio data to protect their sound data from 'rippers'. */
+    float         sounddefentrylimit;           /* [in] Optional. Specify 0 to ignore. A value between 0 -> 1 that is multiplied with the number of sound definition entries in each sound definition in the project being loaded in order to programmatically reduce the number of sound definition entries used at runtime. */
+    unsigned int  loadfrommemory_length;        /* [in] Optional. Specify 0 to ignore. Length of memory buffer pointed to by name_or_data parameter passed to EventSystem::load. If this field is non-zero then the name_or_data parameter passed to EventSystem::load will be interpreted as a pointer to a memory buffer containing the .fev data to load. If this field is zero the name_or_data parameter is interpreted as the filename of the .fev file to load. */
+    FMOD_BOOL     override_category_vals;       /* [in] Optional. If this member is set to true, newly-loaded categories will impart their properties (volume, pitch etc.) to existing categories of the same name. */
+    unsigned int  sizeof_instancepool_simple;   /* [in] Optional. Specify 0 to ignore. If this value is non-zero, FMOD will create an instance pool for simple events with "sizeof_instancepool_simple" entries. Note: Event instance pools currently work for simple events only. Complex events will behave as normal and not be pooled. */
+
+} FMOD_EVENT_LOADINFO;
+
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_EVENT_CALLBACK) (FMOD_EVENT *event, FMOD_EVENT_CALLBACKTYPE type, void *param1, void *param2, void *userdata);
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These callback types are used with FMOD_EVENTQUEUE_CALLBACK.
+
+    [REMARKS]
+    <b>Note!</b> Currently the user must call EventSystem::update for these callbacks to trigger!<p>
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    EventQueue::setCallback
+    FMOD_EVENTQUEUE_CALLBACK
+    EventSystem::update
+]
+*/
+typedef enum
+{
+    FMOD_EVENTQUEUE_CALLBACKTYPE_PREPARE,       /* Called when an entry is being prepared for playback */
+    FMOD_EVENTQUEUE_CALLBACKTYPE_ABOUTTOPLAY,   /* Called when an entry is about to play */
+    FMOD_EVENTQUEUE_CALLBACKTYPE_FINISHED,      /* Called when an entry has finished playing */
+    FMOD_EVENTQUEUE_CALLBACKTYPE_EXPIRED        /* Called when an entry has expired before being played. See EventQueueEntry::setExpiryTime */
+
+} FMOD_EVENTQUEUE_CALLBACKTYPE;
+
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_EVENTQUEUE_CALLBACK)(FMOD_EVENTQUEUE_CALLBACKTYPE type, FMOD_EVENTQUEUE *queue, FMOD_EVENTQUEUEENTRY *entry, void *callbackuserdata);
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing realtime information about the music system.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    MusicSystem::getInfo
+]
+*/
+typedef struct FMOD_MUSIC_INFO
+{
+    FMOD_BOOL               starving;           /* [out] True if any streams in the music system are starving. */
+    FMOD_BOOL               all_samples_loaded; /* [out] True if all non-streaming samples in the music system are loaded, false otherwise. */
+} FMOD_MUSIC_INFO;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure used to hold information about music system entites.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_MUSIC_ITERATOR
+]
+*/
+typedef struct FMOD_MUSIC_ENTITY
+{
+	const char* name;                       /* The name of the music entity as a null terminated string. */
+	FMOD_MUSIC_ID id;                       /* The ID of the music entity. */
+} FMOD_MUSIC_ENTITY;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure used to enumerate entities in the music system.
+
+    [REMARKS]
+    The music system provides methods to initialize and advance iterators. Iterator members should never need to be set manually.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_MUSIC_ENTITY
+    MusicSystem::getCues
+    MusicSystem::getParameters
+]
+*/
+typedef struct FMOD_MUSIC_ITERATOR
+{
+	const FMOD_MUSIC_ENTITY* value;         /* The music entity the iterator points to. A null value indicates an invalid iterator. */
+	const char* filter;                     /* The string used to filter music entities. */
+} FMOD_MUSIC_ITERATOR;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing information about a music sample, for use with
+    FMOD_MUSIC_CALLBACKTYPE_SEGMENT_CREATE and FMOD_MUSIC_CALLBACKTYPE_SEGMENT_RELEASE.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_MUSIC_CALLBACK
+    FMOD_MUSIC_CALLBACKTYPE
+]
+*/
+typedef struct FMOD_MUSIC_SAMPLE_INFO
+{
+    unsigned int  segment_id;   /* The ID of the parent segment. */
+    unsigned int  index;        /* The index of the sample within the parent segment. */
+    const char   *filename;     /* The filename of the sample.<br/> <b>Note:</b> If the sample was built by a version of FMOD Designer before 4.29.09, this field will be 0. */
+} FMOD_MUSIC_SAMPLE_INFO;
+
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure containing information about a music segment, for use with
+    FMOD_MUSIC_CALLBACKTYPE_CHANNEL_CREATED and FMOD_MUSIC_CALLBACKTYPE_CHANNEL_DESTROYED.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    FMOD_MUSIC_CALLBACK
+    FMOD_MUSIC_CALLBACKTYPE
+]
+*/
+typedef struct FMOD_MUSIC_SEGMENT_INFO
+{
+    unsigned int  segment_id;   /* The ID of the segment. */
+    unsigned int  theme_id;     /* The ID of the parent theme. */
+} FMOD_MUSIC_SEGMENT_INFO;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These callback types are used with FMOD_MUSIC_CALLBACK.
+
+    [REMARKS]
+    <b>Note!</b>  Currently the user must call EventSystem::update for these callbacks to trigger!<br />
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    MusicSystem::setCallback
+    FMOD_MUSIC_CALLBACK
+    EventSystem::update
+]
+*/
+typedef enum
+{
+    FMOD_MUSIC_CALLBACKTYPE_SEGMENT_START,       /* Called when a segment is started. */
+    FMOD_MUSIC_CALLBACKTYPE_SEGMENT_END,         /* Called when a segment ends. */
+    FMOD_MUSIC_CALLBACKTYPE_SAMPLE_CREATE,       /* Called when a segment needs a sound created. */
+    FMOD_MUSIC_CALLBACKTYPE_SAMPLE_RELEASE,      /* Called when a segment is finished with a sound. */
+    FMOD_MUSIC_CALLBACKTYPE_CHANNEL_CREATED,     /* Called when a channel is created to play a segment. */
+    FMOD_MUSIC_CALLBACKTYPE_CHANNEL_DESTROYED,   /* Called when a segment channel is destroyed. */
+    FMOD_MUSIC_CALLBACKTYPE_RESET,               /* Called when the system is reset */
+    FMOD_MUSIC_CALLBACKTYPE_BEAT                 /* Called each time a beat is passed (based on segment tempo and time signature) */
+} FMOD_MUSIC_CALLBACKTYPE;
+
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_MUSIC_CALLBACK) (FMOD_MUSIC_CALLBACKTYPE type, void *param1, void *param2, void *userdata);
+
+
+/* ========================================================================================== */
+/* FUNCTION PROTOTYPES                                                                        */
+/* ========================================================================================== */
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+/*
+    FMOD EventSystem factory functions.  Use this to create an FMOD EventSystem Instance.  Below you will see FMOD_EventSystem_Init/Release to get started.
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_Create(FMOD_EVENTSYSTEM **eventsystem);
+
+/*$ preserve end $*/
+
+/*
+    'EventSystem' API
+*/
+
+/*
+     Initialization / system functions.
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_Init              (FMOD_EVENTSYSTEM *eventsystem, int maxchannels, FMOD_INITFLAGS flags, void *extradriverdata, FMOD_EVENT_INITFLAGS eventflags);
+FMOD_RESULT F_API FMOD_EventSystem_Release           (FMOD_EVENTSYSTEM *eventsystem);
+FMOD_RESULT F_API FMOD_EventSystem_Update            (FMOD_EVENTSYSTEM *eventsystem);
+FMOD_RESULT F_API FMOD_EventSystem_SetMediaPath      (FMOD_EVENTSYSTEM *eventsystem, const char *path);
+FMOD_RESULT F_API FMOD_EventSystem_SetPluginPath     (FMOD_EVENTSYSTEM *eventsystem, const char *path);
+FMOD_RESULT F_API FMOD_EventSystem_GetVersion        (FMOD_EVENTSYSTEM *eventsystem, unsigned int *version);
+FMOD_RESULT F_API FMOD_EventSystem_GetInfo           (FMOD_EVENTSYSTEM *eventsystem, FMOD_EVENT_SYSTEMINFO *info);
+FMOD_RESULT F_API FMOD_EventSystem_GetSystemObject   (FMOD_EVENTSYSTEM *eventsystem, FMOD_SYSTEM **system);
+FMOD_RESULT F_API FMOD_EventSystem_GetMusicSystem    (FMOD_EVENTSYSTEM *eventsystem, FMOD_MUSICSYSTEM **musicsystem);
+FMOD_RESULT F_API FMOD_EventSystem_SetLanguage       (FMOD_EVENTSYSTEM *eventsystem, const char *language);
+FMOD_RESULT F_API FMOD_EventSystem_GetLanguage       (FMOD_EVENTSYSTEM *eventsystem, char *language);
+FMOD_RESULT F_API FMOD_EventSystem_RegisterDSP       (FMOD_EVENTSYSTEM *eventsystem, FMOD_DSP_DESCRIPTION *description, unsigned int *handle);
+
+/*
+     FEV load/unload.                                 
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_Load              (FMOD_EVENTSYSTEM *eventsystem, const char *name_or_data, FMOD_EVENT_LOADINFO *loadinfo, FMOD_EVENTPROJECT **project);
+FMOD_RESULT F_API FMOD_EventSystem_Unload            (FMOD_EVENTSYSTEM *eventsystem);
+
+/*
+     Event,EventGroup,EventCategory Retrieval.        
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_GetProject        (FMOD_EVENTSYSTEM *eventsystem, const char *name, FMOD_EVENTPROJECT **project);
+FMOD_RESULT F_API FMOD_EventSystem_GetProjectByIndex (FMOD_EVENTSYSTEM *eventsystem, int index, FMOD_EVENTPROJECT **project);
+FMOD_RESULT F_API FMOD_EventSystem_GetNumProjects    (FMOD_EVENTSYSTEM *eventsystem, int *numprojects);
+FMOD_RESULT F_API FMOD_EventSystem_GetCategory       (FMOD_EVENTSYSTEM *eventsystem, const char *name, FMOD_EVENTCATEGORY **category);
+FMOD_RESULT F_API FMOD_EventSystem_GetCategoryByIndex(FMOD_EVENTSYSTEM *eventsystem, int index, FMOD_EVENTCATEGORY **category);
+FMOD_RESULT F_API FMOD_EventSystem_GetMusicCategory  (FMOD_EVENTSYSTEM *eventsystem, FMOD_EVENTCATEGORY **category);
+FMOD_RESULT F_API FMOD_EventSystem_GetNumCategories  (FMOD_EVENTSYSTEM *eventsystem, int *numcategories);
+FMOD_RESULT F_API FMOD_EventSystem_GetGroup          (FMOD_EVENTSYSTEM *eventsystem, const char *name, FMOD_BOOL cacheevents, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventSystem_GetEvent          (FMOD_EVENTSYSTEM *eventsystem, const char *name, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventSystem_GetEventBySystemID(FMOD_EVENTSYSTEM *eventsystem, unsigned int systemid, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventSystem_GetEventByGUID    (FMOD_EVENTSYSTEM *eventsystem, const FMOD_GUID *guid, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventSystem_GetEventByGUIDString(FMOD_EVENTSYSTEM *eventsystem, const char *guid, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventSystem_GetNumEvents      (FMOD_EVENTSYSTEM *eventsystem, int *numevents);
+
+/*
+     Reverb interfaces.
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_SetReverbProperties(FMOD_EVENTSYSTEM *eventsystem, const FMOD_REVERB_PROPERTIES *props);
+FMOD_RESULT F_API FMOD_EventSystem_GetReverbProperties(FMOD_EVENTSYSTEM *eventsystem, FMOD_REVERB_PROPERTIES *props);
+
+FMOD_RESULT F_API FMOD_EventSystem_GetReverbPreset   (FMOD_EVENTSYSTEM *eventsystem, const char *name, FMOD_REVERB_PROPERTIES *props, int *index);
+FMOD_RESULT F_API FMOD_EventSystem_GetReverbPresetByIndex(FMOD_EVENTSYSTEM *eventsystem, const int index, FMOD_REVERB_PROPERTIES *props, char **name);
+FMOD_RESULT F_API FMOD_EventSystem_GetNumReverbPresets(FMOD_EVENTSYSTEM *eventsystem, int *numpresets);
+
+FMOD_RESULT F_API FMOD_EventSystem_CreateReverb      (FMOD_EVENTSYSTEM *eventsystem, FMOD_EVENTREVERB **reverb);
+FMOD_RESULT F_API FMOD_EventSystem_SetReverbAmbientProperties(FMOD_EVENTSYSTEM *eventsystem, FMOD_REVERB_PROPERTIES *props);
+FMOD_RESULT F_API FMOD_EventSystem_GetReverbAmbientProperties(FMOD_EVENTSYSTEM *eventsystem, FMOD_REVERB_PROPERTIES *props);
+
+/*
+     Event queue interfaces.
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_CreateEventQueue  (FMOD_EVENTSYSTEM *eventsystem, FMOD_EVENTQUEUE **queue);
+FMOD_RESULT F_API FMOD_EventSystem_CreateEventQueueEntry(FMOD_EVENTSYSTEM *eventsystem, FMOD_EVENT *event, FMOD_EVENTQUEUEENTRY **entry);
+
+/*
+     3D Listener interface.
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_Set3DNumListeners (FMOD_EVENTSYSTEM *eventsystem, int numlisteners);
+FMOD_RESULT F_API FMOD_EventSystem_Get3DNumListeners (FMOD_EVENTSYSTEM *eventsystem, int *numlisteners);
+FMOD_RESULT F_API FMOD_EventSystem_Set3DListenerAttributes(FMOD_EVENTSYSTEM *eventsystem, int listener, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel, const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+FMOD_RESULT F_API FMOD_EventSystem_Get3DListenerAttributes(FMOD_EVENTSYSTEM *eventsystem, int listener, FMOD_VECTOR *pos, FMOD_VECTOR *vel, FMOD_VECTOR *forward, FMOD_VECTOR *up);
+
+/*
+     Get/set user data
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_SetUserData       (FMOD_EVENTSYSTEM *eventsystem, void *userdata);
+FMOD_RESULT F_API FMOD_EventSystem_GetUserData       (FMOD_EVENTSYSTEM *eventsystem, void **userdata);
+
+/*
+     Pre-loading FSB files (from disk or from memory, use FMOD_OPENMEMORY_POINT to point to pre-loaded memory).
+*/
+
+FMOD_RESULT F_API FMOD_EventSystem_PreloadFSB        (FMOD_EVENTSYSTEM *eventsystem, const char *filename, int streaminstance, FMOD_SOUND *sound, FMOD_BOOL unloadprevious);
+FMOD_RESULT F_API FMOD_EventSystem_UnloadFSB         (FMOD_EVENTSYSTEM *eventsystem, const char *filename, int streaminstance);
+
+FMOD_RESULT F_API FMOD_EventSystem_GetMemoryInfo     (FMOD_EVENTSYSTEM *eventsystem, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventProject' API
+*/
+
+FMOD_RESULT F_API FMOD_EventProject_Release          (FMOD_EVENTPROJECT *eventproject);
+FMOD_RESULT F_API FMOD_EventProject_GetInfo          (FMOD_EVENTPROJECT *eventproject, FMOD_EVENT_PROJECTINFO *info);
+FMOD_RESULT F_API FMOD_EventProject_GetGroup         (FMOD_EVENTPROJECT *eventproject, const char *name, FMOD_BOOL cacheevents, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventProject_GetGroupByIndex  (FMOD_EVENTPROJECT *eventproject, int index, FMOD_BOOL cacheevents, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventProject_GetNumGroups     (FMOD_EVENTPROJECT *eventproject, int *numgroups);
+FMOD_RESULT F_API FMOD_EventProject_GetEvent         (FMOD_EVENTPROJECT *eventproject, const char *name, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventProject_GetEventByProjectID(FMOD_EVENTPROJECT *eventproject, unsigned int projectid, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventProject_GetNumEvents     (FMOD_EVENTPROJECT *eventproject, int *numevents);
+FMOD_RESULT F_API FMOD_EventProject_LoadSampleData   (FMOD_EVENTPROJECT *eventproject, int *eventid_array, int sizeof_eventid_array, char **groupname_array, int sizeof_groupname_array, FMOD_EVENT_MODE eventmode);
+FMOD_RESULT F_API FMOD_EventProject_StopAllEvents    (FMOD_EVENTPROJECT *eventproject, FMOD_BOOL immediate);
+FMOD_RESULT F_API FMOD_EventProject_CancelAllLoads   (FMOD_EVENTPROJECT *eventproject);
+FMOD_RESULT F_API FMOD_EventProject_SetUserData      (FMOD_EVENTPROJECT *eventproject, void *userdata);
+FMOD_RESULT F_API FMOD_EventProject_GetUserData      (FMOD_EVENTPROJECT *eventproject, void **userdata);
+
+FMOD_RESULT F_API FMOD_EventProject_GetMemoryInfo    (FMOD_EVENTPROJECT *eventproject, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventGroup' API
+*/
+
+FMOD_RESULT F_API FMOD_EventGroup_GetInfo            (FMOD_EVENTGROUP *eventgroup, int *index, char **name);
+FMOD_RESULT F_API FMOD_EventGroup_LoadEventData      (FMOD_EVENTGROUP *eventgroup, FMOD_EVENT_RESOURCE resource, FMOD_EVENT_MODE mode);
+FMOD_RESULT F_API FMOD_EventGroup_FreeEventData      (FMOD_EVENTGROUP *eventgroup, FMOD_EVENT *event, FMOD_BOOL waituntilready);
+FMOD_RESULT F_API FMOD_EventGroup_GetGroup           (FMOD_EVENTGROUP *eventgroup, const char *name, FMOD_BOOL cacheevents, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventGroup_GetGroupByIndex    (FMOD_EVENTGROUP *eventgroup, int index, FMOD_BOOL cacheevents, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventGroup_GetParentGroup     (FMOD_EVENTGROUP *eventgroup, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_EventGroup_GetParentProject   (FMOD_EVENTGROUP *eventgroup, FMOD_EVENTPROJECT **project);
+FMOD_RESULT F_API FMOD_EventGroup_GetNumGroups       (FMOD_EVENTGROUP *eventgroup, int *numgroups);
+FMOD_RESULT F_API FMOD_EventGroup_GetEvent           (FMOD_EVENTGROUP *eventgroup, const char *name, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventGroup_GetEventByIndex    (FMOD_EVENTGROUP *eventgroup, int index, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventGroup_GetNumEvents       (FMOD_EVENTGROUP *eventgroup, int *numevents);
+FMOD_RESULT F_API FMOD_EventGroup_GetProperty        (FMOD_EVENTGROUP *eventgroup, const char *propertyname, void *value);
+FMOD_RESULT F_API FMOD_EventGroup_GetPropertyByIndex (FMOD_EVENTGROUP *eventgroup, int propertyindex, void *value);
+FMOD_RESULT F_API FMOD_EventGroup_GetNumProperties   (FMOD_EVENTGROUP *eventgroup, int *numproperties);
+FMOD_RESULT F_API FMOD_EventGroup_GetState           (FMOD_EVENTGROUP *eventgroup, FMOD_EVENT_STATE *state);
+FMOD_RESULT F_API FMOD_EventGroup_SetUserData        (FMOD_EVENTGROUP *eventgroup, void *userdata);
+FMOD_RESULT F_API FMOD_EventGroup_GetUserData        (FMOD_EVENTGROUP *eventgroup, void **userdata);
+
+FMOD_RESULT F_API FMOD_EventGroup_GetMemoryInfo      (FMOD_EVENTGROUP *eventgroup, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventCategory' API
+*/
+
+FMOD_RESULT F_API FMOD_EventCategory_GetInfo         (FMOD_EVENTCATEGORY *eventcategory, int *index, char **name);
+FMOD_RESULT F_API FMOD_EventCategory_GetCategory     (FMOD_EVENTCATEGORY *eventcategory, const char *name, FMOD_EVENTCATEGORY **category);
+FMOD_RESULT F_API FMOD_EventCategory_GetCategoryByIndex(FMOD_EVENTCATEGORY *eventcategory, int index, FMOD_EVENTCATEGORY **category);
+FMOD_RESULT F_API FMOD_EventCategory_GetNumCategories(FMOD_EVENTCATEGORY *eventcategory, int *numcategories);
+FMOD_RESULT F_API FMOD_EventCategory_GetEventByIndex (FMOD_EVENTCATEGORY *eventcategory, int index, FMOD_EVENT_MODE mode, FMOD_EVENT **event);
+FMOD_RESULT F_API FMOD_EventCategory_GetNumEvents    (FMOD_EVENTCATEGORY *eventcategory, int *numevents);
+FMOD_RESULT F_API FMOD_EventCategory_GetParentCategory(FMOD_EVENTCATEGORY *eventcategory, FMOD_EVENTCATEGORY **category);
+
+FMOD_RESULT F_API FMOD_EventCategory_StopAllEvents   (FMOD_EVENTCATEGORY *eventcategory);
+FMOD_RESULT F_API FMOD_EventCategory_SetVolume       (FMOD_EVENTCATEGORY *eventcategory, float volume);
+FMOD_RESULT F_API FMOD_EventCategory_GetVolume       (FMOD_EVENTCATEGORY *eventcategory, float *volume);
+FMOD_RESULT F_API FMOD_EventCategory_SetPitch        (FMOD_EVENTCATEGORY *eventcategory, float pitch, FMOD_EVENT_PITCHUNITS units);
+FMOD_RESULT F_API FMOD_EventCategory_GetPitch        (FMOD_EVENTCATEGORY *eventcategory, float *pitch, FMOD_EVENT_PITCHUNITS units);
+FMOD_RESULT F_API FMOD_EventCategory_SetPaused       (FMOD_EVENTCATEGORY *eventcategory, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_EventCategory_GetPaused       (FMOD_EVENTCATEGORY *eventcategory, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_EventCategory_SetMute         (FMOD_EVENTCATEGORY *eventcategory, FMOD_BOOL mute);
+FMOD_RESULT F_API FMOD_EventCategory_GetMute         (FMOD_EVENTCATEGORY *eventcategory, FMOD_BOOL *mute);
+FMOD_RESULT F_API FMOD_EventCategory_GetChannelGroup (FMOD_EVENTCATEGORY *eventcategory, FMOD_CHANNELGROUP **channelgroup);
+FMOD_RESULT F_API FMOD_EventCategory_SetUserData     (FMOD_EVENTCATEGORY *eventcategory, void *userdata);
+FMOD_RESULT F_API FMOD_EventCategory_GetUserData     (FMOD_EVENTCATEGORY *eventcategory, void **userdata);
+
+FMOD_RESULT F_API FMOD_EventCategory_GetMemoryInfo   (FMOD_EVENTCATEGORY *eventcategory, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'Event' API
+*/
+
+FMOD_RESULT F_API FMOD_Event_Release                 (FMOD_EVENT *event, FMOD_BOOL freeeventdata, FMOD_BOOL waituntilready);
+
+FMOD_RESULT F_API FMOD_Event_Start                   (FMOD_EVENT *event);
+FMOD_RESULT F_API FMOD_Event_Stop                    (FMOD_EVENT *event, FMOD_BOOL immediate);
+
+FMOD_RESULT F_API FMOD_Event_GetInfo                 (FMOD_EVENT *event, int *index, char **name, FMOD_EVENT_INFO *info);
+FMOD_RESULT F_API FMOD_Event_GetState                (FMOD_EVENT *event, FMOD_EVENT_STATE *state);
+FMOD_RESULT F_API FMOD_Event_GetParentGroup          (FMOD_EVENT *event, FMOD_EVENTGROUP **group);
+FMOD_RESULT F_API FMOD_Event_GetChannelGroup         (FMOD_EVENT *event, FMOD_CHANNELGROUP **channelgroup);
+FMOD_RESULT F_API FMOD_Event_SetCallback             (FMOD_EVENT *event, FMOD_EVENT_CALLBACK callback, void *userdata);
+
+FMOD_RESULT F_API FMOD_Event_GetParameter            (FMOD_EVENT *event, const char *name, FMOD_EVENTPARAMETER **parameter);
+FMOD_RESULT F_API FMOD_Event_GetParameterByIndex     (FMOD_EVENT *event, int index, FMOD_EVENTPARAMETER **parameter);
+FMOD_RESULT F_API FMOD_Event_GetNumParameters        (FMOD_EVENT *event, int *numparameters);
+FMOD_RESULT F_API FMOD_Event_GetProperty             (FMOD_EVENT *event, const char *propertyname, void *value, FMOD_BOOL this_instance);
+FMOD_RESULT F_API FMOD_Event_GetPropertyByIndex      (FMOD_EVENT *event, int propertyindex, void *value, FMOD_BOOL this_instance);
+FMOD_RESULT F_API FMOD_Event_SetProperty             (FMOD_EVENT *event, const char *propertyname, void *value, FMOD_BOOL this_instance);
+FMOD_RESULT F_API FMOD_Event_SetPropertyByIndex      (FMOD_EVENT *event, int propertyindex, void *value, FMOD_BOOL this_instance);
+FMOD_RESULT F_API FMOD_Event_GetNumProperties        (FMOD_EVENT *event, int *numproperties);
+FMOD_RESULT F_API FMOD_Event_GetPropertyInfo         (FMOD_EVENT *event, int *propertyindex, char **propertyname, FMOD_EVENTPROPERTY_TYPE *type);
+FMOD_RESULT F_API FMOD_Event_GetCategory             (FMOD_EVENT *event, FMOD_EVENTCATEGORY **category);
+
+FMOD_RESULT F_API FMOD_Event_SetVolume               (FMOD_EVENT *event, float volume);
+FMOD_RESULT F_API FMOD_Event_GetVolume               (FMOD_EVENT *event, float *volume);
+FMOD_RESULT F_API FMOD_Event_SetPitch                (FMOD_EVENT *event, float pitch, FMOD_EVENT_PITCHUNITS units);
+FMOD_RESULT F_API FMOD_Event_GetPitch                (FMOD_EVENT *event, float *pitch, FMOD_EVENT_PITCHUNITS units);
+FMOD_RESULT F_API FMOD_Event_SetPaused               (FMOD_EVENT *event, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_Event_GetPaused               (FMOD_EVENT *event, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_Event_SetMute                 (FMOD_EVENT *event, FMOD_BOOL mute);
+FMOD_RESULT F_API FMOD_Event_GetMute                 (FMOD_EVENT *event, FMOD_BOOL *mute);
+FMOD_RESULT F_API FMOD_Event_Set3DAttributes         (FMOD_EVENT *event, const FMOD_VECTOR *position, const FMOD_VECTOR *velocity, const FMOD_VECTOR *orientation);
+FMOD_RESULT F_API FMOD_Event_Get3DAttributes         (FMOD_EVENT *event, FMOD_VECTOR *position, FMOD_VECTOR *velocity, FMOD_VECTOR *orientation);
+FMOD_RESULT F_API FMOD_Event_Set3DOcclusion          (FMOD_EVENT *event, float directocclusion, float reverbocclusion);
+FMOD_RESULT F_API FMOD_Event_Get3DOcclusion          (FMOD_EVENT *event, float *directocclusion, float *reverbocclusion);
+FMOD_RESULT F_API FMOD_Event_SetReverbProperties     (FMOD_EVENT *event, const FMOD_REVERB_CHANNELPROPERTIES *props);
+FMOD_RESULT F_API FMOD_Event_GetReverbProperties     (FMOD_EVENT *event, FMOD_REVERB_CHANNELPROPERTIES *props);
+FMOD_RESULT F_API FMOD_Event_SetUserData             (FMOD_EVENT *event, void *userdata);
+FMOD_RESULT F_API FMOD_Event_GetUserData             (FMOD_EVENT *event, void **userdata);
+
+FMOD_RESULT F_API FMOD_Event_GetMemoryInfo           (FMOD_EVENT *event, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventParameter' API
+*/
+
+FMOD_RESULT F_API FMOD_EventParameter_GetInfo        (FMOD_EVENTPARAMETER *eventparameter, int *index, char **name);
+FMOD_RESULT F_API FMOD_EventParameter_GetRange       (FMOD_EVENTPARAMETER *eventparameter, float *rangemin, float *rangemax);
+FMOD_RESULT F_API FMOD_EventParameter_SetValue       (FMOD_EVENTPARAMETER *eventparameter, float value);
+FMOD_RESULT F_API FMOD_EventParameter_GetValue       (FMOD_EVENTPARAMETER *eventparameter, float *value);
+FMOD_RESULT F_API FMOD_EventParameter_SetVelocity    (FMOD_EVENTPARAMETER *eventparameter, float value);
+FMOD_RESULT F_API FMOD_EventParameter_GetVelocity    (FMOD_EVENTPARAMETER *eventparameter, float *value);
+FMOD_RESULT F_API FMOD_EventParameter_SetSeekSpeed   (FMOD_EVENTPARAMETER *eventparameter, float value);
+FMOD_RESULT F_API FMOD_EventParameter_GetSeekSpeed   (FMOD_EVENTPARAMETER *eventparameter, float *value);
+FMOD_RESULT F_API FMOD_EventParameter_SetUserData    (FMOD_EVENTPARAMETER *eventparameter, void *userdata);
+FMOD_RESULT F_API FMOD_EventParameter_GetUserData    (FMOD_EVENTPARAMETER *eventparameter, void **userdata);
+FMOD_RESULT F_API FMOD_EventParameter_KeyOff         (FMOD_EVENTPARAMETER *eventparameter);
+
+FMOD_RESULT F_API FMOD_EventParameter_GetMemoryInfo  (FMOD_EVENTPARAMETER *eventparameter, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventReverb' API
+*/
+
+FMOD_RESULT F_API FMOD_EventReverb_Release           (FMOD_EVENTREVERB *eventreverb);
+FMOD_RESULT F_API FMOD_EventReverb_Set3DAttributes   (FMOD_EVENTREVERB *eventreverb, const FMOD_VECTOR *position, float mindistance, float maxdistance);
+FMOD_RESULT F_API FMOD_EventReverb_Get3DAttributes   (FMOD_EVENTREVERB *eventreverb, FMOD_VECTOR *position, float *mindistance, float *maxdistance);
+FMOD_RESULT F_API FMOD_EventReverb_SetProperties     (FMOD_EVENTREVERB *eventreverb, const FMOD_REVERB_PROPERTIES *props);
+FMOD_RESULT F_API FMOD_EventReverb_GetProperties     (FMOD_EVENTREVERB *eventreverb, FMOD_REVERB_PROPERTIES *props);
+FMOD_RESULT F_API FMOD_EventReverb_SetActive         (FMOD_EVENTREVERB *eventreverb, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_EventReverb_GetActive         (FMOD_EVENTREVERB *eventreverb, FMOD_BOOL *active);
+FMOD_RESULT F_API FMOD_EventReverb_SetUserData       (FMOD_EVENTREVERB *eventreverb, void *userdata);
+FMOD_RESULT F_API FMOD_EventReverb_GetUserData       (FMOD_EVENTREVERB *eventreverb, void **userdata);
+
+FMOD_RESULT F_API FMOD_EventReverb_GetMemoryInfo     (FMOD_EVENTREVERB *eventreverb, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventQueue' API
+*/
+
+FMOD_RESULT F_API FMOD_EventQueue_Release            (FMOD_EVENTQUEUE *eventqueue);
+FMOD_RESULT F_API FMOD_EventQueue_Add                (FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTQUEUEENTRY *entry, FMOD_BOOL allow_duplicates);
+FMOD_RESULT F_API FMOD_EventQueue_Remove             (FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTQUEUEENTRY *entry);
+FMOD_RESULT F_API FMOD_EventQueue_RemoveHead         (FMOD_EVENTQUEUE *eventqueue);
+FMOD_RESULT F_API FMOD_EventQueue_Clear              (FMOD_EVENTQUEUE *eventqueue, FMOD_BOOL stopallevents);
+FMOD_RESULT F_API FMOD_EventQueue_FindFirstEntry     (FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTQUEUEENTRY **entry);
+FMOD_RESULT F_API FMOD_EventQueue_FindNextEntry      (FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTQUEUEENTRY **entry);
+FMOD_RESULT F_API FMOD_EventQueue_SetPaused          (FMOD_EVENTQUEUE *eventqueue, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_EventQueue_GetPaused          (FMOD_EVENTQUEUE *eventqueue, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_EventQueue_IncludeDuckingCategory(FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTCATEGORY *category, float ducked_volume, float unducked_volume, unsigned int duck_time, unsigned int unduck_time);
+FMOD_RESULT F_API FMOD_EventQueue_ExcludeDuckingCategory(FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTCATEGORY *category);
+FMOD_RESULT F_API FMOD_EventQueue_SetCallback        (FMOD_EVENTQUEUE *eventqueue, FMOD_EVENTQUEUE_CALLBACK callback, void *callbackuserdata);
+FMOD_RESULT F_API FMOD_EventQueue_SetUserData        (FMOD_EVENTQUEUE *eventqueue, void *userdata);
+FMOD_RESULT F_API FMOD_EventQueue_GetUserData        (FMOD_EVENTQUEUE *eventqueue, void **userdata);
+FMOD_RESULT F_API FMOD_EventQueue_Dump               (FMOD_EVENTQUEUE *eventqueue);
+
+FMOD_RESULT F_API FMOD_EventQueue_GetMemoryInfo      (FMOD_EVENTQUEUE *eventqueue, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'EventQueueEntry' API
+*/
+
+FMOD_RESULT F_API FMOD_EventQueueEntry_Release       (FMOD_EVENTQUEUEENTRY *eventqueueentry);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetInfoOnlyEvent(FMOD_EVENTQUEUEENTRY *eventqueueentry, FMOD_EVENT **infoonlyevent);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetRealEvent  (FMOD_EVENTQUEUEENTRY *eventqueueentry, FMOD_EVENT **realevent);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetPriority   (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned char priority);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetPriority   (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned char *priority);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetExpiryTime (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned int expirytime);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetExpiryTime (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned int *expirytime);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetDelayTime  (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned int delay);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetDelayTime  (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned int *delay);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetInterrupt  (FMOD_EVENTQUEUEENTRY *eventqueueentry, FMOD_BOOL interrupt);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetInterrupt  (FMOD_EVENTQUEUEENTRY *eventqueueentry, FMOD_BOOL *interrupt);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetCrossfadeTime(FMOD_EVENTQUEUEENTRY *eventqueueentry, int crossfade);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetCrossfadeTime(FMOD_EVENTQUEUEENTRY *eventqueueentry, int *crossfade);
+FMOD_RESULT F_API FMOD_EventQueueEntry_SetUserData   (FMOD_EVENTQUEUEENTRY *eventqueueentry, void *userdata);
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetUserData   (FMOD_EVENTQUEUEENTRY *eventqueueentry, void **userdata);
+
+FMOD_RESULT F_API FMOD_EventQueueEntry_GetMemoryInfo (FMOD_EVENTQUEUEENTRY *eventqueueentry, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'MusicSystem' API
+*/
+
+FMOD_RESULT F_API FMOD_MusicSystem_Reset             (FMOD_MUSICSYSTEM *musicsystem);
+FMOD_RESULT F_API FMOD_MusicSystem_SetVolume         (FMOD_MUSICSYSTEM *musicsystem, float volume);
+FMOD_RESULT F_API FMOD_MusicSystem_GetVolume         (FMOD_MUSICSYSTEM *musicsystem, float *volume);
+FMOD_RESULT F_API FMOD_MusicSystem_SetReverbProperties(FMOD_MUSICSYSTEM *musicsystem, const FMOD_REVERB_CHANNELPROPERTIES *props);
+FMOD_RESULT F_API FMOD_MusicSystem_GetReverbProperties(FMOD_MUSICSYSTEM *musicsystem, FMOD_REVERB_CHANNELPROPERTIES *props);
+FMOD_RESULT F_API FMOD_MusicSystem_SetPaused         (FMOD_MUSICSYSTEM *musicsystem, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_MusicSystem_GetPaused         (FMOD_MUSICSYSTEM *musicsystem, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_MusicSystem_SetMute           (FMOD_MUSICSYSTEM *musicsystem, FMOD_BOOL mute);
+FMOD_RESULT F_API FMOD_MusicSystem_GetMute           (FMOD_MUSICSYSTEM *musicsystem, FMOD_BOOL *mute);
+FMOD_RESULT F_API FMOD_MusicSystem_GetInfo           (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_INFO *info);
+FMOD_RESULT F_API FMOD_MusicSystem_PromptCue         (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_CUE_ID id);
+FMOD_RESULT F_API FMOD_MusicSystem_PrepareCue        (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_CUE_ID id, FMOD_MUSICPROMPT **prompt);
+FMOD_RESULT F_API FMOD_MusicSystem_GetParameterValue (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_PARAM_ID id, float *parameter);
+FMOD_RESULT F_API FMOD_MusicSystem_SetParameterValue (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_PARAM_ID id, float parameter);
+
+FMOD_RESULT F_API FMOD_MusicSystem_GetCues           (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_ITERATOR *it, const char *filter);
+FMOD_RESULT F_API FMOD_MusicSystem_GetNextCue        (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_ITERATOR *it);
+FMOD_RESULT F_API FMOD_MusicSystem_GetParameters     (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_ITERATOR *it, const char *filter);
+FMOD_RESULT F_API FMOD_MusicSystem_GetNextParameter  (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_ITERATOR *it);
+
+FMOD_RESULT F_API FMOD_MusicSystem_LoadSoundData     (FMOD_MUSICSYSTEM *musicsystem, FMOD_EVENT_RESOURCE resource, FMOD_EVENT_MODE mode);
+FMOD_RESULT F_API FMOD_MusicSystem_FreeSoundData     (FMOD_MUSICSYSTEM *musicsystem, FMOD_BOOL waituntilready);
+
+FMOD_RESULT F_API FMOD_MusicSystem_SetCallback       (FMOD_MUSICSYSTEM *musicsystem, FMOD_MUSIC_CALLBACK callback, void *userdata);
+
+FMOD_RESULT F_API FMOD_MusicSystem_GetMemoryInfo     (FMOD_MUSICSYSTEM *musicsystem, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'MusicPrompt' API
+*/
+
+FMOD_RESULT F_API FMOD_MusicPrompt_Release           (FMOD_MUSICPROMPT *musicprompt);
+FMOD_RESULT F_API FMOD_MusicPrompt_Begin             (FMOD_MUSICPROMPT *musicprompt);
+FMOD_RESULT F_API FMOD_MusicPrompt_End               (FMOD_MUSICPROMPT *musicprompt);
+FMOD_RESULT F_API FMOD_MusicPrompt_IsActive          (FMOD_MUSICPROMPT *musicprompt, FMOD_BOOL *active);
+
+FMOD_RESULT F_API FMOD_MusicPrompt_GetMemoryInfo     (FMOD_MUSICPROMPT *musicprompt, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+/*$ preserve start $*/
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif
+
+/*$ preserve end $*/

--- a/src/moaicore/fmoddesignerinc/fmod_event.hpp
+++ b/src/moaicore/fmoddesignerinc/fmod_event.hpp
@@ -1,0 +1,396 @@
+/*
+    fmod_event.hpp - Data-driven event classes
+    Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.
+
+    This header is the base header for all other FMOD EventSystem headers. If you are programming in C use FMOD_EVENT.H
+*/
+
+#ifndef __FMOD_EVENT_HPP__
+#define __FMOD_EVENT_HPP__
+
+#ifndef _FMOD_HPP
+#include "fmod.hpp"
+#endif
+#ifndef __FMOD_EVENT_H__
+#include "fmod_event.h"
+#endif
+
+namespace FMOD
+{
+    class EventSystem;
+    class EventCategory;
+    class EventProject;
+    class EventGroup;
+    class Event;
+    class EventParameter;
+    class EventReverb;
+    class EventQueue;
+    class EventQueueEntry;
+    class MusicSystem;
+    class MusicPrompt;
+
+    /*
+        FMOD EventSystem factory functions.
+    */
+    inline FMOD_RESULT EventSystem_Create(EventSystem **eventsystem) { return FMOD_EventSystem_Create((FMOD_EVENTSYSTEM **)eventsystem); }
+
+    /*
+       'EventSystem' API
+    */
+    class EventSystem
+    {
+        public :
+
+        // Initialization / system functions.
+        FMOD_RESULT F_API init                      (int maxchannels, FMOD_INITFLAGS flags, void *extradriverdata, FMOD_EVENT_INITFLAGS eventflags = FMOD_EVENT_INIT_NORMAL);
+        FMOD_RESULT F_API release                   ();
+        FMOD_RESULT F_API update                    ();
+        FMOD_RESULT F_API setMediaPath              (const char *path);
+        FMOD_RESULT F_API setPluginPath             (const char *path);
+        FMOD_RESULT F_API getVersion                (unsigned int *version);
+        FMOD_RESULT F_API getInfo                   (FMOD_EVENT_SYSTEMINFO *info);
+        FMOD_RESULT F_API getSystemObject           (System **system);
+        FMOD_RESULT F_API getMusicSystem            (MusicSystem **musicsystem);
+        FMOD_RESULT F_API setLanguage               (const char *language);
+        FMOD_RESULT F_API getLanguage               (char *language);
+        FMOD_RESULT F_API registerDSP               (FMOD_DSP_DESCRIPTION *description, unsigned int *handle);
+
+        // FEV load/unload.                                 
+        FMOD_RESULT F_API load                      (const char *name_or_data, FMOD_EVENT_LOADINFO *loadinfo, EventProject **project);
+        FMOD_RESULT F_API unload                    ();
+                                                            
+        // Event,EventGroup,EventCategory Retrieval.        
+        FMOD_RESULT F_API getProject                (const char *name, EventProject **project);
+        FMOD_RESULT F_API getProjectByIndex         (int index,        EventProject **project);
+        FMOD_RESULT F_API getNumProjects            (int *numprojects);
+        FMOD_RESULT F_API getCategory               (const char *name, EventCategory **category);
+        FMOD_RESULT F_API getCategoryByIndex        (int index,        EventCategory **category);
+        FMOD_RESULT F_API getMusicCategory          (EventCategory **category);
+        FMOD_RESULT F_API getNumCategories          (int *numcategories);
+        FMOD_RESULT F_API getGroup                  (const char *name, bool cacheevents, EventGroup **group);
+        FMOD_RESULT F_API getEvent                  (const char *name, FMOD_EVENT_MODE mode, Event **event);
+        FMOD_RESULT F_API getEventBySystemID        (unsigned int systemid, FMOD_EVENT_MODE mode, Event **event);
+        FMOD_RESULT F_API getEventByGUID            (const FMOD_GUID *guid, FMOD_EVENT_MODE mode, Event **event);
+        FMOD_RESULT F_API getEventByGUIDString      (const char *guid, FMOD_EVENT_MODE mode, Event **event);
+        FMOD_RESULT F_API getNumEvents              (int *numevents);
+
+        // Reverb interfaces.
+        FMOD_RESULT F_API setReverbProperties       (const FMOD_REVERB_PROPERTIES *props);
+        FMOD_RESULT F_API getReverbProperties       (FMOD_REVERB_PROPERTIES *props);
+
+        FMOD_RESULT F_API getReverbPreset           (const char *name, FMOD_REVERB_PROPERTIES *props, int *index = 0);
+        FMOD_RESULT F_API getReverbPresetByIndex    (const int index,  FMOD_REVERB_PROPERTIES *props, char **name = 0);
+        FMOD_RESULT F_API getNumReverbPresets       (int *numpresets);
+
+        FMOD_RESULT F_API createReverb              (EventReverb **reverb);
+        FMOD_RESULT F_API setReverbAmbientProperties(FMOD_REVERB_PROPERTIES *props);
+        FMOD_RESULT F_API getReverbAmbientProperties(FMOD_REVERB_PROPERTIES *props);
+
+        // Event queue interfaces.
+        FMOD_RESULT F_API createEventQueue          (EventQueue **queue);
+        FMOD_RESULT F_API createEventQueueEntry     (Event *event, EventQueueEntry **entry);
+
+        // 3D Listener interface.
+        FMOD_RESULT F_API set3DNumListeners         (int numlisteners);
+        FMOD_RESULT F_API get3DNumListeners         (int *numlisteners);
+        FMOD_RESULT F_API set3DListenerAttributes   (int listener, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel, const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+        FMOD_RESULT F_API get3DListenerAttributes   (int listener, FMOD_VECTOR *pos, FMOD_VECTOR *vel, FMOD_VECTOR *forward, FMOD_VECTOR *up);
+
+        // Get/set user data
+        FMOD_RESULT F_API setUserData               (void *userdata);
+        FMOD_RESULT F_API getUserData               (void **userdata);
+
+        // Pre-loading FSB files (from disk or from memory, use FMOD_OPENMEMORY_POINT to point to pre-loaded memory).
+        FMOD_RESULT F_API preloadFSB                (const char *filename, int streaminstance, Sound *sound, bool unloadprevious = false);
+        FMOD_RESULT F_API unloadFSB                 (const char *filename, int streaminstance);
+
+        FMOD_RESULT F_API getMemoryInfo             (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+       'EventProject' API
+    */
+    class EventProject
+    {
+        public :
+
+        virtual FMOD_RESULT F_API release            () = 0;
+        virtual FMOD_RESULT F_API getInfo            (FMOD_EVENT_PROJECTINFO *info) = 0;
+        virtual FMOD_RESULT F_API getGroup           (const char *name, bool cacheevents, EventGroup **group) = 0;
+        virtual FMOD_RESULT F_API getGroupByIndex    (int index,        bool cacheevents, EventGroup **group) = 0;
+        virtual FMOD_RESULT F_API getNumGroups       (int *numgroups) = 0;
+        virtual FMOD_RESULT F_API getEvent           (const char *name, FMOD_EVENT_MODE mode, Event **event) = 0;
+        virtual FMOD_RESULT F_API getEventByProjectID(unsigned int projectid, FMOD_EVENT_MODE mode, Event **event) = 0;
+        virtual FMOD_RESULT F_API getNumEvents       (int *numevents) = 0;
+        virtual FMOD_RESULT F_API loadSampleData     (int *eventid_array, int sizeof_eventid_array, char **groupname_array, int sizeof_groupname_array, FMOD_EVENT_MODE eventmode) = 0;
+        virtual FMOD_RESULT F_API stopAllEvents      (bool immediate = false) = 0;
+        virtual FMOD_RESULT F_API cancelAllLoads     () = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventProject(){};
+    };
+
+    /*
+       'EventGroup' API
+    */
+    class EventGroup
+    {
+        public :
+
+        virtual FMOD_RESULT F_API getInfo            (int *index, char **name) = 0;
+        virtual FMOD_RESULT F_API loadEventData      (FMOD_EVENT_RESOURCE resource = FMOD_EVENT_RESOURCE_STREAMS_AND_SAMPLES, FMOD_EVENT_MODE mode = FMOD_EVENT_DEFAULT) = 0;
+        virtual FMOD_RESULT F_API freeEventData      (Event *event = 0, bool waituntilready = true) = 0;
+        virtual FMOD_RESULT F_API getGroup           (const char *name, bool cacheevents, EventGroup **group) = 0;
+        virtual FMOD_RESULT F_API getGroupByIndex    (int index,        bool cacheevents, EventGroup **group) = 0;
+        virtual FMOD_RESULT F_API getParentGroup     (EventGroup **group) = 0;
+        virtual FMOD_RESULT F_API getParentProject   (EventProject **project) = 0;
+        virtual FMOD_RESULT F_API getNumGroups       (int *numgroups) = 0;
+        virtual FMOD_RESULT F_API getEvent           (const char *name, FMOD_EVENT_MODE mode, Event **event) = 0;
+        virtual FMOD_RESULT F_API getEventByIndex    (int index,        FMOD_EVENT_MODE mode, Event **event) = 0;
+        virtual FMOD_RESULT F_API getNumEvents       (int *numevents) = 0;
+        virtual FMOD_RESULT F_API getProperty        (const char *propertyname, void *value) = 0;
+        virtual FMOD_RESULT F_API getPropertyByIndex (int propertyindex, void *value) = 0;
+        virtual FMOD_RESULT F_API getNumProperties   (int *numproperties) = 0;
+        virtual FMOD_RESULT F_API getState           (FMOD_EVENT_STATE *state) = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventGroup(){};
+    };
+
+    /*
+       'EventCategory' API
+    */
+    class EventCategory
+    {
+        public :
+
+        virtual FMOD_RESULT F_API getInfo            (int *index, char **name) = 0;
+        virtual FMOD_RESULT F_API getCategory        (const char *name, EventCategory **category) = 0;
+        virtual FMOD_RESULT F_API getCategoryByIndex (int index, EventCategory **category) = 0;
+        virtual FMOD_RESULT F_API getNumCategories   (int *numcategories) = 0;
+        virtual FMOD_RESULT F_API getEventByIndex    (int index, FMOD_EVENT_MODE mode, Event **event) = 0;
+        virtual FMOD_RESULT F_API getNumEvents       (int *numevents) = 0;
+        virtual FMOD_RESULT F_API getParentCategory  (EventCategory **category) = 0;
+
+        virtual FMOD_RESULT F_API stopAllEvents      () = 0;
+        virtual FMOD_RESULT F_API setVolume          (float volume) = 0;
+        virtual FMOD_RESULT F_API getVolume          (float *volume) = 0;
+        virtual FMOD_RESULT F_API setPitch           (float pitch, FMOD_EVENT_PITCHUNITS units = FMOD_EVENT_PITCHUNITS_RAW) = 0;
+        virtual FMOD_RESULT F_API getPitch           (float *pitch, FMOD_EVENT_PITCHUNITS units = FMOD_EVENT_PITCHUNITS_RAW) = 0;
+        virtual FMOD_RESULT F_API setPaused          (bool paused) = 0;
+        virtual FMOD_RESULT F_API getPaused          (bool *paused) = 0;
+        virtual FMOD_RESULT F_API setMute            (bool mute) = 0;
+        virtual FMOD_RESULT F_API getMute            (bool *mute) = 0;
+        virtual FMOD_RESULT F_API getChannelGroup    (ChannelGroup **channelgroup) = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventCategory(){};
+    };
+
+    /*
+       'Event' API
+    */
+    class Event
+    {
+        public :
+
+        FMOD_RESULT F_API release                    (bool freeeventdata = false, bool waituntilready = true);
+
+        FMOD_RESULT F_API start                      ();
+        FMOD_RESULT F_API stop                       (bool immediate = false);
+
+        FMOD_RESULT F_API getInfo                    (int *index, char **name, FMOD_EVENT_INFO *info);
+        FMOD_RESULT F_API getState                   (FMOD_EVENT_STATE *state);
+        FMOD_RESULT F_API getParentGroup             (EventGroup **group);
+        FMOD_RESULT F_API getChannelGroup            (ChannelGroup **channelgroup);
+        FMOD_RESULT F_API setCallback                (FMOD_EVENT_CALLBACK callback, void *userdata);
+
+        FMOD_RESULT F_API getParameter               (const char *name, EventParameter **parameter);
+        FMOD_RESULT F_API getParameterByIndex        (int index, EventParameter **parameter);
+        FMOD_RESULT F_API getNumParameters           (int *numparameters);
+        FMOD_RESULT F_API getProperty                (const char *propertyname, void *value, bool this_instance = false);
+        FMOD_RESULT F_API getPropertyByIndex         (int propertyindex, void *value, bool this_instance = false);
+        FMOD_RESULT F_API setProperty                (const char *propertyname, void *value, bool this_instance = false);
+        FMOD_RESULT F_API setPropertyByIndex         (int propertyindex, void *value, bool this_instance = false);
+        FMOD_RESULT F_API getNumProperties           (int *numproperties);
+        FMOD_RESULT F_API getPropertyInfo            (int *propertyindex, char **propertyname, FMOD_EVENTPROPERTY_TYPE *type = 0);
+        FMOD_RESULT F_API getCategory                (EventCategory **category);
+
+        FMOD_RESULT F_API setVolume                  (float volume);
+        FMOD_RESULT F_API getVolume                  (float *volume);
+        FMOD_RESULT F_API setPitch                   (float pitch, FMOD_EVENT_PITCHUNITS units = FMOD_EVENT_PITCHUNITS_RAW);
+        FMOD_RESULT F_API getPitch                   (float *pitch, FMOD_EVENT_PITCHUNITS units = FMOD_EVENT_PITCHUNITS_RAW);
+        FMOD_RESULT F_API setPaused                  (bool paused);
+        FMOD_RESULT F_API getPaused                  (bool *paused);
+        FMOD_RESULT F_API setMute                    (bool mute);
+        FMOD_RESULT F_API getMute                    (bool *mute);
+        FMOD_RESULT F_API set3DAttributes            (const FMOD_VECTOR *position, const FMOD_VECTOR *velocity, const FMOD_VECTOR *orientation = 0);
+        FMOD_RESULT F_API get3DAttributes            (FMOD_VECTOR *position, FMOD_VECTOR *velocity, FMOD_VECTOR *orientation = 0);
+        FMOD_RESULT F_API set3DOcclusion             (float directocclusion, float reverbocclusion);
+        FMOD_RESULT F_API get3DOcclusion             (float *directocclusion, float *reverbocclusion);
+        FMOD_RESULT F_API setReverbProperties        (const FMOD_REVERB_CHANNELPROPERTIES *props);
+        FMOD_RESULT F_API getReverbProperties        (FMOD_REVERB_CHANNELPROPERTIES *props);
+        FMOD_RESULT F_API setUserData                (void *userdata);
+        FMOD_RESULT F_API getUserData                (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo              (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+       'EventParameter' API
+    */
+    class EventParameter
+    {
+        public :
+
+        FMOD_RESULT F_API getInfo                    (int *index, char **name);
+        FMOD_RESULT F_API getRange                   (float *rangemin, float *rangemax);
+        FMOD_RESULT F_API setValue                   (float value);
+        FMOD_RESULT F_API getValue                   (float *value);
+        FMOD_RESULT F_API setVelocity                (float value);
+        FMOD_RESULT F_API getVelocity                (float *value);
+        FMOD_RESULT F_API setSeekSpeed               (float value);
+        FMOD_RESULT F_API getSeekSpeed               (float *value);
+        FMOD_RESULT F_API setUserData                (void *userdata);
+        FMOD_RESULT F_API getUserData                (void **userdata);
+        FMOD_RESULT F_API keyOff                     ();
+
+        FMOD_RESULT F_API getMemoryInfo              (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+       'EventReverb ' API
+    */
+    class EventReverb
+    {
+        public :
+
+        virtual FMOD_RESULT F_API release            () = 0;
+        virtual FMOD_RESULT F_API set3DAttributes    (const FMOD_VECTOR *position, float mindistance, float maxdistance) = 0;
+        virtual FMOD_RESULT F_API get3DAttributes    (FMOD_VECTOR *position, float *mindistance,float *maxdistance) = 0;
+        virtual FMOD_RESULT F_API setProperties      (const FMOD_REVERB_PROPERTIES *props) = 0;
+        virtual FMOD_RESULT F_API getProperties      (FMOD_REVERB_PROPERTIES *props) = 0;
+        virtual FMOD_RESULT F_API setActive          (bool active) = 0;
+        virtual FMOD_RESULT F_API getActive          (bool *active) = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventReverb(){};
+    };
+
+    /*
+       'EventQueue' API
+    */
+    class EventQueue
+    {
+        public :
+
+        virtual FMOD_RESULT F_API release            () = 0;
+        virtual FMOD_RESULT F_API add                (EventQueueEntry *entry, bool allow_duplicates = true) = 0;
+        virtual FMOD_RESULT F_API remove             (EventQueueEntry *entry) = 0;
+        virtual FMOD_RESULT F_API removeHead         () = 0;
+        virtual FMOD_RESULT F_API clear              (bool stopallevents = true) = 0;
+        virtual FMOD_RESULT F_API findFirstEntry     (EventQueueEntry **entry) = 0;
+        virtual FMOD_RESULT F_API findNextEntry      (EventQueueEntry **entry) = 0;
+        virtual FMOD_RESULT F_API setPaused          (bool paused) = 0;
+        virtual FMOD_RESULT F_API getPaused          (bool *paused) = 0;
+        virtual FMOD_RESULT F_API includeDuckingCategory (EventCategory *category, float ducked_volume, float unducked_volume, unsigned int duck_time, unsigned int unduck_time) = 0;
+        virtual FMOD_RESULT F_API excludeDuckingCategory (EventCategory *category) = 0;
+        virtual FMOD_RESULT F_API setCallback        (FMOD_EVENTQUEUE_CALLBACK callback, void *callbackuserdata) = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+        virtual FMOD_RESULT F_API dump               () = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventQueue(){};
+    };
+
+    /*
+       'EventQueueEntry' API
+    */
+    class EventQueueEntry
+    {
+        public :
+
+        virtual FMOD_RESULT F_API release            () = 0;
+        virtual FMOD_RESULT F_API getInfoOnlyEvent   (Event **infoonlyevent) = 0;
+        virtual FMOD_RESULT F_API getRealEvent       (Event **realevent) = 0;
+        virtual FMOD_RESULT F_API setPriority        (unsigned char priority) = 0;
+        virtual FMOD_RESULT F_API getPriority        (unsigned char *priority) = 0;
+        virtual FMOD_RESULT F_API setExpiryTime      (unsigned int expirytime) = 0;
+        virtual FMOD_RESULT F_API getExpiryTime      (unsigned int *expirytime) = 0;
+        virtual FMOD_RESULT F_API setDelayTime       (unsigned int delay) = 0;
+        virtual FMOD_RESULT F_API getDelayTime       (unsigned int *delay) = 0;
+        virtual FMOD_RESULT F_API setInterrupt       (bool interrupt) = 0;
+        virtual FMOD_RESULT F_API getInterrupt       (bool *interrupt) = 0;
+        virtual FMOD_RESULT F_API setCrossfadeTime   (int crossfade) = 0;
+        virtual FMOD_RESULT F_API getCrossfadeTime   (int *crossfade) = 0;
+        virtual FMOD_RESULT F_API setUserData        (void *userdata) = 0;
+        virtual FMOD_RESULT F_API getUserData        (void **userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~EventQueueEntry(){};
+    };
+
+    /*
+        'MusicSystem' API
+    */
+    class MusicSystem
+    {
+        public :
+
+        virtual FMOD_RESULT F_API reset              () = 0;
+        virtual FMOD_RESULT F_API setVolume          (float volume) = 0;
+        virtual FMOD_RESULT F_API getVolume          (float *volume) = 0;
+        virtual FMOD_RESULT F_API setReverbProperties(const FMOD_REVERB_CHANNELPROPERTIES *props) = 0;
+        virtual FMOD_RESULT F_API getReverbProperties(FMOD_REVERB_CHANNELPROPERTIES *props) = 0;
+        virtual FMOD_RESULT F_API setPaused          (bool paused) = 0;
+        virtual FMOD_RESULT F_API getPaused          (bool *paused) = 0;
+        virtual FMOD_RESULT F_API setMute            (bool mute) = 0;
+        virtual FMOD_RESULT F_API getMute            (bool *mute) = 0;
+        virtual FMOD_RESULT F_API getInfo            (FMOD_MUSIC_INFO *info) = 0;
+        virtual FMOD_RESULT F_API promptCue          (FMOD_MUSIC_CUE_ID id) = 0;
+        virtual FMOD_RESULT F_API prepareCue         (FMOD_MUSIC_CUE_ID id, MusicPrompt **prompt) = 0;
+        virtual FMOD_RESULT F_API getParameterValue  (FMOD_MUSIC_PARAM_ID id, float *parameter) = 0;
+        virtual FMOD_RESULT F_API setParameterValue  (FMOD_MUSIC_PARAM_ID id, float parameter) = 0;
+
+        virtual FMOD_RESULT F_API getCues            (FMOD_MUSIC_ITERATOR *it, const char *filter = 0) = 0;
+        virtual FMOD_RESULT F_API getNextCue         (FMOD_MUSIC_ITERATOR *it) = 0;
+        virtual FMOD_RESULT F_API getParameters      (FMOD_MUSIC_ITERATOR *it, const char *filter = 0) = 0;
+        virtual FMOD_RESULT F_API getNextParameter   (FMOD_MUSIC_ITERATOR *it) = 0;
+
+        virtual FMOD_RESULT F_API loadSoundData      (FMOD_EVENT_RESOURCE resource = FMOD_EVENT_RESOURCE_SAMPLES, FMOD_EVENT_MODE mode = FMOD_EVENT_DEFAULT) = 0;
+        virtual FMOD_RESULT F_API freeSoundData      (bool waituntilready = true) = 0;
+
+        virtual FMOD_RESULT F_API setCallback        (FMOD_MUSIC_CALLBACK callback, void *userdata) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~MusicSystem(){};
+    };
+
+    /*
+        'MusicPrompt' API
+    */
+    class MusicPrompt
+    {
+        public :
+
+        virtual FMOD_RESULT F_API release            () = 0;
+        virtual FMOD_RESULT F_API begin              () = 0;
+        virtual FMOD_RESULT F_API end                () = 0;
+        virtual FMOD_RESULT F_API isActive           (bool *active) = 0;
+
+        virtual FMOD_RESULT F_API getMemoryInfo      (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details) = 0;
+        virtual ~MusicPrompt(){};
+    };
+}
+
+
+#endif

--- a/src/moaicore/fmoddesignerinc/fmod_event_net.h
+++ b/src/moaicore/fmoddesignerinc/fmod_event_net.h
@@ -1,0 +1,42 @@
+/* ============================================================================================ */
+/* FMOD Ex - Main C/C++ Network event system header file.                                       */
+/* Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.                                   */
+/*                                                                                              */
+/* This header is the base header for all other FMOD NetEventSystem headers. If you are         */
+/* programming in C use this exclusively, or if you are programming C++ use this in             */
+/* conjunction with FMOD_EVENT_NET.HPP                                                          */
+/* ============================================================================================ */
+
+#ifndef __FMOD_EVENT_NET_H__
+#define __FMOD_EVENT_NET_H__
+
+#ifndef __FMOD_EVENT_H__
+#include "fmod_event.h"
+#endif
+
+/*
+    FMOD NetEventSystem version number.  Check this against NetEventSystem_GetVersion.
+    0xaaaabbcc -> aaaa = major version number.  bb = minor version number.  cc = development version number.
+*/
+#define FMOD_EVENT_NET_VERSION 0x00044000
+
+/*
+    Default port that the target (game) will listen on
+*/
+#define FMOD_EVENT_NET_PORT    17997
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+FMOD_RESULT F_API FMOD_NetEventSystem_Init       (FMOD_EVENTSYSTEM *eventsystem, unsigned short port);
+FMOD_RESULT F_API FMOD_NetEventSystem_Update     ();
+FMOD_RESULT F_API FMOD_NetEventSystem_Shutdown   ();
+FMOD_RESULT F_API FMOD_NetEventSystem_GetVersion (unsigned int *version);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/moaicore/fmoddesignerinc/fmod_event_net.hpp
+++ b/src/moaicore/fmoddesignerinc/fmod_event_net.hpp
@@ -1,0 +1,26 @@
+/* ============================================================================================ */
+/* FMOD Ex - Main C/C++ Network event system header file.                                       */
+/* Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.                                   */
+/*                                                                                              */
+/* Use this header to enable network tweaking and auditioning in realtime from FMOD Designer.   */
+/* If you are programming in C use FMOD_EVENT_NET.H                                             */
+/* ============================================================================================ */
+
+#ifndef __FMOD_EVENT_NET_HPP__
+#define __FMOD_EVENT_NET_HPP__
+
+#ifndef __FMOD_EVENT_NET_H__
+#include "fmod_event_net.h"
+#endif
+
+namespace FMOD
+{
+    class EventSystem;
+
+    FMOD_RESULT F_API NetEventSystem_Init       (EventSystem *eventsystem, unsigned short port = FMOD_EVENT_NET_PORT);
+    FMOD_RESULT F_API NetEventSystem_Update     ();
+    FMOD_RESULT F_API NetEventSystem_Shutdown   ();
+    FMOD_RESULT F_API NetEventSystem_GetVersion (unsigned int *version);
+}
+
+#endif

--- a/src/moaicore/fmodinc/fmod.h
+++ b/src/moaicore/fmodinc/fmod.h
@@ -1,0 +1,2439 @@
+
+/* ============================================================================================ */
+/* FMOD Ex - Main C/C++ header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011. */
+/*                                                                                              */
+/* This header is the base header for all other FMOD headers.  If you are programming in C      */
+/* use this exclusively, or if you are programming C++ use this in conjunction with FMOD.HPP    */
+/*                                                                                              */
+/* ============================================================================================ */
+
+#ifndef _FMOD_H
+#define _FMOD_H
+
+/*
+    FMOD version number.  Check this against FMOD::System::getVersion.
+    0xaaaabbcc -> aaaa = major version number.  bb = minor version number.  cc = development version number.
+*/
+
+#define FMOD_VERSION    0x00044000
+
+/*
+    Compiler specific settings.
+*/
+
+#if defined(__CYGWIN32__)
+    #define F_CDECL __cdecl
+    #define F_STDCALL __stdcall
+    #define F_DECLSPEC __declspec
+    #define F_DLLEXPORT ( dllexport )
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(_WIN64)
+    #define F_CDECL _cdecl
+    #define F_STDCALL _stdcall
+    #define F_DECLSPEC __declspec
+    #define F_DLLEXPORT ( dllexport )
+#elif defined(__MACH__) || defined(__ANDROID__) || defined(__linux__)
+    #define F_CDECL
+    #define F_STDCALL
+    #define F_DECLSPEC
+    #define F_DLLEXPORT __attribute__ ((visibility("default")))
+#else
+    #define F_CDECL
+    #define F_STDCALL
+    #define F_DECLSPEC
+    #define F_DLLEXPORT
+#endif
+
+#ifdef DLL_EXPORTS
+    #if defined(__MACH__) || defined(__ANDROID__) || defined(__linux__)
+        #define F_API __attribute__ ((visibility("default")))
+    #else
+        #define F_API __declspec(dllexport) F_STDCALL
+    #endif
+#else
+    #define F_API F_STDCALL
+#endif
+
+#define F_CALLBACK F_STDCALL
+
+/*
+    FMOD types.
+*/
+
+typedef int                       FMOD_BOOL;
+typedef struct FMOD_SYSTEM        FMOD_SYSTEM;
+typedef struct FMOD_SOUND         FMOD_SOUND;
+typedef struct FMOD_CHANNEL       FMOD_CHANNEL;
+typedef struct FMOD_CHANNELGROUP  FMOD_CHANNELGROUP;
+typedef struct FMOD_SOUNDGROUP    FMOD_SOUNDGROUP;
+typedef struct FMOD_REVERB        FMOD_REVERB;
+typedef struct FMOD_DSP           FMOD_DSP;
+typedef struct FMOD_DSPCONNECTION FMOD_DSPCONNECTION;
+typedef struct FMOD_POLYGON		  FMOD_POLYGON;
+typedef struct FMOD_GEOMETRY	  FMOD_GEOMETRY;
+typedef struct FMOD_SYNCPOINT	  FMOD_SYNCPOINT;
+typedef unsigned int              FMOD_MODE;
+typedef unsigned int              FMOD_TIMEUNIT;
+typedef unsigned int              FMOD_INITFLAGS;
+typedef unsigned int              FMOD_CAPS;
+typedef unsigned int              FMOD_DEBUGLEVEL;
+typedef unsigned int              FMOD_MEMORY_TYPE;
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    error codes.  Returned from every function.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+]
+*/
+typedef enum
+{
+    FMOD_OK,                        /* No errors. */
+    FMOD_ERR_ALREADYLOCKED,         /* Tried to call lock a second time before unlock was called. */
+    FMOD_ERR_BADCOMMAND,            /* Tried to call a function on a data type that does not allow this type of functionality (ie calling Sound::lock on a streaming sound). */
+    FMOD_ERR_CDDA_DRIVERS,          /* Neither NTSCSI nor ASPI could be initialised. */
+    FMOD_ERR_CDDA_INIT,             /* An error occurred while initialising the CDDA subsystem. */
+    FMOD_ERR_CDDA_INVALID_DEVICE,   /* Couldn't find the specified device. */
+    FMOD_ERR_CDDA_NOAUDIO,          /* No audio tracks on the specified disc. */
+    FMOD_ERR_CDDA_NODEVICES,        /* No CD/DVD devices were found. */ 
+    FMOD_ERR_CDDA_NODISC,           /* No disc present in the specified drive. */
+    FMOD_ERR_CDDA_READ,             /* A CDDA read error occurred. */
+    FMOD_ERR_CHANNEL_ALLOC,         /* Error trying to allocate a channel. */
+    FMOD_ERR_CHANNEL_STOLEN,        /* The specified channel has been reused to play another sound. */
+    FMOD_ERR_COM,                   /* A Win32 COM related error occured. COM failed to initialize or a QueryInterface failed meaning a Windows codec or driver was not installed properly. */
+    FMOD_ERR_DMA,                   /* DMA Failure.  See debug output for more information. */
+    FMOD_ERR_DSP_CONNECTION,        /* DSP connection error.  Connection possibly caused a cyclic dependancy.  Or tried to connect a tree too many units deep (more than 128). */
+    FMOD_ERR_DSP_FORMAT,            /* DSP Format error.  A DSP unit may have attempted to connect to this network with the wrong format. */
+    FMOD_ERR_DSP_NOTFOUND,          /* DSP connection error.  Couldn't find the DSP unit specified. */
+    FMOD_ERR_DSP_RUNNING,           /* DSP error.  Cannot perform this operation while the network is in the middle of running.  This will most likely happen if a connection or disconnection is attempted in a DSP callback. */
+    FMOD_ERR_DSP_TOOMANYCONNECTIONS,/* DSP connection error.  The unit being connected to or disconnected should only have 1 input or output. */
+    FMOD_ERR_FILE_BAD,              /* Error loading file. */
+    FMOD_ERR_FILE_COULDNOTSEEK,     /* Couldn't perform seek operation.  This is a limitation of the medium (ie netstreams) or the file format. */
+    FMOD_ERR_FILE_DISKEJECTED,      /* Media was ejected while reading. */
+    FMOD_ERR_FILE_EOF,              /* End of file unexpectedly reached while trying to read essential data (truncated data?). */
+    FMOD_ERR_FILE_NOTFOUND,         /* File not found. */
+    FMOD_ERR_FILE_UNWANTED,         /* Unwanted file access occured. */
+    FMOD_ERR_FORMAT,                /* Unsupported file or audio format. */
+    FMOD_ERR_HTTP,                  /* A HTTP error occurred. This is a catch-all for HTTP errors not listed elsewhere. */
+    FMOD_ERR_HTTP_ACCESS,           /* The specified resource requires authentication or is forbidden. */
+    FMOD_ERR_HTTP_PROXY_AUTH,       /* Proxy authentication is required to access the specified resource. */
+    FMOD_ERR_HTTP_SERVER_ERROR,     /* A HTTP server error occurred. */
+    FMOD_ERR_HTTP_TIMEOUT,          /* The HTTP request timed out. */
+    FMOD_ERR_INITIALIZATION,        /* FMOD was not initialized correctly to support this function. */
+    FMOD_ERR_INITIALIZED,           /* Cannot call this command after System::init. */
+    FMOD_ERR_INTERNAL,              /* An error occured that wasn't supposed to.  Contact support. */
+    FMOD_ERR_INVALID_ADDRESS,       /* On Xbox 360, this memory address passed to FMOD must be physical, (ie allocated with XPhysicalAlloc.) */
+    FMOD_ERR_INVALID_FLOAT,         /* Value passed in was a NaN, Inf or denormalized float. */
+    FMOD_ERR_INVALID_HANDLE,        /* An invalid object handle was used. */
+    FMOD_ERR_INVALID_PARAM,         /* An invalid parameter was passed to this function. */
+    FMOD_ERR_INVALID_POSITION,      /* An invalid seek position was passed to this function. */
+    FMOD_ERR_INVALID_SPEAKER,       /* An invalid speaker was passed to this function based on the current speaker mode. */
+    FMOD_ERR_INVALID_SYNCPOINT,     /* The syncpoint did not come from this sound handle. */
+    FMOD_ERR_INVALID_VECTOR,        /* The vectors passed in are not unit length, or perpendicular. */
+    FMOD_ERR_MAXAUDIBLE,            /* Reached maximum audible playback count for this sound's soundgroup. */
+    FMOD_ERR_MEMORY,                /* Not enough memory or resources. */
+    FMOD_ERR_MEMORY_CANTPOINT,      /* Can't use FMOD_OPENMEMORY_POINT on non PCM source data, or non mp3/xma/adpcm data if FMOD_CREATECOMPRESSEDSAMPLE was used. */
+    FMOD_ERR_MEMORY_SRAM,           /* Not enough memory or resources on console sound ram. */
+    FMOD_ERR_NEEDS2D,               /* Tried to call a command on a 3d sound when the command was meant for 2d sound. */
+    FMOD_ERR_NEEDS3D,               /* Tried to call a command on a 2d sound when the command was meant for 3d sound. */
+    FMOD_ERR_NEEDSHARDWARE,         /* Tried to use a feature that requires hardware support.  (ie trying to play a GCADPCM compressed sound in software on Wii). */
+    FMOD_ERR_NEEDSSOFTWARE,         /* Tried to use a feature that requires the software engine.  Software engine has either been turned off, or command was executed on a hardware channel which does not support this feature. */
+    FMOD_ERR_NET_CONNECT,           /* Couldn't connect to the specified host. */
+    FMOD_ERR_NET_SOCKET_ERROR,      /* A socket error occurred.  This is a catch-all for socket-related errors not listed elsewhere. */
+    FMOD_ERR_NET_URL,               /* The specified URL couldn't be resolved. */
+    FMOD_ERR_NET_WOULD_BLOCK,       /* Operation on a non-blocking socket could not complete immediately. */
+    FMOD_ERR_NOTREADY,              /* Operation could not be performed because specified sound/DSP connection is not ready. */
+    FMOD_ERR_OUTPUT_ALLOCATED,      /* Error initializing output device, but more specifically, the output device is already in use and cannot be reused. */
+    FMOD_ERR_OUTPUT_CREATEBUFFER,   /* Error creating hardware sound buffer. */
+    FMOD_ERR_OUTPUT_DRIVERCALL,     /* A call to a standard soundcard driver failed, which could possibly mean a bug in the driver or resources were missing or exhausted. */
+    FMOD_ERR_OUTPUT_ENUMERATION,    /* Error enumerating the available driver list. List may be inconsistent due to a recent device addition or removal. */
+    FMOD_ERR_OUTPUT_FORMAT,         /* Soundcard does not support the minimum features needed for this soundsystem (16bit stereo output). */
+    FMOD_ERR_OUTPUT_INIT,           /* Error initializing output device. */
+    FMOD_ERR_OUTPUT_NOHARDWARE,     /* FMOD_HARDWARE was specified but the sound card does not have the resources necessary to play it. */
+    FMOD_ERR_OUTPUT_NOSOFTWARE,     /* Attempted to create a software sound but no software channels were specified in System::init. */
+    FMOD_ERR_PAN,                   /* Panning only works with mono or stereo sound sources. */
+    FMOD_ERR_PLUGIN,                /* An unspecified error has been returned from a 3rd party plugin. */
+    FMOD_ERR_PLUGIN_INSTANCES,      /* The number of allowed instances of a plugin has been exceeded. */
+    FMOD_ERR_PLUGIN_MISSING,        /* A requested output, dsp unit type or codec was not available. */
+    FMOD_ERR_PLUGIN_RESOURCE,       /* A resource that the plugin requires cannot be found. (ie the DLS file for MIDI playback) */
+    FMOD_ERR_PRELOADED,             /* The specified sound is still in use by the event system, call EventSystem::unloadFSB before trying to release it. */
+    FMOD_ERR_PROGRAMMERSOUND,       /* The specified sound is still in use by the event system, wait for the event which is using it finish with it. */
+    FMOD_ERR_RECORD,                /* An error occured trying to initialize the recording device. */
+    FMOD_ERR_REVERB_INSTANCE,       /* Specified instance in FMOD_REVERB_PROPERTIES couldn't be set. Most likely because it is an invalid instance number or the reverb doesnt exist. */
+    FMOD_ERR_SUBSOUND_ALLOCATED,    /* This subsound is already being used by another sound, you cannot have more than one parent to a sound.  Null out the other parent's entry first. */
+    FMOD_ERR_SUBSOUND_CANTMOVE,     /* Shared subsounds cannot be replaced or moved from their parent stream, such as when the parent stream is an FSB file. */
+    FMOD_ERR_SUBSOUND_MODE,         /* The subsound's mode bits do not match with the parent sound's mode bits.  See documentation for function that it was called with. */
+    FMOD_ERR_SUBSOUNDS,             /* The error occured because the sound referenced contains subsounds when it shouldn't have, or it doesn't contain subsounds when it should have.  The operation may also not be able to be performed on a parent sound, or a parent sound was played without setting up a sentence first. */
+    FMOD_ERR_TAGNOTFOUND,           /* The specified tag could not be found or there are no tags. */
+    FMOD_ERR_TOOMANYCHANNELS,       /* The sound created exceeds the allowable input channel count.  This can be increased using the maxinputchannels parameter in System::setSoftwareFormat. */
+    FMOD_ERR_UNIMPLEMENTED,         /* Something in FMOD hasn't been implemented when it should be! contact support! */
+    FMOD_ERR_UNINITIALIZED,         /* This command failed because System::init or System::setDriver was not called. */
+    FMOD_ERR_UNSUPPORTED,           /* A command issued was not supported by this object.  Possibly a plugin without certain callbacks specified. */
+    FMOD_ERR_UPDATE,                /* An error caused by System::update occured. */
+    FMOD_ERR_VERSION,               /* The version number of this file format is not supported. */
+
+    FMOD_ERR_EVENT_FAILED,          /* An Event failed to be retrieved, most likely due to 'just fail' being specified as the max playbacks behavior. */
+    FMOD_ERR_EVENT_INFOONLY,        /* Can't execute this command on an EVENT_INFOONLY event. */
+    FMOD_ERR_EVENT_INTERNAL,        /* An error occured that wasn't supposed to.  See debug log for reason. */
+    FMOD_ERR_EVENT_MAXSTREAMS,      /* Event failed because 'Max streams' was hit when FMOD_EVENT_INIT_FAIL_ON_MAXSTREAMS was specified. */
+    FMOD_ERR_EVENT_MISMATCH,        /* FSB mismatches the FEV it was compiled with, the stream/sample mode it was meant to be created with was different, or the FEV was built for a different platform. */
+    FMOD_ERR_EVENT_NAMECONFLICT,    /* A category with the same name already exists. */
+    FMOD_ERR_EVENT_NOTFOUND,        /* The requested event, event group, event category or event property could not be found. */
+    FMOD_ERR_EVENT_NEEDSSIMPLE,     /* Tried to call a function on a complex event that's only supported by simple events. */
+    FMOD_ERR_EVENT_GUIDCONFLICT,    /* An event with the same GUID already exists. */
+    FMOD_ERR_EVENT_ALREADY_LOADED,  /* The specified project or bank has already been loaded. Having multiple copies of the same project loaded simultaneously is forbidden. */
+
+    FMOD_ERR_MUSIC_UNINITIALIZED,   /* Music system is not initialized probably because no music data is loaded. */
+    FMOD_ERR_MUSIC_NOTFOUND,        /* The requested music entity could not be found. */
+    FMOD_ERR_MUSIC_NOCALLBACK,      /* The music callback is required, but it has not been set. */
+
+    FMOD_RESULT_FORCEINT = 65536    /* Makes sure this enum is signed 32bit. */
+} FMOD_RESULT;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]   
+    Structure describing a point in 3D space.
+
+    [REMARKS]
+    FMOD uses a left handed co-ordinate system by default.
+    To use a right handed co-ordinate system specify FMOD_INIT_3D_RIGHTHANDED from FMOD_INITFLAGS in System::init.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::set3DListenerAttributes
+    System::get3DListenerAttributes
+    Channel::set3DAttributes
+    Channel::get3DAttributes
+    Channel::set3DCustomRolloff
+    Channel::get3DCustomRolloff
+    Sound::set3DCustomRolloff
+    Sound::get3DCustomRolloff
+    Geometry::addPolygon
+    Geometry::setPolygonVertex
+    Geometry::getPolygonVertex
+    Geometry::setRotation
+    Geometry::getRotation
+    Geometry::setPosition
+    Geometry::getPosition
+    Geometry::setScale
+    Geometry::getScale
+    FMOD_INITFLAGS
+]
+*/
+typedef struct
+{
+	float x;        /* X co-ordinate in 3D space. */
+    float y;        /* Y co-ordinate in 3D space. */
+    float z;        /* Z co-ordinate in 3D space. */
+} FMOD_VECTOR;
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]   
+    Structure describing a globally unique identifier.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::getDriverInfo
+]
+*/
+typedef struct
+{
+    unsigned int   Data1;       /* Specifies the first 8 hexadecimal digits of the GUID */
+    unsigned short Data2;       /* Specifies the first group of 4 hexadecimal digits.   */
+    unsigned short Data3;       /* Specifies the second group of 4 hexadecimal digits.  */
+    unsigned char  Data4[8];    /* Array of 8 bytes. The first 2 bytes contain the third group of 4 hexadecimal digits. The remaining 6 bytes contain the final 12 hexadecimal digits. */
+} FMOD_GUID;
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Structure that is passed into FMOD_FILE_ASYNCREADCALLBACK.  Use the information in this structure to perform
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+    
+    Instructions: write to 'buffer', and 'bytesread' <b>BEFORE</b> setting 'result'.  
+    As soon as result is set, FMOD will asynchronously continue internally using the data provided in this structure.
+    
+    Set 'result' to the result expected from a normal file read callback.
+    If the read was successful, set it to FMOD_OK.
+    If it read some data but hit the end of the file, set it to FMOD_ERR_FILE_EOF.
+    If a bad error occurred, return FMOD_ERR_FILE_BAD
+    If a disk was ejected, return FMOD_ERR_FILE_DISKEJECTED.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_FILE_ASYNCREADCALLBACK
+    FMOD_FILE_ASYNCCANCELCALLBACK
+]
+*/
+typedef struct
+{
+    void           *handle;         /* [r] The file handle that was filled out in the open callback. */
+    unsigned int    offset;         /* [r] Seek position, make sure you read from this file offset. */
+    unsigned int    sizebytes;      /* [r] how many bytes requested for read. */
+    int             priority;       /* [r] 0 = low importance.  100 = extremely important (ie 'must read now or stuttering may occur') */
+
+    void           *buffer;         /* [w] Buffer to read file data into. */
+    unsigned int    bytesread;      /* [w] Fill this in before setting result code to tell FMOD how many bytes were read. */
+    FMOD_RESULT     result;         /* [r/w] Result code, FMOD_OK tells the system it is ready to consume the data.  Set this last!  Default value = FMOD_ERR_NOTREADY. */
+
+    void           *userdata;       /* [r] User data pointer. */
+} FMOD_ASYNCREADINFO;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These output types are used with System::setOutput / System::getOutput, to choose which output method to use.
+  
+    [REMARKS]
+    To pass information to the driver when initializing fmod use the extradriverdata parameter in System::init for the following reasons.
+    - FMOD_OUTPUTTYPE_WAVWRITER - extradriverdata is a pointer to a char * filename that the wav writer will output to.
+    - FMOD_OUTPUTTYPE_WAVWRITER_NRT - extradriverdata is a pointer to a char * filename that the wav writer will output to.
+    - FMOD_OUTPUTTYPE_DSOUND - extradriverdata is a pointer to a HWND so that FMOD can set the focus on the audio for a particular window.
+    - FMOD_OUTPUTTYPE_PS3 - extradriverdata is a pointer to a FMOD_PS3_EXTRADRIVERDATA struct. This can be found in fmodps3.h.
+    - FMOD_OUTPUTTYPE_GC - extradriverdata is a pointer to a FMOD_GC_INFO struct. This can be found in fmodgc.h.
+    - FMOD_OUTPUTTYPE_WII - extradriverdata is a pointer to a FMOD_WII_INFO struct. This can be found in fmodwii.h.
+    - FMOD_OUTPUTTYPE_ALSA - extradriverdata is a pointer to a FMOD_LINUX_EXTRADRIVERDATA struct. This can be found in fmodlinux.h.
+    
+    Currently these are the only FMOD drivers that take extra information.  Other unknown plugins may have different requirements.
+    
+    Note! If FMOD_OUTPUTTYPE_WAVWRITER_NRT or FMOD_OUTPUTTYPE_NOSOUND_NRT are used, and if the System::update function is being called
+    very quickly (ie for a non realtime decode) it may be being called too quickly for the FMOD streamer thread to respond to.  
+    The result will be a skipping/stuttering output in the captured audio.
+    
+    To remedy this, disable the FMOD Ex streamer thread, and use FMOD_INIT_STREAM_FROM_UPDATE to avoid skipping in the output stream,
+    as it will lock the mixer and the streamer together in the same thread.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::setOutput
+    System::getOutput
+    System::setSoftwareFormat
+    System::getSoftwareFormat
+    System::init
+    System::update
+    FMOD_INITFLAGS
+]
+*/
+typedef enum
+{
+    FMOD_OUTPUTTYPE_AUTODETECT,      /* Picks the best output mode for the platform.  This is the default. */
+                                     
+    FMOD_OUTPUTTYPE_UNKNOWN,         /* All             - 3rd party plugin, unknown.  This is for use with System::getOutput only. */
+    FMOD_OUTPUTTYPE_NOSOUND,         /* All             - All calls in this mode succeed but make no sound. */
+    FMOD_OUTPUTTYPE_WAVWRITER,       /* All             - Writes output to fmodoutput.wav by default.  Use the 'extradriverdata' parameter in System::init, by simply passing the filename as a string, to set the wav filename. */
+    FMOD_OUTPUTTYPE_NOSOUND_NRT,     /* All             - Non-realtime version of FMOD_OUTPUTTYPE_NOSOUND.  User can drive mixer with System::update at whatever rate they want. */
+    FMOD_OUTPUTTYPE_WAVWRITER_NRT,   /* All             - Non-realtime version of FMOD_OUTPUTTYPE_WAVWRITER.  User can drive mixer with System::update at whatever rate they want. */
+                                     
+    FMOD_OUTPUTTYPE_DSOUND,          /* Win32/Win64     - DirectSound output.                       (Default on Windows XP and below) */
+    FMOD_OUTPUTTYPE_WINMM,           /* Win32/Win64     - Windows Multimedia output. */
+    FMOD_OUTPUTTYPE_WASAPI,          /* Win32           - Windows Audio Session API.                (Default on Windows Vista and above) */
+    FMOD_OUTPUTTYPE_ASIO,            /* Win32           - Low latency ASIO 2.0 driver. */
+    FMOD_OUTPUTTYPE_OSS,             /* Linux/Linux64   - Open Sound System output.                 (Default on Linux, third preference) */
+    FMOD_OUTPUTTYPE_ALSA,            /* Linux/Linux64   - Advanced Linux Sound Architecture output. (Default on Linux, second preference if available) */
+    FMOD_OUTPUTTYPE_ESD,             /* Linux/Linux64   - Enlightment Sound Daemon output. */
+    FMOD_OUTPUTTYPE_PULSEAUDIO,      /* Linux/Linux64   - PulseAudio output.                        (Default on Linux, first preference if available) */
+    FMOD_OUTPUTTYPE_COREAUDIO,       /* Mac             - Macintosh CoreAudio output.               (Default on Mac) */
+    FMOD_OUTPUTTYPE_XBOX360,         /* Xbox 360        - Native Xbox360 output.                    (Default on Xbox 360) */
+    FMOD_OUTPUTTYPE_PSP,             /* PSP             - Native PSP output.                        (Default on PSP) */
+    FMOD_OUTPUTTYPE_PS3,             /* PS3             - Native PS3 output.                        (Default on PS3) */
+    FMOD_OUTPUTTYPE_NGP,             /* NGP             - Native NGP output.                        (Default on NGP) */
+	FMOD_OUTPUTTYPE_WII,			 /* Wii			    - Native Wii output.                        (Default on Wii) */
+    FMOD_OUTPUTTYPE_3DS,             /* 3DS             - Native 3DS output                         (Default on 3DS) */
+    FMOD_OUTPUTTYPE_AUDIOTRACK,      /* Android         - Java Audio Track output.                  (Default on Android 2.2 and below) */
+    FMOD_OUTPUTTYPE_OPENSL,          /* Android         - OpenSL ES output.                         (Default on Android 2.3 and above) */   
+    FMOD_OUTPUTTYPE_NACL,            /* Native Client   - Native Client output.                     (Default on Native Client) */
+    FMOD_OUTPUTTYPE_WIIU,            /* Wii U           - Native Wii U output.                      (Default on Wii U) */
+
+    FMOD_OUTPUTTYPE_MAX,             /* Maximum number of output types supported. */
+    FMOD_OUTPUTTYPE_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_OUTPUTTYPE;
+
+
+/*
+[DEFINE] 
+[
+    [NAME]
+    FMOD_CAPS
+
+    [DESCRIPTION]   
+    Bit fields to use with System::getDriverCaps to determine the capabilities of a card / output device.
+
+    [REMARKS]
+    It is important to check FMOD_CAPS_HARDWARE_EMULATED on windows machines, to then adjust System::setDSPBufferSize to (1024, 10) to compensate for the higher latency.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::getDriverCaps
+    System::setDSPBufferSize
+]
+*/
+#define FMOD_CAPS_NONE                   0x00000000  /* Device has no special capabilities. */
+#define FMOD_CAPS_HARDWARE               0x00000001  /* Device supports hardware mixing. */
+#define FMOD_CAPS_HARDWARE_EMULATED      0x00000002  /* User has device set to 'Hardware acceleration = off' in control panel, and now extra 200ms latency is incurred. */
+#define FMOD_CAPS_OUTPUT_MULTICHANNEL    0x00000004  /* Device can do multichannel output, ie greater than 2 channels. */
+#define FMOD_CAPS_OUTPUT_FORMAT_PCM8     0x00000008  /* Device can output to 8bit integer PCM. */
+#define FMOD_CAPS_OUTPUT_FORMAT_PCM16    0x00000010  /* Device can output to 16bit integer PCM. */
+#define FMOD_CAPS_OUTPUT_FORMAT_PCM24    0x00000020  /* Device can output to 24bit integer PCM. */
+#define FMOD_CAPS_OUTPUT_FORMAT_PCM32    0x00000040  /* Device can output to 32bit integer PCM. */
+#define FMOD_CAPS_OUTPUT_FORMAT_PCMFLOAT 0x00000080  /* Device can output to 32bit floating point PCM. */
+#define FMOD_CAPS_REVERB_LIMITED         0x00002000  /* Device supports some form of limited hardware reverb, maybe parameterless and only selectable by environment. */
+/* [DEFINE_END] */
+
+/*
+[DEFINE] 
+[
+    [NAME]
+    FMOD_DEBUGLEVEL
+
+    [DESCRIPTION]   
+    Bit fields to use with FMOD::Debug_SetLevel / FMOD::Debug_GetLevel to control the level of tty debug output with logging versions of FMOD (fmodL).
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    Debug_SetLevel 
+    Debug_GetLevel
+]
+*/
+#define FMOD_DEBUG_LEVEL_NONE           0x00000000
+#define FMOD_DEBUG_LEVEL_LOG            0x00000001      /* Will display generic logging messages. */
+#define FMOD_DEBUG_LEVEL_ERROR          0x00000002      /* Will display errors. */
+#define FMOD_DEBUG_LEVEL_WARNING        0x00000004      /* Will display warnings that are not fatal. */
+#define FMOD_DEBUG_LEVEL_HINT           0x00000008      /* Will hint to you if there is something possibly better you could be doing. */
+#define FMOD_DEBUG_LEVEL_ALL            0x000000FF    
+#define FMOD_DEBUG_TYPE_MEMORY          0x00000100      /* Show FMOD memory related logging messages. */
+#define FMOD_DEBUG_TYPE_THREAD          0x00000200      /* Show FMOD thread related logging messages. */
+#define FMOD_DEBUG_TYPE_FILE            0x00000400      /* Show FMOD file system related logging messages. */
+#define FMOD_DEBUG_TYPE_NET             0x00000800      /* Show FMOD network related logging messages. */
+#define FMOD_DEBUG_TYPE_EVENT           0x00001000      /* Show FMOD Event related logging messages. */
+#define FMOD_DEBUG_TYPE_ALL             0x0000FFFF                      
+#define FMOD_DEBUG_DISPLAY_TIMESTAMPS   0x01000000      /* Display the timestamp of the log entry in milliseconds. */
+#define FMOD_DEBUG_DISPLAY_LINENUMBERS  0x02000000      /* Display the FMOD Ex source code line numbers, for debugging purposes. */
+#define FMOD_DEBUG_DISPLAY_COMPRESS     0x04000000      /* If a message is repeated more than 5 times it will stop displaying it and instead display the number of times the message was logged. */
+#define FMOD_DEBUG_DISPLAY_THREAD       0x08000000      /* Display the thread ID of the calling function that caused this log entry to appear. */
+#define FMOD_DEBUG_DISPLAY_ALL          0x0F000000
+#define FMOD_DEBUG_ALL                  0xFFFFFFFF
+/* [DEFINE_END] */
+
+
+/*
+[DEFINE] 
+[
+    [NAME]
+    FMOD_MEMORY_TYPE
+
+    [DESCRIPTION]   
+    Bit fields for memory allocation type being passed into FMOD memory callbacks.
+
+    [REMARKS]
+    Remember this is a bitfield.  You may get more than 1 bit set (ie physical + persistent) so do not simply switch on the types!  You must check each bit individually or clear out the bits that you do not want within the callback.
+    Bits can be excluded if you want during Memory_Initialize so that you never get them.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_MEMORY_ALLOCCALLBACK
+    FMOD_MEMORY_REALLOCCALLBACK
+    FMOD_MEMORY_FREECALLBACK
+    Memory_Initialize
+    
+]
+*/
+#define FMOD_MEMORY_NORMAL             0x00000000       /* Standard memory. */
+#define FMOD_MEMORY_STREAM_FILE        0x00000001       /* Stream file buffer, size controllable with System::setStreamBufferSize. */
+#define FMOD_MEMORY_STREAM_DECODE      0x00000002       /* Stream decode buffer, size controllable with FMOD_CREATESOUNDEXINFO::decodebuffersize. */
+#define FMOD_MEMORY_SAMPLEDATA         0x00000004       /* Sample data buffer.  Raw audio data, usually PCM/MPEG/ADPCM/XMA data. */
+#define FMOD_MEMORY_DSP_OUTPUTBUFFER   0x00000008       /* DSP memory block allocated when more than 1 output exists on a DSP node. */
+#define FMOD_MEMORY_XBOX360_PHYSICAL   0x00100000       /* Requires XPhysicalAlloc / XPhysicalFree. */
+#define FMOD_MEMORY_PERSISTENT         0x00200000       /* Persistent memory. Memory will be freed when System::release is called. */
+#define FMOD_MEMORY_SECONDARY          0x00400000       /* Secondary memory. Allocation should be in secondary memory. For example RSX on the PS3. */
+#define FMOD_MEMORY_ALL                0xFFFFFFFF
+/* [DEFINE_END] */
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These are speaker types defined for use with the System::setSpeakerMode or System::getSpeakerMode command.
+
+    [REMARKS]
+    These are important notes on speaker modes in regards to sounds created with FMOD_SOFTWARE.
+    Note below the phrase 'sound channels' is used.  These are the subchannels inside a sound, they are not related and 
+    have nothing to do with the FMOD class "Channel".
+    For example a mono sound has 1 sound channel, a stereo sound has 2 sound channels, and an AC3 or 6 channel wav file have 6 "sound channels".
+    
+    FMOD_SPEAKERMODE_RAW
+    ---------------------
+    This mode is for output devices that are not specifically mono/stereo/quad/surround/5.1 or 7.1, but are multichannel.
+    Use System::setSoftwareFormat to specify the number of speakers you want to address, otherwise it will default to 2 (stereo).
+    Sound channels map to speakers sequentially, so a mono sound maps to output speaker 0, stereo sound maps to output speaker 0 & 1.
+    The user assumes knowledge of the speaker order.  FMOD_SPEAKER enumerations may not apply, so raw channel indices should be used.
+    Multichannel sounds map input channels to output channels 1:1. 
+    Channel::setPan and Channel::setSpeakerMix do not work.
+    Speaker levels must be manually set with Channel::setSpeakerLevels.
+    
+    FMOD_SPEAKERMODE_MONO
+    ---------------------
+    This mode is for a 1 speaker arrangement.
+    Panning does not work in this speaker mode.
+    Mono, stereo and multichannel sounds have each sound channel played on the one speaker unity.
+    Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    Channel::setSpeakerMix does not work.
+    
+    FMOD_SPEAKERMODE_STEREO
+    -----------------------
+    This mode is for 2 speaker arrangements that have a left and right speaker.
+    - Mono sounds default to an even distribution between left and right.  They can be panned with Channel::setPan.
+    - Stereo sounds default to the middle, or full left in the left speaker and full right in the right speaker.  
+    - They can be cross faded with Channel::setPan.
+    - Multichannel sounds have each sound channel played on each speaker at unity.
+    - Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    - Channel::setSpeakerMix works but only front left and right parameters are used, the rest are ignored.
+    
+    FMOD_SPEAKERMODE_QUAD
+    ------------------------
+    This mode is for 4 speaker arrangements that have a front left, front right, rear left and a rear right speaker.
+    - Mono sounds default to an even distribution between front left and front right.  They can be panned with Channel::setPan.
+    - Stereo sounds default to the left sound channel played on the front left, and the right sound channel played on the front right.
+    - They can be cross faded with Channel::setPan.
+    - Multichannel sounds default to all of their sound channels being played on each speaker in order of input.
+    - Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    - Channel::setSpeakerMix works but side left, side right, center and lfe are ignored.
+    
+    FMOD_SPEAKERMODE_SURROUND
+    ------------------------
+    This mode is for 5 speaker arrangements that have a left/right/center/rear left/rear right.
+    - Mono sounds default to the center speaker.  They can be panned with Channel::setPan.
+    - Stereo sounds default to the left sound channel played on the front left, and the right sound channel played on the front right.  
+    - They can be cross faded with Channel::setPan.
+    - Multichannel sounds default to all of their sound channels being played on each speaker in order of input.  
+    - Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    - Channel::setSpeakerMix works but side left / side right are ignored.
+    
+    FMOD_SPEAKERMODE_5POINT1
+    ------------------------
+    This mode is for 5.1 speaker arrangements that have a left/right/center/rear left/rear right and a subwoofer speaker.
+    - Mono sounds default to the center speaker.  They can be panned with Channel::setPan.
+    - Stereo sounds default to the left sound channel played on the front left, and the right sound channel played on the front right.  
+    - They can be cross faded with Channel::setPan.
+    - Multichannel sounds default to all of their sound channels being played on each speaker in order of input.  
+    - Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    - Channel::setSpeakerMix works but side left / side right are ignored.
+    
+    FMOD_SPEAKERMODE_7POINT1
+    ------------------------
+    This mode is for 7.1 speaker arrangements that have a left/right/center/rear left/rear right/side left/side right 
+    and a subwoofer speaker.
+    - Mono sounds default to the center speaker.  They can be panned with Channel::setPan.
+    - Stereo sounds default to the left sound channel played on the front left, and the right sound channel played on the front right.  
+    - They can be cross faded with Channel::setPan.
+    - Multichannel sounds default to all of their sound channels being played on each speaker in order of input.  
+    - Mix behavior for multichannel sounds can be set with Channel::setSpeakerLevels.
+    - Channel::setSpeakerMix works and every parameter is used to set the balance of a sound in any speaker.
+    
+    FMOD_SPEAKERMODE_SRS5_1_MATRIX
+    ------------------------------------------------------
+    This mode is for mono, stereo, 5.1 and 6.1 speaker arrangements, as it is backwards and forwards compatible with 
+    stereo, but to get a surround effect a SRS 5.1, Prologic or Prologic 2 hardware decoder / amplifier is needed or 
+    a compatible SRS equipped device (e.g., laptop, TV, etc.) or accessory (e.g., headphone).
+    Pan behavior is the same as FMOD_SPEAKERMODE_5POINT1.
+    
+    If this function is called the numoutputchannels setting in System::setSoftwareFormat is overwritten.
+    
+    Output rate must be 44100, 48000 or 96000 for this to work otherwise FMOD_ERR_OUTPUT_INIT will be returned.
+
+    FMOD_SPEAKERMODE_MYEARS
+    ------------------------------------------------------
+    This mode is for headphones.  This will attempt to load a MyEars profile (see myears.net.au) and use it to generate
+    surround sound on headphones using a personalized HRTF algorithm, for realistic 3d sound.
+    Pan behavior is the same as FMOD_SPEAKERMODE_7POINT1.
+    MyEars speaker mode will automatically be set if the speakermode is FMOD_SPEAKERMODE_STEREO and the MyEars profile exists.
+    If this mode is set explicitly, FMOD_INIT_DISABLE_MYEARS_AUTODETECT has no effect.
+    If this mode is set explicitly and the MyEars profile does not exist, FMOD_ERR_OUTPUT_DRIVERCALL will be returned.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::setSpeakerMode
+    System::getSpeakerMode
+    System::getDriverCaps
+    System::setSoftwareFormat
+    Channel::setSpeakerLevels
+]
+*/
+typedef enum
+{
+    FMOD_SPEAKERMODE_RAW,              /* There is no specific speakermode.  Sound channels are mapped in order of input to output.  Use System::setSoftwareFormat to specify speaker count. See remarks for more information. */
+    FMOD_SPEAKERMODE_MONO,             /* The speakers are monaural. */
+    FMOD_SPEAKERMODE_STEREO,           /* The speakers are stereo (DEFAULT). */
+    FMOD_SPEAKERMODE_QUAD,             /* 4 speaker setup.  This includes front left, front right, rear left, rear right.  */
+    FMOD_SPEAKERMODE_SURROUND,         /* 5 speaker setup.  This includes front left, front right, center, rear left, rear right. */
+    FMOD_SPEAKERMODE_5POINT1,          /* 5.1 speaker setup.  This includes front left, front right, center, rear left, rear right and a subwoofer. */
+    FMOD_SPEAKERMODE_7POINT1,          /* 7.1 speaker setup.  This includes front left, front right, center, rear left, rear right, side left, side right and a subwoofer. */
+    
+    FMOD_SPEAKERMODE_SRS5_1_MATRIX,    /* Stereo compatible output, embedded with surround information. SRS 5.1/Prologic/Prologic2 decoders will split the signal into a 5.1 speaker set-up or SRS virtual surround will decode into a 2-speaker/headphone setup.  See remarks about limitations.*/
+    FMOD_SPEAKERMODE_MYEARS,           /* Stereo output, but data is encoded using personalized HRTF algorithms.  See myears.net.au */
+
+    FMOD_SPEAKERMODE_MAX,              /* Maximum number of speaker modes supported. */
+    FMOD_SPEAKERMODE_FORCEINT = 65536  /* Makes sure this enum is signed 32bit. */
+} FMOD_SPEAKERMODE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These are speaker types defined for use with the Channel::setSpeakerLevels command.
+    It can also be used for speaker placement in the System::set3DSpeakerPosition command.
+
+    [REMARKS]
+    If you are using FMOD_SPEAKERMODE_RAW and speaker assignments are meaningless, just cast a raw integer value to this type.
+    For example (FMOD_SPEAKER)7 would use the 7th speaker (also the same as FMOD_SPEAKER_SIDE_RIGHT).
+    Values higher than this can be used if an output system has more than 8 speaker types / output channels.  15 is the current maximum.
+    
+    NOTE: On Playstation 3 in 7.1, the extra 2 speakers are not side left/side right, they are 'surround back left'/'surround back right' which
+    locate the speakers behind the listener instead of to the sides like on PC.  FMOD_SPEAKER_SBL/FMOD_SPEAKER_SBR are provided to make it 
+    clearer what speaker is being addressed on that platform.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_SPEAKERMODE
+    Channel::setSpeakerLevels
+    Channel::getSpeakerLevels
+    System::set3DSpeakerPosition
+    System::get3DSpeakerPosition
+]
+*/
+typedef enum
+{
+    FMOD_SPEAKER_FRONT_LEFT,
+    FMOD_SPEAKER_FRONT_RIGHT,
+    FMOD_SPEAKER_FRONT_CENTER,
+    FMOD_SPEAKER_LOW_FREQUENCY,
+    FMOD_SPEAKER_BACK_LEFT,
+    FMOD_SPEAKER_BACK_RIGHT,
+    FMOD_SPEAKER_SIDE_LEFT,
+    FMOD_SPEAKER_SIDE_RIGHT,
+    
+    FMOD_SPEAKER_MAX,                                       /* Maximum number of speaker types supported. */
+    FMOD_SPEAKER_MONO        = FMOD_SPEAKER_FRONT_LEFT,     /* For use with FMOD_SPEAKERMODE_MONO and Channel::SetSpeakerLevels.  Mapped to same value as FMOD_SPEAKER_FRONT_LEFT. */
+    FMOD_SPEAKER_NULL        = 65535,                       /* A non speaker.  Use this with ASIO mapping to ignore a speaker. */
+    FMOD_SPEAKER_SBL         = FMOD_SPEAKER_SIDE_LEFT,      /* For use with FMOD_SPEAKERMODE_7POINT1 on PS3 where the extra speakers are surround back inside of side speakers. */
+    FMOD_SPEAKER_SBR         = FMOD_SPEAKER_SIDE_RIGHT,     /* For use with FMOD_SPEAKERMODE_7POINT1 on PS3 where the extra speakers are surround back inside of side speakers. */
+    FMOD_SPEAKER_FORCEINT    = 65536                        /* Makes sure this enum is signed 32bit. */
+} FMOD_SPEAKER;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These are plugin types defined for use with the System::getNumPlugins, 
+    System::getPluginInfo and System::unloadPlugin functions.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::getNumPlugins
+    System::getPluginInfo
+    System::unloadPlugin
+]
+*/
+typedef enum
+{
+    FMOD_PLUGINTYPE_OUTPUT,          /* The plugin type is an output module.  FMOD mixed audio will play through one of these devices */
+    FMOD_PLUGINTYPE_CODEC,           /* The plugin type is a file format codec.  FMOD will use these codecs to load file formats for playback. */
+    FMOD_PLUGINTYPE_DSP,             /* The plugin type is a DSP unit.  FMOD will use these plugins as part of its DSP network to apply effects to output or generate sound in realtime. */
+
+    FMOD_PLUGINTYPE_MAX,             /* Maximum number of plugin types supported. */
+    FMOD_PLUGINTYPE_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_PLUGINTYPE;
+
+
+/*
+[DEFINE]
+[
+    [NAME]
+    FMOD_INITFLAGS
+
+    [DESCRIPTION]   
+    Initialization flags.  Use them with System::init in the flags parameter to change various behavior.  
+
+    [REMARKS]
+    Use System::setAdvancedSettings to adjust settings for some of the features that are enabled by these flags.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::init
+    System::update 
+    System::setAdvancedSettings
+    Channel::set3DOcclusion
+]
+*/
+#define FMOD_INIT_NORMAL                     0x00000000 /* All platforms - Initialize normally */
+#define FMOD_INIT_STREAM_FROM_UPDATE         0x00000001 /* All platforms - No stream thread is created internally.  Streams are driven from System::update.  Mainly used with non-realtime outputs. */
+#define FMOD_INIT_3D_RIGHTHANDED             0x00000002 /* All platforms - FMOD will treat +X as right, +Y as up and +Z as backwards (towards you). */
+#define FMOD_INIT_SOFTWARE_DISABLE           0x00000004 /* All platforms - Disable software mixer to save memory.  Anything created with FMOD_SOFTWARE will fail and DSP will not work. */
+#define FMOD_INIT_OCCLUSION_LOWPASS          0x00000008 /* All platforms - All FMOD_SOFTWARE (and FMOD_HARDWARE on 3DS and NGP) with FMOD_3D based voices will add a software lowpass filter effect into the DSP chain which is automatically used when Channel::set3DOcclusion is used or the geometry API. */
+#define FMOD_INIT_HRTF_LOWPASS               0x00000010 /* All platforms - All FMOD_SOFTWARE (and FMOD_HARDWARE on 3DS and NGP) with FMOD_3D based voices will add a software lowpass filter effect into the DSP chain which causes sounds to sound duller when the sound goes behind the listener.  Use System::setAdvancedSettings to adjust cutoff frequency. */
+#define FMOD_INIT_DISTANCE_FILTERING         0x00000200 /* All platforms - All FMOD_SOFTWARE with FMOD_3D based voices will add a software lowpass and highpass filter effect into the DSP chain which will act as a distance-automated bandpass filter. Use System::setAdvancedSettings to adjust the center frequency. */
+#define FMOD_INIT_SOFTWARE_REVERB_LOWMEM     0x00000040 /* All platforms - SFX reverb is run using 22/24khz delay buffers, halving the memory required. */
+#define FMOD_INIT_ENABLE_PROFILE             0x00000020 /* All platforms - Enable TCP/IP based host which allows FMOD Designer or FMOD Profiler to connect to it, and view memory, CPU and the DSP network graph in real-time. */
+#define FMOD_INIT_VOL0_BECOMES_VIRTUAL       0x00000080 /* All platforms - Any sounds that are 0 volume will go virtual and not be processed except for having their positions updated virtually.  Use System::setAdvancedSettings to adjust what volume besides zero to switch to virtual at. */
+#define FMOD_INIT_WASAPI_EXCLUSIVE           0x00000100 /* Win32 Vista only - for WASAPI output - Enable exclusive access to hardware, lower latency at the expense of excluding other applications from accessing the audio hardware. */
+#define FMOD_INIT_PS3_PREFERDTS              0x00800000 /* PS3 only - Prefer DTS over Dolby Digital if both are supported. Note: 8 and 6 channel LPCM is always preferred over both DTS and Dolby Digital. */
+#define FMOD_INIT_PS3_FORCE2CHLPCM           0x01000000 /* PS3 only - Force PS3 system output mode to 2 channel LPCM. */
+#define FMOD_INIT_DISABLEDOLBY               0x00100000 /* Wii / 3DS - Disable Dolby Pro Logic surround. Speakermode will be set to STEREO even if user has selected surround in the system settings. */
+#define FMOD_INIT_SYSTEM_MUSICMUTENOTPAUSE   0x00200000 /* Xbox 360 / PS3 - The "music" channelgroup which by default pauses when custom 360 dashboard / PS3 BGM music is played, can be changed to mute (therefore continues playing) instead of pausing, by using this flag. */
+#define FMOD_INIT_SYNCMIXERWITHUPDATE        0x00400000 /* Win32/Wii/PS3/Xbox/Xbox 360 - FMOD Mixer thread is woken up to do a mix when System::update is called rather than waking periodically on its own timer. */
+#define FMOD_INIT_GEOMETRY_USECLOSEST        0x04000000 /* All platforms - With the geometry engine, only process the closest polygon rather than accumulating all polygons the sound to listener line intersects. */
+#define FMOD_INIT_DISABLE_MYEARS_AUTODETECT  0x08000000 /* Win32 - Disables automatic setting of FMOD_SPEAKERMODE_STEREO to FMOD_SPEAKERMODE_MYEARS if the MyEars profile exists on the PC.  MyEars is HRTF 7.1 downmixing through headphones. */
+/* [DEFINE_END] */
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These definitions describe the type of song being played.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getFormat
+]
+*/
+typedef enum
+{
+    FMOD_SOUND_TYPE_UNKNOWN,         /* 3rd party / unknown plugin format. */
+    FMOD_SOUND_TYPE_AIFF,            /* AIFF. */
+    FMOD_SOUND_TYPE_ASF,             /* Microsoft Advanced Systems Format (ie WMA/ASF/WMV). */
+    FMOD_SOUND_TYPE_AT3,             /* Sony ATRAC 3 format */
+    FMOD_SOUND_TYPE_CDDA,            /* Digital CD audio. */
+    FMOD_SOUND_TYPE_DLS,             /* Sound font / downloadable sound bank. */
+    FMOD_SOUND_TYPE_FLAC,            /* FLAC lossless codec. */
+    FMOD_SOUND_TYPE_FSB,             /* FMOD Sample Bank. */
+    FMOD_SOUND_TYPE_GCADPCM,         /* Nintendo GameCube/Wii ADPCM */
+    FMOD_SOUND_TYPE_IT,              /* Impulse Tracker. */
+    FMOD_SOUND_TYPE_MIDI,            /* MIDI. extracodecdata is a pointer to an FMOD_MIDI_EXTRACODECDATA structure. */
+    FMOD_SOUND_TYPE_MOD,             /* Protracker / Fasttracker MOD. */
+    FMOD_SOUND_TYPE_MPEG,            /* MP2/MP3 MPEG. */
+    FMOD_SOUND_TYPE_OGGVORBIS,       /* Ogg vorbis. */
+    FMOD_SOUND_TYPE_PLAYLIST,        /* Information only from ASX/PLS/M3U/WAX playlists */
+    FMOD_SOUND_TYPE_RAW,             /* Raw PCM data. */
+    FMOD_SOUND_TYPE_S3M,             /* ScreamTracker 3. */
+    FMOD_SOUND_TYPE_SF2,             /* Sound font 2 format. */
+    FMOD_SOUND_TYPE_USER,            /* User created sound. */
+    FMOD_SOUND_TYPE_WAV,             /* Microsoft WAV. */
+    FMOD_SOUND_TYPE_XM,              /* FastTracker 2 XM. */
+    FMOD_SOUND_TYPE_XMA,             /* Xbox360 XMA */
+    FMOD_SOUND_TYPE_VAG,             /* PlayStation Portable ADPCM VAG format. */
+    FMOD_SOUND_TYPE_AUDIOQUEUE,      /* iPhone hardware decoder, supports AAC, ALAC and MP3. extracodecdata is a pointer to an FMOD_AUDIOQUEUE_EXTRACODECDATA structure. */
+    FMOD_SOUND_TYPE_XWMA,            /* Xbox360 XWMA */
+    FMOD_SOUND_TYPE_BCWAV,           /* 3DS BCWAV container format for DSP ADPCM and PCM */
+    FMOD_SOUND_TYPE_AT9,             /* NGP ATRAC 9 format */
+
+    FMOD_SOUND_TYPE_MAX,             /* Maximum number of sound types supported. */
+    FMOD_SOUND_TYPE_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_SOUND_TYPE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These definitions describe the native format of the hardware or software buffer that will be used.
+
+    [REMARKS]
+    This is the format the native hardware or software buffer will be or is created in.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::createSound
+    Sound::getFormat
+]
+*/
+typedef enum
+{
+    FMOD_SOUND_FORMAT_NONE,             /* Unitialized / unknown. */
+    FMOD_SOUND_FORMAT_PCM8,             /* 8bit integer PCM data. */
+    FMOD_SOUND_FORMAT_PCM16,            /* 16bit integer PCM data. */
+    FMOD_SOUND_FORMAT_PCM24,            /* 24bit integer PCM data. */
+    FMOD_SOUND_FORMAT_PCM32,            /* 32bit integer PCM data. */
+    FMOD_SOUND_FORMAT_PCMFLOAT,         /* 32bit floating point PCM data. */
+    FMOD_SOUND_FORMAT_GCADPCM,          /* Compressed Nintendo 3DS/Wii DSP data. */
+    FMOD_SOUND_FORMAT_IMAADPCM,         /* Compressed IMA ADPCM data. */
+    FMOD_SOUND_FORMAT_VAG,              /* Compressed PlayStation Portable ADPCM data. */
+    FMOD_SOUND_FORMAT_HEVAG,            /* Compressed PSVita ADPCM data. */
+    FMOD_SOUND_FORMAT_XMA,              /* Compressed Xbox360 XMA data. */
+    FMOD_SOUND_FORMAT_MPEG,             /* Compressed MPEG layer 2 or 3 data. */
+    FMOD_SOUND_FORMAT_CELT,             /* Compressed CELT data. */
+    FMOD_SOUND_FORMAT_AT9,              /* Compressed PSVita ATRAC9 data. */
+    FMOD_SOUND_FORMAT_XWMA,             /* Compressed Xbox360 xWMA data. */
+
+    FMOD_SOUND_FORMAT_MAX,              /* Maximum number of sound formats supported. */   
+    FMOD_SOUND_FORMAT_FORCEINT = 65536  /* Makes sure this enum is signed 32bit. */
+} FMOD_SOUND_FORMAT;
+
+
+/*
+[DEFINE]
+[
+    [NAME] 
+    FMOD_MODE
+
+    [DESCRIPTION]   
+    Sound description bitfields, bitwise OR them together for loading and describing sounds.
+
+    [REMARKS]
+    By default a sound will open as a static sound that is decompressed fully into memory to PCM. (ie equivalent of FMOD_CREATESAMPLE)
+    To have a sound stream instead, use FMOD_CREATESTREAM, or use the wrapper function System::createStream.
+    Some opening modes (ie FMOD_OPENUSER, FMOD_OPENMEMORY, FMOD_OPENMEMORY_POINT, FMOD_OPENRAW) will need extra information.
+    This can be provided using the FMOD_CREATESOUNDEXINFO structure.
+    
+    Specifying FMOD_OPENMEMORY_POINT will POINT to your memory rather allocating its own sound buffers and duplicating it internally.
+    <b><u>This means you cannot free the memory while FMOD is using it, until after Sound::release is called.</b></u>
+    With FMOD_OPENMEMORY_POINT, for PCM formats, only WAV, FSB, and RAW are supported.  For compressed formats, only those formats supported by FMOD_CREATECOMPRESSEDSAMPLE are supported.
+    With FMOD_OPENMEMORY_POINT and FMOD_OPENRAW or PCM, if using them together, note that you must pad the data on each side by 16 bytes.  This is so fmod can modify the ends of the data for looping/interpolation/mixing purposes.  If a wav file, you will need to insert silence, and then reset loop points to stop the playback from playing that silence.
+    With FMOD_OPENMEMORY_POINT, For Wii/PSP FMOD_HARDWARE supports this flag for the GCADPCM/VAG formats.  On other platforms FMOD_SOFTWARE must be used.
+    
+    <b>Xbox 360 memory</b> On Xbox 360 Specifying FMOD_OPENMEMORY_POINT to a virtual memory address will cause FMOD_ERR_INVALID_ADDRESS
+    to be returned.  Use physical memory only for this functionality.
+    
+    FMOD_LOWMEM is used on a sound if you want to minimize the memory overhead, by having FMOD not allocate memory for certain 
+    features that are not likely to be used in a game environment.  These are :
+    1. Sound::getName functionality is removed.  256 bytes per sound is saved.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::createSound
+    System::createStream
+    Sound::setMode
+    Sound::getMode
+    Channel::setMode
+    Channel::getMode
+    Sound::set3DCustomRolloff
+    Channel::set3DCustomRolloff
+    Sound::getOpenState
+]
+*/
+#define FMOD_DEFAULT                   0x00000000  /* Default for all modes listed below. FMOD_LOOP_OFF, FMOD_2D, FMOD_HARDWARE */
+#define FMOD_LOOP_OFF                  0x00000001  /* For non looping sounds. (DEFAULT).  Overrides FMOD_LOOP_NORMAL / FMOD_LOOP_BIDI. */
+#define FMOD_LOOP_NORMAL               0x00000002  /* For forward looping sounds. */
+#define FMOD_LOOP_BIDI                 0x00000004  /* For bidirectional looping sounds. (only works on software mixed static sounds). */
+#define FMOD_2D                        0x00000008  /* Ignores any 3d processing. (DEFAULT). */
+#define FMOD_3D                        0x00000010  /* Makes the sound positionable in 3D.  Overrides FMOD_2D. */
+#define FMOD_HARDWARE                  0x00000020  /* Attempts to make sounds use hardware acceleration. (DEFAULT).  Note on platforms that don't support FMOD_HARDWARE (only 3DS, PS Vita, PSP, Wii and Wii U support FMOD_HARDWARE), this will be internally treated as FMOD_SOFTWARE. */
+#define FMOD_SOFTWARE                  0x00000040  /* Makes the sound be mixed by the FMOD CPU based software mixer.  Overrides FMOD_HARDWARE.  Use this for FFT, DSP, compressed sample support, 2D multi-speaker support and other software related features. */
+#define FMOD_CREATESTREAM              0x00000080  /* Decompress at runtime, streaming from the source provided (ie from disk).  Overrides FMOD_CREATESAMPLE and FMOD_CREATECOMPRESSEDSAMPLE.  Note a stream can only be played once at a time due to a stream only having 1 stream buffer and file handle.  Open multiple streams to have them play concurrently. */
+#define FMOD_CREATESAMPLE              0x00000100  /* Decompress at loadtime, decompressing or decoding whole file into memory as the target sample format (ie PCM).  Fastest for FMOD_SOFTWARE based playback and most flexible.  */
+#define FMOD_CREATECOMPRESSEDSAMPLE    0x00000200  /* Load MP2, MP3, IMAADPCM or XMA into memory and leave it compressed.  During playback the FMOD software mixer will decode it in realtime as a 'compressed sample'.  Can only be used in combination with FMOD_SOFTWARE.  Overrides FMOD_CREATESAMPLE.  If the sound data is not ADPCM, MPEG or XMA it will behave as if it was created with FMOD_CREATESAMPLE and decode the sound into PCM. */
+#define FMOD_OPENUSER                  0x00000400  /* Opens a user created static sample or stream. Use FMOD_CREATESOUNDEXINFO to specify format and/or read callbacks.  If a user created 'sample' is created with no read callback, the sample will be empty.  Use Sound::lock and Sound::unlock to place sound data into the sound if this is the case. */
+#define FMOD_OPENMEMORY                0x00000800  /* "name_or_data" will be interpreted as a pointer to memory instead of filename for creating sounds.  Use FMOD_CREATESOUNDEXINFO to specify length.  If used with FMOD_CREATESAMPLE or FMOD_CREATECOMPRESSEDSAMPLE, FMOD duplicates the memory into its own buffers.  Your own buffer can be freed after open.  If used with FMOD_CREATESTREAM, FMOD will stream out of the buffer whose pointer you passed in.  In this case, your own buffer should not be freed until you have finished with and released the stream.*/
+#define FMOD_OPENMEMORY_POINT          0x10000000  /* "name_or_data" will be interpreted as a pointer to memory instead of filename for creating sounds.  Use FMOD_CREATESOUNDEXINFO to specify length.  This differs to FMOD_OPENMEMORY in that it uses the memory as is, without duplicating the memory into its own buffers.  For Wii/PSP FMOD_HARDWARE supports this flag for the GCADPCM/VAG formats.  On other platforms FMOD_SOFTWARE must be used, as sound hardware on the other platforms (ie PC) cannot access main ram.  Cannot be freed after open, only after Sound::release.   Will not work if the data is compressed and FMOD_CREATECOMPRESSEDSAMPLE is not used. */
+#define FMOD_OPENRAW                   0x00001000  /* Will ignore file format and treat as raw pcm.  Use FMOD_CREATESOUNDEXINFO to specify format.  Requires at least defaultfrequency, numchannels and format to be specified before it will open.  Must be little endian data. */
+#define FMOD_OPENONLY                  0x00002000  /* Just open the file, dont prebuffer or read.  Good for fast opens for info, or when sound::readData is to be used. */
+#define FMOD_ACCURATETIME              0x00004000  /* For System::createSound - for accurate Sound::getLength/Channel::setPosition on VBR MP3, and MOD/S3M/XM/IT/MIDI files.  Scans file first, so takes longer to open. FMOD_OPENONLY does not affect this. */
+#define FMOD_MPEGSEARCH                0x00008000  /* For corrupted / bad MP3 files.  This will search all the way through the file until it hits a valid MPEG header.  Normally only searches for 4k. */
+#define FMOD_NONBLOCKING               0x00010000  /* For opening sounds and getting streamed subsounds (seeking) asyncronously.  Use Sound::getOpenState to poll the state of the sound as it opens or retrieves the subsound in the background. */
+#define FMOD_UNIQUE                    0x00020000  /* Unique sound, can only be played one at a time */
+#define FMOD_3D_HEADRELATIVE           0x00040000  /* Make the sound's position, velocity and orientation relative to the listener. */
+#define FMOD_3D_WORLDRELATIVE          0x00080000  /* Make the sound's position, velocity and orientation absolute (relative to the world). (DEFAULT) */
+#define FMOD_3D_INVERSEROLLOFF         0x00100000  /* This sound will follow the inverse rolloff model where mindistance = full volume, maxdistance = where sound stops attenuating, and rolloff is fixed according to the global rolloff factor.  (DEFAULT) */
+#define FMOD_3D_LINEARROLLOFF          0x00200000  /* This sound will follow a linear rolloff model where mindistance = full volume, maxdistance = silence.  Rolloffscale is ignored. */
+#define FMOD_3D_LINEARSQUAREROLLOFF    0x00400000  /* This sound will follow a linear-square rolloff model where mindistance = full volume, maxdistance = silence.  Rolloffscale is ignored. */
+#define FMOD_3D_CUSTOMROLLOFF          0x04000000  /* This sound will follow a rolloff model defined by Sound::set3DCustomRolloff / Channel::set3DCustomRolloff.  */
+#define FMOD_3D_IGNOREGEOMETRY         0x40000000  /* Is not affect by geometry occlusion.  If not specified in Sound::setMode, or Channel::setMode, the flag is cleared and it is affected by geometry again. */
+#define FMOD_UNICODE                   0x01000000  /* Filename is double-byte unicode. */
+#define FMOD_IGNORETAGS                0x02000000  /* Skips id3v2/asf/etc tag checks when opening a sound, to reduce seek/read overhead when opening files (helps with CD performance). */
+#define FMOD_LOWMEM                    0x08000000  /* Removes some features from samples to give a lower memory overhead, like Sound::getName.  See remarks. */
+#define FMOD_LOADSECONDARYRAM          0x20000000  /* Load sound into the secondary RAM of supported platform. On PS3, sounds will be loaded into RSX/VRAM. */
+#define FMOD_VIRTUAL_PLAYFROMSTART     0x80000000  /* For sounds that start virtual (due to being quiet or low importance), instead of swapping back to audible, and playing at the correct offset according to time, this flag makes the sound play from the start. */
+
+/* [DEFINE_END] */
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These values describe what state a sound is in after FMOD_NONBLOCKING has been used to open it.
+
+    [REMARKS]
+    With streams, if you are using FMOD_NONBLOCKING, note that if the user calls Sound::getSubSound, a stream will go into FMOD_OPENSTATE_SEEKING state and sound related commands will return FMOD_ERR_NOTREADY.
+    With streams, if you are using FMOD_NONBLOCKING, note that if the user calls Channel::getPosition, a stream will go into FMOD_OPENSTATE_SETPOSITION state and sound related commands will return FMOD_ERR_NOTREADY.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    Sound::getOpenState
+    FMOD_MODE
+]
+*/
+typedef enum
+{
+    FMOD_OPENSTATE_READY = 0,       /* Opened and ready to play. */
+    FMOD_OPENSTATE_LOADING,         /* Initial load in progress. */
+    FMOD_OPENSTATE_ERROR,           /* Failed to open - file not found, out of memory etc.  See return value of Sound::getOpenState for what happened. */
+    FMOD_OPENSTATE_CONNECTING,      /* Connecting to remote host (internet sounds only). */
+    FMOD_OPENSTATE_BUFFERING,       /* Buffering data. */
+    FMOD_OPENSTATE_SEEKING,         /* Seeking to subsound and re-flushing stream buffer. */
+    FMOD_OPENSTATE_PLAYING,         /* Ready and playing, but not possible to release at this time without stalling the main thread. */
+    FMOD_OPENSTATE_SETPOSITION,     /* Seeking within a stream to a different position. */
+
+    FMOD_OPENSTATE_MAX,             /* Maximum number of open state types. */
+    FMOD_OPENSTATE_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_OPENSTATE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These flags are used with SoundGroup::setMaxAudibleBehavior to determine what happens when more sounds 
+    are played than are specified with SoundGroup::setMaxAudible.
+
+    [REMARKS]
+    When using FMOD_SOUNDGROUP_BEHAVIOR_MUTE, SoundGroup::setMuteFadeSpeed can be used to stop a sudden transition.  
+    Instead, the time specified will be used to cross fade between the sounds that go silent and the ones that become audible.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    SoundGroup::setMaxAudibleBehavior
+    SoundGroup::getMaxAudibleBehavior
+    SoundGroup::setMaxAudible
+    SoundGroup::getMaxAudible
+    SoundGroup::setMuteFadeSpeed
+    SoundGroup::getMuteFadeSpeed
+]
+*/
+typedef enum 
+{
+    FMOD_SOUNDGROUP_BEHAVIOR_FAIL,              /* Any sound played that puts the sound count over the SoundGroup::setMaxAudible setting, will simply fail during System::playSound. */
+    FMOD_SOUNDGROUP_BEHAVIOR_MUTE,              /* Any sound played that puts the sound count over the SoundGroup::setMaxAudible setting, will be silent, then if another sound in the group stops the sound that was silent before becomes audible again. */
+    FMOD_SOUNDGROUP_BEHAVIOR_STEALLOWEST,       /* Any sound played that puts the sound count over the SoundGroup::setMaxAudible setting, will steal the quietest / least important sound playing in the group. */
+
+    FMOD_SOUNDGROUP_BEHAVIOR_MAX,               /* Maximum number of open state types. */
+    FMOD_SOUNDGROUP_BEHAVIOR_FORCEINT = 65536   /* Makes sure this enum is signed 32bit. */
+} FMOD_SOUNDGROUP_BEHAVIOR;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These callback types are used with Channel::setCallback.
+
+    [REMARKS]
+    Each callback has commanddata parameters passed as int unique to the type of callback.
+    See reference to FMOD_CHANNEL_CALLBACK to determine what they might mean for each type of callback.
+    
+    <b>Note!</b>  Currently the user must call System::update for these callbacks to trigger!
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Channel::setCallback
+    FMOD_CHANNEL_CALLBACK
+    System::update
+]
+*/
+typedef enum
+{
+    FMOD_CHANNEL_CALLBACKTYPE_END,                  /* Called when a sound ends. */
+    FMOD_CHANNEL_CALLBACKTYPE_VIRTUALVOICE,         /* Called when a voice is swapped out or swapped in. */
+    FMOD_CHANNEL_CALLBACKTYPE_SYNCPOINT,            /* Called when a syncpoint is encountered.  Can be from wav file markers. */
+    FMOD_CHANNEL_CALLBACKTYPE_OCCLUSION,            /* Called when the channel has its geometry occlusion value calculated.  Can be used to clamp or change the value. */
+
+    FMOD_CHANNEL_CALLBACKTYPE_MAX,                  /* Maximum number of callback types supported. */
+    FMOD_CHANNEL_CALLBACKTYPE_FORCEINT = 65536      /* Makes sure this enum is signed 32bit. */
+} FMOD_CHANNEL_CALLBACKTYPE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These callback types are used with System::setCallback.
+
+    [REMARKS]
+    Each callback has commanddata parameters passed as void* unique to the type of callback.
+    See reference to FMOD_SYSTEM_CALLBACK to determine what they might mean for each type of callback.
+    
+    <b>Note!</b> Using FMOD_SYSTEM_CALLBACKTYPE_DEVICELISTCHANGED (on Mac only) requires the application to be running an event loop which will allow external changes to device list to be detected by FMOD.
+    
+    <b>Note!</b> The 'system' object pointer will be null for FMOD_SYSTEM_CALLBACKTYPE_THREADCREATED and FMOD_SYSTEM_CALLBACKTYPE_MEMORYALLOCATIONFAILED callbacks.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::setCallback
+    FMOD_SYSTEM_CALLBACK
+    System::update
+    DSP::addInput
+]
+*/
+typedef enum
+{
+    FMOD_SYSTEM_CALLBACKTYPE_DEVICELISTCHANGED,         /* Called from System::update when the enumerated list of devices has changed. */
+    FMOD_SYSTEM_CALLBACKTYPE_DEVICELOST,                /* Called from System::update when an output device has been lost due to control panel parameter changes and FMOD cannot automatically recover. */
+    FMOD_SYSTEM_CALLBACKTYPE_MEMORYALLOCATIONFAILED,    /* Called directly when a memory allocation fails somewhere in FMOD.  (NOTE - 'system' will be NULL in this callback type.)*/
+    FMOD_SYSTEM_CALLBACKTYPE_THREADCREATED,             /* Called directly when a thread is created. (NOTE - 'system' will be NULL in this callback type.) */
+    FMOD_SYSTEM_CALLBACKTYPE_BADDSPCONNECTION,          /* Called when a bad connection was made with DSP::addInput. Usually called from mixer thread because that is where the connections are made.  */
+    FMOD_SYSTEM_CALLBACKTYPE_BADDSPLEVEL,               /* Called when too many effects were added exceeding the maximum tree depth of 128.  This is most likely caused by accidentally adding too many DSP effects. Usually called from mixer thread because that is where the connections are made.  */
+
+    FMOD_SYSTEM_CALLBACKTYPE_MAX,                       /* Maximum number of callback types supported. */
+    FMOD_SYSTEM_CALLBACKTYPE_FORCEINT = 65536           /* Makes sure this enum is signed 32bit. */
+} FMOD_SYSTEM_CALLBACKTYPE;
+
+
+/* 
+    FMOD Callbacks
+*/
+typedef FMOD_RESULT (F_CALLBACK *FMOD_SYSTEM_CALLBACK)       (FMOD_SYSTEM *system, FMOD_SYSTEM_CALLBACKTYPE type, void *commanddata1, void *commanddata2);
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CHANNEL_CALLBACK)      (FMOD_CHANNEL *channel, FMOD_CHANNEL_CALLBACKTYPE type, void *commanddata1, void *commanddata2);
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_SOUND_NONBLOCKCALLBACK)(FMOD_SOUND *sound, FMOD_RESULT result);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_SOUND_PCMREADCALLBACK)(FMOD_SOUND *sound, void *data, unsigned int datalen);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_SOUND_PCMSETPOSCALLBACK)(FMOD_SOUND *sound, int subsound, unsigned int position, FMOD_TIMEUNIT postype);
+
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_OPENCALLBACK)     (const char *name, int unicode, unsigned int *filesize, void **handle, void **userdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_CLOSECALLBACK)    (void *handle, void *userdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_READCALLBACK)     (void *handle, void *buffer, unsigned int sizebytes, unsigned int *bytesread, void *userdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_SEEKCALLBACK)     (void *handle, unsigned int pos, void *userdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_ASYNCREADCALLBACK)(FMOD_ASYNCREADINFO *info, void *userdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_FILE_ASYNCCANCELCALLBACK)(void *handle, void *userdata);
+
+typedef void *      (F_CALLBACK *FMOD_MEMORY_ALLOCCALLBACK)  (unsigned int size, FMOD_MEMORY_TYPE type, const char *sourcestr);
+typedef void *      (F_CALLBACK *FMOD_MEMORY_REALLOCCALLBACK)(void *ptr, unsigned int size, FMOD_MEMORY_TYPE type, const char *sourcestr);
+typedef void        (F_CALLBACK *FMOD_MEMORY_FREECALLBACK)   (void *ptr, FMOD_MEMORY_TYPE type, const char *sourcestr);
+
+typedef float       (F_CALLBACK *FMOD_3D_ROLLOFFCALLBACK)    (FMOD_CHANNEL *channel, float distance);
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    List of windowing methods used in spectrum analysis to reduce leakage / transient signals intefering with the analysis.
+    This is a problem with analysis of continuous signals that only have a small portion of the signal sample (the fft window size).
+    Windowing the signal with a curve or triangle tapers the sides of the fft window to help alleviate this problem.
+
+    [REMARKS]
+    Cyclic signals such as a sine wave that repeat their cycle in a multiple of the window size do not need windowing.
+    I.e. If the sine wave repeats every 1024, 512, 256 etc samples and the FMOD fft window is 1024, then the signal would not need windowing.
+    Not windowing is the same as FMOD_DSP_FFT_WINDOW_RECT, which is the default.
+    If the cycle of the signal (ie the sine wave) is not a multiple of the window size, it will cause frequency abnormalities, so a different windowing method is needed.
+    
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::getSpectrum
+    Channel::getSpectrum
+]
+*/
+typedef enum
+{
+    FMOD_DSP_FFT_WINDOW_RECT,            /* w[n] = 1.0                                                                                            */
+    FMOD_DSP_FFT_WINDOW_TRIANGLE,        /* w[n] = TRI(2n/N)                                                                                      */
+    FMOD_DSP_FFT_WINDOW_HAMMING,         /* w[n] = 0.54 - (0.46 * COS(n/N) )                                                                      */
+    FMOD_DSP_FFT_WINDOW_HANNING,         /* w[n] = 0.5 *  (1.0  - COS(n/N) )                                                                      */
+    FMOD_DSP_FFT_WINDOW_BLACKMAN,        /* w[n] = 0.42 - (0.5  * COS(n/N) ) + (0.08 * COS(2.0 * n/N) )                                           */
+    FMOD_DSP_FFT_WINDOW_BLACKMANHARRIS,  /* w[n] = 0.35875 - (0.48829 * COS(1.0 * n/N)) + (0.14128 * COS(2.0 * n/N)) - (0.01168 * COS(3.0 * n/N)) */
+    
+    FMOD_DSP_FFT_WINDOW_MAX,             /* Maximum number of FFT window types supported. */
+    FMOD_DSP_FFT_WINDOW_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_DSP_FFT_WINDOW;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    List of interpolation types that the FMOD Ex software mixer supports.  
+
+    [REMARKS]
+    The default resampler type is FMOD_DSP_RESAMPLER_LINEAR.
+    Use System::setSoftwareFormat to tell FMOD the resampling quality you require for FMOD_SOFTWARE based sounds.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    System::setSoftwareFormat
+    System::getSoftwareFormat
+]
+*/
+typedef enum
+{
+    FMOD_DSP_RESAMPLER_NOINTERP,        /* No interpolation.  High frequency aliasing hiss will be audible depending on the sample rate of the sound. */
+    FMOD_DSP_RESAMPLER_LINEAR,          /* Linear interpolation (default method).  Fast and good quality, causes very slight lowpass effect on low frequency sounds. */
+    FMOD_DSP_RESAMPLER_CUBIC,           /* Cubic interpolation.  Slower than linear interpolation but better quality. */
+    FMOD_DSP_RESAMPLER_SPLINE,          /* 5 point spline interpolation.  Slowest resampling method but best quality. */
+
+    FMOD_DSP_RESAMPLER_MAX,             /* Maximum number of resample methods supported. */
+    FMOD_DSP_RESAMPLER_FORCEINT = 65536 /* Makes sure this enum is signed 32bit. */
+} FMOD_DSP_RESAMPLER;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    List of tag types that could be stored within a sound.  These include id3 tags, metadata from netstreams and vorbis/asf data.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getTag
+]
+*/
+typedef enum
+{
+    FMOD_TAGTYPE_UNKNOWN = 0,
+    FMOD_TAGTYPE_ID3V1,
+    FMOD_TAGTYPE_ID3V2,
+    FMOD_TAGTYPE_VORBISCOMMENT,
+    FMOD_TAGTYPE_SHOUTCAST,
+    FMOD_TAGTYPE_ICECAST,
+    FMOD_TAGTYPE_ASF,
+    FMOD_TAGTYPE_MIDI,
+    FMOD_TAGTYPE_PLAYLIST,
+    FMOD_TAGTYPE_FMOD,
+    FMOD_TAGTYPE_USER,
+
+    FMOD_TAGTYPE_MAX,               /* Maximum number of tag types supported. */
+    FMOD_TAGTYPE_FORCEINT = 65536   /* Makes sure this enum is signed 32bit. */
+} FMOD_TAGTYPE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    List of data types that can be returned by Sound::getTag
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getTag
+]
+*/
+typedef enum
+{
+    FMOD_TAGDATATYPE_BINARY = 0,
+    FMOD_TAGDATATYPE_INT,
+    FMOD_TAGDATATYPE_FLOAT,
+    FMOD_TAGDATATYPE_STRING,
+    FMOD_TAGDATATYPE_STRING_UTF16,
+    FMOD_TAGDATATYPE_STRING_UTF16BE,
+    FMOD_TAGDATATYPE_STRING_UTF8,
+    FMOD_TAGDATATYPE_CDTOC,
+
+    FMOD_TAGDATATYPE_MAX,               /* Maximum number of tag datatypes supported. */
+    FMOD_TAGDATATYPE_FORCEINT = 65536   /* Makes sure this enum is signed 32bit. */
+} FMOD_TAGDATATYPE;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    Types of delay that can be used with Channel::setDelay / Channel::getDelay.
+
+    [REMARKS]
+    If you haven't called Channel::setDelay yet, if you call Channel::getDelay with FMOD_DELAYTYPE_DSPCLOCK_START it will return the 
+    equivalent global DSP clock value to determine when a channel started, so that you can use it for other channels to sync against.
+    
+    Use System::getDSPClock to also get the current dspclock time, a base for future calls to Channel::setDelay.
+    
+    Use FMOD_64BIT_ADD or FMOD_64BIT_SUB to add a hi/lo combination together and cope with wraparound.
+    
+    If FMOD_DELAYTYPE_END_MS is specified, the value is not treated as a 64 bit number, just the delayhi value is used and it is treated as milliseconds.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Channel::setDelay
+    Channel::getDelay
+    System::getDSPClock
+]
+*/
+typedef enum
+{
+    FMOD_DELAYTYPE_END_MS,              /* Delay at the end of the sound in milliseconds.  Use delayhi only.   Channel::isPlaying will remain true until this delay has passed even though the sound itself has stopped playing.*/
+    FMOD_DELAYTYPE_DSPCLOCK_START,      /* Time the sound started if Channel::getDelay is used, or if Channel::setDelay is used, the sound will delay playing until this exact tick. */
+    FMOD_DELAYTYPE_DSPCLOCK_END,        /* Time the sound should end. If this is non-zero, the channel will go silent at this exact tick. */
+    FMOD_DELAYTYPE_DSPCLOCK_PAUSE,      /* Time the sound should pause. If this is non-zero, the channel will pause at this exact tick. */
+
+    FMOD_DELAYTYPE_MAX,                 /* Maximum number of tag datatypes supported. */
+    FMOD_DELAYTYPE_FORCEINT = 65536     /* Makes sure this enum is signed 32bit. */
+} FMOD_DELAYTYPE;
+
+
+#define FMOD_64BIT_ADD(_hi1, _lo1, _hi2, _lo2) _hi1 += ((_hi2) + ((((_lo1) + (_lo2)) < (_lo1)) ? 1 : 0)); (_lo1) += (_lo2);
+#define FMOD_64BIT_SUB(_hi1, _lo1, _hi2, _lo2) _hi1 -= ((_hi2) + ((((_lo1) - (_lo2)) > (_lo1)) ? 1 : 0)); (_lo1) -= (_lo2);
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]   
+    Structure describing a piece of tag data.
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getTag
+    FMOD_TAGTYPE
+    FMOD_TAGDATATYPE
+]
+*/
+typedef struct FMOD_TAG
+{
+    FMOD_TAGTYPE      type;         /* [r] The type of this tag. */
+    FMOD_TAGDATATYPE  datatype;     /* [r] The type of data that this tag contains */
+    char             *name;         /* [r] The name of this tag i.e. "TITLE", "ARTIST" etc. */
+    void             *data;         /* [r] Pointer to the tag data - its format is determined by the datatype member */
+    unsigned int      datalen;      /* [r] Length of the data contained in this tag */
+    FMOD_BOOL         updated;      /* [r] True if this tag has been updated since last being accessed with Sound::getTag */
+} FMOD_TAG;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]   
+    Structure describing a CD/DVD table of contents
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getTag
+]
+*/
+typedef struct FMOD_CDTOC
+{
+    int numtracks;                  /* [r] The number of tracks on the CD */
+    int min[100];                   /* [r] The start offset of each track in minutes */
+    int sec[100];                   /* [r] The start offset of each track in seconds */
+    int frame[100];                 /* [r] The start offset of each track in frames */
+} FMOD_CDTOC;
+
+
+/*
+[DEFINE]
+[
+    [NAME]
+    FMOD_TIMEUNIT
+
+    [DESCRIPTION]   
+    List of time types that can be returned by Sound::getLength and used with Channel::setPosition or Channel::getPosition.
+
+    [REMARKS]
+    FMOD_TIMEUNIT_SENTENCE_MS, FMOD_TIMEUNIT_SENTENCE_PCM, FMOD_TIMEUNIT_SENTENCE_PCMBYTES, FMOD_TIMEUNIT_SENTENCE and FMOD_TIMEUNIT_SENTENCE_SUBSOUND are only supported by Channel functions.
+    Do not combine flags except FMOD_TIMEUNIT_BUFFERED.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    Sound::getLength
+    Channel::setPosition
+    Channel::getPosition
+]
+*/
+#define FMOD_TIMEUNIT_MS                0x00000001  /* Milliseconds. */
+#define FMOD_TIMEUNIT_PCM               0x00000002  /* PCM samples, related to milliseconds * samplerate / 1000. */
+#define FMOD_TIMEUNIT_PCMBYTES          0x00000004  /* Bytes, related to PCM samples * channels * datawidth (ie 16bit = 2 bytes). */
+#define FMOD_TIMEUNIT_RAWBYTES          0x00000008  /* Raw file bytes of (compressed) sound data (does not include headers).  Only used by Sound::getLength and Channel::getPosition. */
+#define FMOD_TIMEUNIT_PCMFRACTION       0x00000010  /* Fractions of 1 PCM sample.  Unsigned int range 0 to 0xFFFFFFFF.  Used for sub-sample granularity for DSP purposes. */
+#define FMOD_TIMEUNIT_MODORDER          0x00000100  /* MOD/S3M/XM/IT.  Order in a sequenced module format.  Use Sound::getFormat to determine the PCM format being decoded to. */
+#define FMOD_TIMEUNIT_MODROW            0x00000200  /* MOD/S3M/XM/IT.  Current row in a sequenced module format.  Sound::getLength will return the number of rows in the currently playing or seeked to pattern. */
+#define FMOD_TIMEUNIT_MODPATTERN        0x00000400  /* MOD/S3M/XM/IT.  Current pattern in a sequenced module format.  Sound::getLength will return the number of patterns in the song and Channel::getPosition will return the currently playing pattern. */
+#define FMOD_TIMEUNIT_SENTENCE_MS       0x00010000  /* Currently playing subsound in a sentence time in milliseconds. */
+#define FMOD_TIMEUNIT_SENTENCE_PCM      0x00020000  /* Currently playing subsound in a sentence time in PCM Samples, related to milliseconds * samplerate / 1000. */
+#define FMOD_TIMEUNIT_SENTENCE_PCMBYTES 0x00040000  /* Currently playing subsound in a sentence time in bytes, related to PCM samples * channels * datawidth (ie 16bit = 2 bytes). */
+#define FMOD_TIMEUNIT_SENTENCE          0x00080000  /* Currently playing sentence index according to the channel. */
+#define FMOD_TIMEUNIT_SENTENCE_SUBSOUND 0x00100000  /* Currently playing subsound index in a sentence. */
+#define FMOD_TIMEUNIT_BUFFERED          0x10000000  /* Time value as seen by buffered stream.  This is always ahead of audible time, and is only used for processing. */
+/* [DEFINE_END] */
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]
+    When creating a multichannel sound, FMOD will pan them to their default speaker locations, for example a 6 channel sound will default to one channel per 5.1 output speaker.
+    Another example is a stereo sound.  It will default to left = front left, right = front right.
+    
+    This is for sounds that are not 'default'.  For example you might have a sound that is 6 channels but actually made up of 3 stereo pairs, that should all be located in front left, front right only.
+
+    [REMARKS]
+    For full flexibility of speaker assignments, use Channel::setSpeakerLevels.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_CREATESOUNDEXINFO
+    Channel::setSpeakerLevels
+]
+*/
+typedef enum
+{
+    FMOD_SPEAKERMAPTYPE_DEFAULT,     /* This is the default, and just means FMOD decides which speakers it puts the source channels. */
+    FMOD_SPEAKERMAPTYPE_ALLMONO,     /* This means the sound is made up of all mono sounds.  All voices will be panned to the front center by default in this case.  */
+    FMOD_SPEAKERMAPTYPE_ALLSTEREO,   /* This means the sound is made up of all stereo sounds.  All voices will be panned to front left and front right alternating every second channel.  */
+    FMOD_SPEAKERMAPTYPE_51_PROTOOLS  /* Map a 5.1 sound to use protools L C R Ls Rs LFE mapping.  Will return an error if not a 6 channel sound. */
+} FMOD_SPEAKERMAPTYPE;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Use this structure with System::createSound when more control is needed over loading.
+    The possible reasons to use this with System::createSound are:
+    - Loading a file from memory.
+    - Loading a file from within another larger (possibly wad/pak) file, by giving the loader an offset and length.
+    - To create a user created / non file based sound.
+    - To specify a starting subsound to seek to within a multi-sample sounds (ie FSB/DLS/SF2) when created as a stream.
+    - To specify which subsounds to load for multi-sample sounds (ie FSB/DLS/SF2) so that memory is saved and only a subset is actually loaded/read from disk.
+    - To specify 'piggyback' read and seek callbacks for capture of sound data as fmod reads and decodes it.  Useful for ripping decoded PCM data from sounds as they are loaded / played.
+    - To specify a MIDI DLS/SF2 sample set file to load when opening a MIDI file.
+    See below on what members to fill for each of the above types of sound you want to create.
+
+    [REMARKS]
+    This structure is optional!  Specify 0 or NULL in System::createSound if you don't need it!
+    
+    <u>Loading a file from memory.</u>
+    - Create the sound using the FMOD_OPENMEMORY flag.
+    - Mandatory.  Specify 'length' for the size of the memory block in bytes.
+    - Other flags are optional.
+    
+    
+    <u>Loading a file from within another larger (possibly wad/pak) file, by giving the loader an offset and length.</u>
+    - Mandatory.  Specify 'fileoffset' and 'length'.
+    - Other flags are optional.
+    
+    
+    <u>To create a user created / non file based sound.</u>
+    - Create the sound using the FMOD_OPENUSER flag.
+    - Mandatory.  Specify 'defaultfrequency, 'numchannels' and 'format'.
+    - Other flags are optional.
+    
+    
+    <u>To specify a starting subsound to seek to and flush with, within a multi-sample stream (ie FSB/DLS/SF2).</u>
+    
+    - Mandatory.  Specify 'initialsubsound'.
+    
+    
+    <u>To specify which subsounds to load for multi-sample sounds (ie FSB/DLS/SF2) so that memory is saved and only a subset is actually loaded/read from disk.</u>
+    
+    - Mandatory.  Specify 'inclusionlist' and 'inclusionlistnum'.
+    
+    
+    <u>To specify 'piggyback' read and seek callbacks for capture of sound data as fmod reads and decodes it.  Useful for ripping decoded PCM data from sounds as they are loaded / played.</u>
+    
+    - Mandatory.  Specify 'pcmreadcallback' and 'pcmseekcallback'.
+    
+    
+    <u>To specify a MIDI DLS/SF2 sample set file to load when opening a MIDI file.</u>
+    
+    - Mandatory.  Specify 'dlsname'.
+    
+    
+    Setting the 'decodebuffersize' is for cpu intensive codecs that may be causing stuttering, not file intensive codecs (ie those from CD or netstreams) which are normally 
+    altered with System::setStreamBufferSize.  As an example of cpu intensive codecs, an mp3 file will take more cpu to decode than a PCM wav file.
+    If you have a stuttering effect, then it is using more cpu than the decode buffer playback rate can keep up with.  Increasing the decode buffersize will most likely solve this problem.
+    
+    
+    FSB codec.  If inclusionlist and numsubsounds are used together, this will trigger a special mode where subsounds are shuffled down to save memory.  (useful for large FSB 
+    files where you only want to load 1 sound).  There will be no gaps, ie no null subsounds.  As an example, if there are 10,000 subsounds and there is an inclusionlist with only 1 entry, 
+    and numsubsounds = 1, then subsound 0 will be that entry, and there will only be the memory allocated for 1 subsound.  Previously there would still be 10,000 subsound pointers and other
+    associated codec entries allocated along with it multiplied by 10,000.
+    
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::createSound
+    System::setStreamBufferSize
+    FMOD_MODE
+    FMOD_SOUND_FORMAT
+    FMOD_SOUND_TYPE
+    FMOD_SPEAKERMAPTYPE
+]
+*/
+typedef struct FMOD_CREATESOUNDEXINFO
+{
+    int                            cbsize;             /* [w] Size of this structure.  This is used so the structure can be expanded in the future and still work on older versions of FMOD Ex. */
+    unsigned int                   length;             /* [w] Optional. Specify 0 to ignore. Size in bytes of file to load, or sound to create (in this case only if FMOD_OPENUSER is used).  Required if loading from memory.  If 0 is specified, then it will use the size of the file (unless loading from memory then an error will be returned). */
+    unsigned int                   fileoffset;         /* [w] Optional. Specify 0 to ignore. Offset from start of the file to start loading from.  This is useful for loading files from inside big data files. */
+    int                            numchannels;        /* [w] Optional. Specify 0 to ignore. Number of channels in a sound mandatory if FMOD_OPENUSER or FMOD_OPENRAW is used. */
+    int                            defaultfrequency;   /* [w] Optional. Specify 0 to ignore. Default frequency of sound in a sound mandatory if FMOD_OPENUSER or FMOD_OPENRAW is used.  Other formats use the frequency determined by the file format. */
+    FMOD_SOUND_FORMAT              format;             /* [w] Optional. Specify 0 or FMOD_SOUND_FORMAT_NONE to ignore. Format of the sound mandatory if FMOD_OPENUSER or FMOD_OPENRAW is used.  Other formats use the format determined by the file format.   */
+    unsigned int                   decodebuffersize;   /* [w] Optional. Specify 0 to ignore. For streams.  This determines the size of the double buffer (in PCM samples) that a stream uses.  Use this for user created streams if you want to determine the size of the callback buffer passed to you.  Specify 0 to use FMOD's default size which is currently equivalent to 400ms of the sound format created/loaded. */
+    int                            initialsubsound;    /* [w] Optional. Specify 0 to ignore. In a multi-sample file format such as .FSB/.DLS/.SF2, specify the initial subsound to seek to, only if FMOD_CREATESTREAM is used. */
+    int                            numsubsounds;       /* [w] Optional. Specify 0 to ignore or have no subsounds.  In a sound created with FMOD_OPENUSER, specify the number of subsounds that are accessable with Sound::getSubSound.  If not created with FMOD_OPENUSER, this will limit the number of subsounds loaded within a multi-subsound file.  If using FSB, then if FMOD_CREATESOUNDEXINFO::inclusionlist is used, this will shuffle subsounds down so that there are not any gaps.  It will mean that the indices of the sounds will be different. */
+    int                           *inclusionlist;      /* [w] Optional. Specify 0 to ignore. In a multi-sample format such as .FSB/.DLS/.SF2 it may be desirable to specify only a subset of sounds to be loaded out of the whole file.  This is an array of subsound indices to load into memory when created. */
+    int                            inclusionlistnum;   /* [w] Optional. Specify 0 to ignore. This is the number of integers contained within the inclusionlist array. */
+    FMOD_SOUND_PCMREADCALLBACK     pcmreadcallback;    /* [w] Optional. Specify 0 to ignore. Callback to 'piggyback' on FMOD's read functions and accept or even write PCM data while FMOD is opening the sound.  Used for user sounds created with FMOD_OPENUSER or for capturing decoded data as FMOD reads it. */
+    FMOD_SOUND_PCMSETPOSCALLBACK   pcmsetposcallback;  /* [w] Optional. Specify 0 to ignore. Callback for when the user calls a seeking function such as Channel::setTime or Channel::setPosition within a multi-sample sound, and for when it is opened.*/
+    FMOD_SOUND_NONBLOCKCALLBACK    nonblockcallback;   /* [w] Optional. Specify 0 to ignore. Callback for successful completion, or error while loading a sound that used the FMOD_NONBLOCKING flag.*/
+    const char                    *dlsname;            /* [w] Optional. Specify 0 to ignore. Filename for a DLS or SF2 sample set when loading a MIDI file. If not specified, on Windows it will attempt to open /windows/system32/drivers/gm.dls or /windows/system32/drivers/etc/gm.dls, on Mac it will attempt to load /System/Library/Components/CoreAudio.component/Contents/Resources/gs_instruments.dls, otherwise the MIDI will fail to open. Current DLS support is for level 1 of the specification. */
+    const char                    *encryptionkey;      /* [w] Optional. Specify 0 to ignore. Key for encrypted FSB file.  Without this key an encrypted FSB file will not load. */
+    int                            maxpolyphony;       /* [w] Optional. Specify 0 to ignore. For sequenced formats with dynamic channel allocation such as .MID and .IT, this specifies the maximum voice count allowed while playing.  .IT defaults to 64.  .MID defaults to 32. */
+    void                          *userdata;           /* [w] Optional. Specify 0 to ignore. This is user data to be attached to the sound during creation.  Access via Sound::getUserData.  Note: This is not passed to FMOD_FILE_OPENCALLBACK, that is a different userdata that is file specific. */
+    FMOD_SOUND_TYPE                suggestedsoundtype; /* [w] Optional. Specify 0 or FMOD_SOUND_TYPE_UNKNOWN to ignore.  Instead of scanning all codec types, use this to speed up loading by making it jump straight to this codec. */
+    FMOD_FILE_OPENCALLBACK         useropen;           /* [w] Optional. Specify 0 to ignore. Callback for opening this file. */
+    FMOD_FILE_CLOSECALLBACK        userclose;          /* [w] Optional. Specify 0 to ignore. Callback for closing this file. */
+    FMOD_FILE_READCALLBACK         userread;           /* [w] Optional. Specify 0 to ignore. Callback for reading from this file. */
+    FMOD_FILE_SEEKCALLBACK         userseek;           /* [w] Optional. Specify 0 to ignore. Callback for seeking within this file. */
+    FMOD_FILE_ASYNCREADCALLBACK    userasyncread;      /* [w] Optional. Specify 0 to ignore. Callback for seeking within this file. */
+    FMOD_FILE_ASYNCCANCELCALLBACK  userasynccancel;    /* [w] Optional. Specify 0 to ignore. Callback for seeking within this file. */
+    FMOD_SPEAKERMAPTYPE            speakermap;         /* [w] Optional. Specify 0 to ignore. Use this to differ the way fmod maps multichannel sounds to speakers.  See FMOD_SPEAKERMAPTYPE for more. */
+    FMOD_SOUNDGROUP               *initialsoundgroup;  /* [w] Optional. Specify 0 to ignore. Specify a sound group if required, to put sound in as it is created. */
+    unsigned int                   initialseekposition;/* [w] Optional. Specify 0 to ignore. For streams. Specify an initial position to seek the stream to. */
+    FMOD_TIMEUNIT                  initialseekpostype; /* [w] Optional. Specify 0 to ignore. For streams. Specify the time unit for the position set in initialseekposition. */
+    int                            ignoresetfilesystem;/* [w] Optional. Specify 0 to ignore. Set to 1 to use fmod's built in file system. Ignores setFileSystem callbacks and also FMOD_CREATESOUNEXINFO file callbacks.  Useful for specific cases where you don't want to use your own file system but want to use fmod's file system (ie net streaming). */
+    int                            cddaforceaspi;      /* [w] Optional. Specify 0 to ignore. For CDDA sounds only - if non-zero use ASPI instead of NTSCSI to access the specified CD/DVD device. */
+    unsigned int                   audioqueuepolicy;   /* [w] Optional. Specify 0 or FMOD_AUDIOQUEUE_CODECPOLICY_DEFAULT to ignore. Policy used to determine whether hardware or software is used for decoding, see FMOD_AUDIOQUEUE_CODECPOLICY for options (iOS >= 3.0 required, otherwise only hardware is available) */ 
+    unsigned int                   minmidigranularity; /* [w] Optional. Specify 0 to ignore. Allows you to set a minimum desired MIDI mixer granularity. Values smaller than 512 give greater than default accuracy at the cost of more CPU and vice versa. Specify 0 for default (512 samples). */
+    int                            nonblockthreadid;   /* [w] Optional. Specify 0 to ignore. Specifies a thread index to execute non blocking load on.  Allows for up to 5 threads to be used for loading at once.  This is to avoid one load blocking another.  Maximum value = 4. */
+} FMOD_CREATESOUNDEXINFO;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Structure defining a reverb environment.
+
+    [REMARKS]
+    Note the default reverb properties are the same as the FMOD_PRESET_GENERIC preset.
+    Note that integer values that typically range from -10,000 to 1000 are represented in 
+    decibels, and are of a logarithmic scale, not linear, wheras float values are always linear.
+    
+    The numerical values listed below are the maximum, minimum and default values for each variable respectively.
+    
+    <b>SUPPORTED</b> next to each parameter means the platform the parameter can be set on.  Some platforms support all parameters and some don't.
+    WII   means Nintendo Wii hardware reverb (must use FMOD_HARDWARE).
+    PSP   means Playstation Portable hardware reverb (must use FMOD_HARDWARE).
+    SFX   means FMOD SFX software reverb.  This works on any platform that uses FMOD_SOFTWARE for loading sounds.
+    ---   means unsupported/deprecated.  Will either be removed or supported by SFX in the future.
+    
+    Nintendo Wii Notes:
+    This structure supports only limited parameters, and maps them to the Wii hardware reverb as follows.
+    DecayTime = 'time'
+    ReverbDelay = 'predelay'
+    ModulationDepth = 'damping'
+    Reflections = 'coloration'
+    EnvDiffusion = 'crosstalk'
+    Room = 'mix'
+    
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+    Members marked with [r/w] are either read or write depending on if you are using System::setReverbProperties (w) or System::getReverbProperties (r).
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::setReverbProperties
+    System::getReverbProperties
+    FMOD_REVERB_PRESETS
+    FMOD_REVERB_FLAGS
+]
+*/
+typedef struct FMOD_REVERB_PROPERTIES
+{                                   /*       MIN    MAX     DEFAULT DESCRIPTION */
+    int          Instance;          /* [w]   0      3       0       Environment Instance.                                                 (SUPPORTED:SFX(4 instances) and Wii (3 instances)) */
+    int          Environment;       /* [r/w] -1     25      -1      Sets all listener properties.  -1 = OFF.                              (SUPPORTED:SFX(-1 only)/PSP) */
+    float        EnvDiffusion;      /* [r/w] 0.0    1.0     1.0     Environment diffusion                                                 (SUPPORTED:WII) */
+    int          Room;              /* [r/w] -10000 0       -1000   Room effect level (at mid frequencies)                                (SUPPORTED:SFX/WII/PSP) */
+    int          RoomHF;            /* [r/w] -10000 0       -100    Relative room effect level at high frequencies                        (SUPPORTED:SFX) */
+    int          RoomLF;            /* [r/w] -10000 0       0       Relative room effect level at low frequencies                         (SUPPORTED:SFX) */
+    float        DecayTime;         /* [r/w] 0.1    20.0    1.49    Reverberation decay time at mid frequencies                           (SUPPORTED:SFX/WII) */
+    float        DecayHFRatio;      /* [r/w] 0.1    2.0     0.83    High-frequency to mid-frequency decay time ratio                      (SUPPORTED:SFX) */
+    float        DecayLFRatio;      /* [r/w] 0.1    2.0     1.0     Low-frequency to mid-frequency decay time ratio                       (SUPPORTED:---) */
+    int          Reflections;       /* [r/w] -10000 1000    -2602   Early reflections level relative to room effect                       (SUPPORTED:SFX/WII) */
+    float        ReflectionsDelay;  /* [r/w] 0.0    0.3     0.007   Initial reflection delay time                                         (SUPPORTED:SFX) */
+    int          Reverb;            /* [r/w] -10000 2000    200     Late reverberation level relative to room effect                      (SUPPORTED:SFX) */
+    float        ReverbDelay;       /* [r/w] 0.0    0.1     0.011   Late reverberation delay time relative to initial reflection          (SUPPORTED:SFX/WII) */
+    float        ModulationTime;    /* [r/w] 0.04   4.0     0.25    Modulation time                                                       (SUPPORTED:---) */
+    float        ModulationDepth;   /* [r/w] 0.0    1.0     0.0     Modulation depth                                                      (SUPPORTED:WII) */
+    float        HFReference;       /* [r/w] 20.0   20000.0 5000.0  Reference high frequency (hz)                                         (SUPPORTED:SFX) */
+    float        LFReference;       /* [r/w] 20.0   1000.0  250.0   Reference low frequency (hz)                                          (SUPPORTED:SFX) */
+    float        Diffusion;         /* [r/w] 0.0    100.0   100.0   Value that controls the echo density in the late reverberation decay. (SUPPORTED:SFX) */
+    float        Density;           /* [r/w] 0.0    100.0   100.0   Value that controls the modal density in the late reverberation decay (SUPPORTED:SFX) */
+    unsigned int Flags;             /* [r/w] FMOD_REVERB_FLAGS - modifies the behavior of above properties                                (SUPPORTED:WII) */
+} FMOD_REVERB_PROPERTIES;
+
+
+/*
+[DEFINE] 
+[
+    [NAME] 
+    FMOD_REVERB_FLAGS
+
+    [DESCRIPTION]
+    Values for the Flags member of the FMOD_REVERB_PROPERTIES structure.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_REVERB_PROPERTIES
+]
+*/
+#define FMOD_REVERB_FLAGS_HIGHQUALITYREVERB     0x00000400 /* Wii. Use high quality reverb */
+#define FMOD_REVERB_FLAGS_HIGHQUALITYDPL2REVERB 0x00000800 /* Wii. Use high quality DPL2 reverb */
+#define FMOD_REVERB_FLAGS_DEFAULT               0x00000000
+/* [DEFINE_END] */
+
+
+/*
+[DEFINE] 
+[
+    [NAME] 
+    FMOD_REVERB_PRESETS
+
+    [DESCRIPTION]   
+    A set of predefined environment PARAMETERS.
+    These are used to initialize an FMOD_REVERB_PROPERTIES structure statically.
+    i.e.
+    FMOD_REVERB_PROPERTIES prop = FMOD_PRESET_GENERIC;
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::setReverbProperties
+]
+*/
+/*                                    Inst Env  Diffus  Room   RoomHF  RmLF DecTm   DecHF  DecLF   Refl  RefDel   Revb  RevDel  ModTm  ModDp   HFRef    LFRef   Diffus  Densty  FLAGS */
+#define FMOD_PRESET_OFF              {  0, -1,  1.00f, -10000, -10000, 0,   1.00f,  1.00f, 1.0f,  -2602, 0.007f,   200, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f,   0.0f,   0.0f, 0x33f }
+#define FMOD_PRESET_GENERIC          {  0,  0,  1.00f, -1000,  -100,   0,   1.49f,  0.83f, 1.0f,  -2602, 0.007f,   200, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_PADDEDCELL       {  0,  1,  1.00f, -1000,  -6000,  0,   0.17f,  0.10f, 1.0f,  -1204, 0.001f,   207, 0.002f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_ROOM             {  0,  2,  1.00f, -1000,  -454,   0,   0.40f,  0.83f, 1.0f,  -1646, 0.002f,    53, 0.003f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_BATHROOM         {  0,  3,  1.00f, -1000,  -1200,  0,   1.49f,  0.54f, 1.0f,   -370, 0.007f,  1030, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f,  60.0f, 0x3f }
+#define FMOD_PRESET_LIVINGROOM       {  0,  4,  1.00f, -1000,  -6000,  0,   0.50f,  0.10f, 1.0f,  -1376, 0.003f, -1104, 0.004f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_STONEROOM        {  0,  5,  1.00f, -1000,  -300,   0,   2.31f,  0.64f, 1.0f,   -711, 0.012f,    83, 0.017f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_AUDITORIUM       {  0,  6,  1.00f, -1000,  -476,   0,   4.32f,  0.59f, 1.0f,   -789, 0.020f,  -289, 0.030f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_CONCERTHALL      {  0,  7,  1.00f, -1000,  -500,   0,   3.92f,  0.70f, 1.0f,  -1230, 0.020f,    -2, 0.029f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_CAVE             {  0,  8,  1.00f, -1000,  0,      0,   2.91f,  1.30f, 1.0f,   -602, 0.015f,  -302, 0.022f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x1f }
+#define FMOD_PRESET_ARENA            {  0,  9,  1.00f, -1000,  -698,   0,   7.24f,  0.33f, 1.0f,  -1166, 0.020f,    16, 0.030f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_HANGAR           {  0,  10, 1.00f, -1000,  -1000,  0,   10.05f, 0.23f, 1.0f,   -602, 0.020f,   198, 0.030f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_CARPETTEDHALLWAY {  0,  11, 1.00f, -1000,  -4000,  0,   0.30f,  0.10f, 1.0f,  -1831, 0.002f, -1630, 0.030f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_HALLWAY          {  0,  12, 1.00f, -1000,  -300,   0,   1.49f,  0.59f, 1.0f,  -1219, 0.007f,   441, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_STONECORRIDOR    {  0,  13, 1.00f, -1000,  -237,   0,   2.70f,  0.79f, 1.0f,  -1214, 0.013f,   395, 0.020f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_ALLEY            {  0,  14, 0.30f, -1000,  -270,   0,   1.49f,  0.86f, 1.0f,  -1204, 0.007f,    -4, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_FOREST           {  0,  15, 0.30f, -1000,  -3300,  0,   1.49f,  0.54f, 1.0f,  -2560, 0.162f,  -229, 0.088f, 0.25f, 0.000f, 5000.0f, 250.0f,  79.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_CITY             {  0,  16, 0.50f, -1000,  -800,   0,   1.49f,  0.67f, 1.0f,  -2273, 0.007f, -1691, 0.011f, 0.25f, 0.000f, 5000.0f, 250.0f,  50.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_MOUNTAINS        {  0,  17, 0.27f, -1000,  -2500,  0,   1.49f,  0.21f, 1.0f,  -2780, 0.300f, -1434, 0.100f, 0.25f, 0.000f, 5000.0f, 250.0f,  27.0f, 100.0f, 0x1f }
+#define FMOD_PRESET_QUARRY           {  0,  18, 1.00f, -1000,  -1000,  0,   1.49f,  0.83f, 1.0f, -10000, 0.061f,   500, 0.025f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_PLAIN            {  0,  19, 0.21f, -1000,  -2000,  0,   1.49f,  0.50f, 1.0f,  -2466, 0.179f, -1926, 0.100f, 0.25f, 0.000f, 5000.0f, 250.0f,  21.0f, 100.0f, 0x3f }
+#define FMOD_PRESET_PARKINGLOT       {  0,  20, 1.00f, -1000,  0,      0,   1.65f,  1.50f, 1.0f,  -1363, 0.008f, -1153, 0.012f, 0.25f, 0.000f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x1f }
+#define FMOD_PRESET_SEWERPIPE        {  0,  21, 0.80f, -1000,  -1000,  0,   2.81f,  0.14f, 1.0f,    429, 0.014f,  1023, 0.021f, 0.25f, 0.000f, 5000.0f, 250.0f,  80.0f,  60.0f, 0x3f }
+#define FMOD_PRESET_UNDERWATER       {  0,  22, 1.00f, -1000,  -4000,  0,   1.49f,  0.10f, 1.0f,   -449, 0.007f,  1700, 0.011f, 1.18f, 0.348f, 5000.0f, 250.0f, 100.0f, 100.0f, 0x3f }
+
+/* PlayStation Portable Only presets */
+#define FMOD_PRESET_PSP_ROOM         {  0,  1,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_STUDIO_A     {  0,  2,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_STUDIO_B     {  0,  3,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_STUDIO_C     {  0,  4,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_HALL         {  0,  5,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_SPACE        {  0,  6,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_ECHO         {  0,  7,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_DELAY        {  0,  8,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+#define FMOD_PRESET_PSP_PIPE         {  0,  9,  0,     0,      0,      0,   0.0f,   0.0f,  0.0f,     0,  0.000f,     0, 0.000f, 0.00f, 0.000f, 0000.0f,   0.0f,  0.0f,    0.0f, 0x31f }
+/* [DEFINE_END] */
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Structure defining the properties for a reverb source, related to a FMOD channel.
+    
+    Note the default reverb properties are the same as the FMOD_PRESET_GENERIC preset.
+    Note that integer values that typically range from -10,000 to 1000 are represented in 
+    decibels, and are of a logarithmic scale, not linear, wheras float values are typically linear.
+    PORTABILITY: Each member has the platform it supports in braces ie (win32/wii).
+    
+    The numerical values listed below are the maximum, minimum and default values for each variable respectively.
+
+    [REMARKS]
+    <b>SUPPORTED</b> next to each parameter means the platform the parameter can be set on.  Some platforms support all parameters and some don't.
+    WII   means Nintendo Wii hardware reverb (must use FMOD_HARDWARE).
+    PSP   means Playstation Portable hardware reverb (must use FMOD_HARDWARE).
+    SFX   means FMOD SFX software reverb.  This works on any platform that uses FMOD_SOFTWARE for loading sounds.
+    ---   means unsupported/deprecated.  Will either be removed or supported by SFX in the future.
+    
+    
+    <b>'ConnectionPoint' Parameter.</b>  This parameter is for the FMOD software reverb only (known as SFX in the list above).
+    By default the dsp network connection for a channel and its reverb is between the 'SFX Reverb' unit, and the channel's wavetable/resampler/dspcodec/oscillator unit (the unit below the channel DSP head).  NULL can be used for this parameter to make it use this default behaviour.
+    This parameter allows the user to connect the SFX reverb to somewhere else internally, for example the channel DSP head, or a related channelgroup.  The event system uses this so that it can have the output of an event going to the reverb, instead of just the output of the event's channels (thereby ignoring event effects/submixes etc).
+    Do not use if you are unaware of DSP network connection issues.  Leave it at the default of NULL instead.
+    
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+    Members marked with [r/w] are either read or write depending on if you are using Channel::setReverbProperties (w) or Channel::getReverbProperties (r).
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    Channel::setReverbProperties
+    Channel::getReverbProperties
+    FMOD_REVERB_CHANNELFLAGS 
+]
+*/
+typedef struct FMOD_REVERB_CHANNELPROPERTIES
+{                                      /*       MIN    MAX  DEFAULT  DESCRIPTION */
+    int          Direct;               /* [r/w] -10000 1000 0        Direct path level                                        (SUPPORTED:SFX) */
+    int          Room;                 /* [r/w] -10000 1000 0        Room effect level                                        (SUPPORTED:SFX) */
+    unsigned int Flags;                /* [r/w] FMOD_REVERB_CHANNELFLAGS - modifies the behavior of properties                (SUPPORTED:SFX) */
+    FMOD_DSP    *ConnectionPoint;      /* [r/w] See remarks.         DSP network location to connect reverb for this channel. (SUPPORTED:SFX).*/
+} FMOD_REVERB_CHANNELPROPERTIES;
+
+
+/*
+[DEFINE] 
+[
+    [NAME] 
+    FMOD_REVERB_CHANNELFLAGS
+
+    [DESCRIPTION]
+    Values for the Flags member of the FMOD_REVERB_CHANNELPROPERTIES structure.
+
+    [REMARKS]
+    For SFX Reverb, there is support for multiple reverb environments.
+    Use FMOD_REVERB_CHANNELFLAGS_ENVIRONMENT0 to FMOD_REVERB_CHANNELFLAGS_ENVIRONMENT3 in the flags member 
+    of FMOD_REVERB_CHANNELPROPERTIES to specify which environment instance(s) to target. 
+    - If you do not specify any instance the first reverb instance will be used.
+    - If you specify more than one instance with getReverbProperties, the first instance will be used.
+    - If you specify more than one instance with setReverbProperties, it will set more than 1 instance at once.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_REVERB_CHANNELPROPERTIES
+]
+*/
+#define FMOD_REVERB_CHANNELFLAGS_INSTANCE0     0x00000010 /* SFX/Wii. Specify channel to target reverb instance 0.  Default target. */
+#define FMOD_REVERB_CHANNELFLAGS_INSTANCE1     0x00000020 /* SFX/Wii. Specify channel to target reverb instance 1. */
+#define FMOD_REVERB_CHANNELFLAGS_INSTANCE2     0x00000040 /* SFX/Wii. Specify channel to target reverb instance 2. */
+#define FMOD_REVERB_CHANNELFLAGS_INSTANCE3     0x00000080 /* SFX. Specify channel to target reverb instance 3. */
+
+#define FMOD_REVERB_CHANNELFLAGS_DEFAULT       FMOD_REVERB_CHANNELFLAGS_INSTANCE0
+/* [DEFINE_END] */
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Settings for advanced features like configuring memory and cpu usage for the FMOD_CREATECOMPRESSEDSAMPLE feature.
+
+    [REMARKS]
+    maxMPEGcodecs / maxADPCMcodecs / maxXMAcodecs will determine the maximum cpu usage of playing realtime samples.  Use this to lower potential excess cpu usage and also control memory usage.
+    
+    maxPCMcodecs is for use with PS3 only. It will determine the maximum number of PCM voices that can be played at once. This includes streams of any format and all sounds created
+    *without* the FMOD_CREATECOMPRESSEDSAMPLE flag.
+    
+    Memory will be allocated for codecs 'up front' (during System::init) if these values are specified as non zero.  If any are zero, it allocates memory for the codec whenever a file of the type in question is loaded.  So if maxMPEGcodecs is 0 for example, it will allocate memory for the mpeg codecs the first time an mp3 is loaded or an mp3 based .FSB file is loaded.
+    
+    Due to inefficient encoding techniques on certain .wav based ADPCM files, FMOD can can need an extra 29720 bytes per codec.  This means for lowest memory consumption.  Use FSB as it uses an optimal/small ADPCM block size.
+    
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+    Members marked with [r/w] are either read or write depending on if you are using System::setAdvancedSettings (w) or System::getAdvancedSettings (r).
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::setAdvancedSettings
+    System::getAdvancedSettings
+    System::init
+    FMOD_MODE
+]
+*/
+typedef struct FMOD_ADVANCEDSETTINGS
+{                       
+    int             cbsize;                     /* [w]   Size of this structure.  Use sizeof(FMOD_ADVANCEDSETTINGS)  NOTE: This must be set before calling System::getAdvancedSettings! */
+    int             maxMPEGcodecs;              /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_CREATECOMPRESSEDSAMPLE only.  Mpeg  codecs consume 21,684 bytes per instance and this number will determine how many mpeg channels can be played simultaneously.   Default = 32. */
+    int             maxADPCMcodecs;             /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_CREATECOMPRESSEDSAMPLE only.  ADPCM codecs consume  2,136 bytes per instance and this number will determine how many ADPCM channels can be played simultaneously.  Default = 32. */
+    int             maxXMAcodecs;               /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_CREATECOMPRESSEDSAMPLE only.  XMA   codecs consume 14,836 bytes per instance and this number will determine how many XMA channels can be played simultaneously.    Default = 32. */
+    int             maxCELTcodecs;              /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_CREATECOMPRESSEDSAMPLE only.  CELT  codecs consume 11,500 bytes per instance and this number will determine how many CELT channels can be played simultaneously.   Default = 32. */    
+    int             maxPCMcodecs;               /* [r/w] Optional. Specify 0 to ignore. For use with PS3 only.                          PCM   codecs consume 12,672 bytes per instance and this number will determine how many streams and PCM voices can be played simultaneously. Default = 16. */
+    int             ASIONumChannels;            /* [r/w] Optional. Specify 0 to ignore. Number of channels available on the ASIO device. */
+    char          **ASIOChannelList;            /* [r/w] Optional. Specify 0 to ignore. Pointer to an array of strings (number of entries defined by ASIONumChannels) with ASIO channel names. */
+    FMOD_SPEAKER   *ASIOSpeakerList;            /* [r/w] Optional. Specify 0 to ignore. Pointer to a list of speakers that the ASIO channels map to.  This can be called after System::init to remap ASIO output. */
+    int             max3DReverbDSPs;            /* [r/w] Optional. Specify 0 to ignore. The max number of 3d reverb DSP's in the system. (NOTE: CURRENTLY DISABLED / UNUSED) */
+    float           HRTFMinAngle;               /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_HRTF_LOWPASS.  The angle range (0-360) of a 3D sound in relation to the listener, at which the HRTF function begins to have an effect. 0 = in front of the listener. 180 = from 90 degrees to the left of the listener to 90 degrees to the right. 360 = behind the listener. Default = 180.0. */
+    float           HRTFMaxAngle;               /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_HRTF_LOWPASS.  The angle range (0-360) of a 3D sound in relation to the listener, at which the HRTF function has maximum effect. 0 = front of the listener. 180 = from 90 degrees to the left of the listener to 90 degrees to the right. 360 = behind the listener. Default = 360.0. */
+    float           HRTFFreq;                   /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_HRTF_LOWPASS.  The cutoff frequency of the HRTF's lowpass filter function when at maximum effect. (i.e. at HRTFMaxAngle).  Default = 4000.0. */
+    float           vol0virtualvol;             /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_VOL0_BECOMES_VIRTUAL.  If this flag is used, and the volume is 0.0, then the sound will become virtual.  Use this value to raise the threshold to a different point where a sound goes virtual. */
+    int             eventqueuesize;             /* [r/w] Optional. Specify 0 to ignore. For use with FMOD Event system only.  Specifies the number of slots available for simultaneous non blocking loads, across all threads.  Default = 32. */
+    unsigned int    defaultDecodeBufferSize;    /* [r/w] Optional. Specify 0 to ignore. For streams. This determines the default size of the double buffer (in milliseconds) that a stream uses.  Default = 400ms */
+    char           *debugLogFilename;           /* [r/w] Optional. Specify 0 to ignore. Gives fmod's logging system a path/filename.  Normally the log is placed in the same directory as the executable and called fmod.log. When using System::getAdvancedSettings, provide at least 256 bytes of memory to copy into. */
+    unsigned short  profileport;                /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_ENABLE_PROFILE.  Specify the port to listen on for connections by the profiler application. */
+    unsigned int    geometryMaxFadeTime;        /* [r/w] Optional. Specify 0 to ignore. The maximum time in miliseconds it takes for a channel to fade to the new level when its occlusion changes. */
+    unsigned int    maxSpectrumWaveDataBuffers; /* [r/w] Optional. Specify 0 to ignore. Tells System::init to allocate a pool of wavedata/spectrum buffers to prevent memory fragmentation, any additional buffers will be allocated normally. */
+    unsigned int    musicSystemCacheDelay;      /* [r/w] Optional. Specify 0 to ignore. The delay the music system should allow for loading a sample from disk (in milliseconds). Default = 400 ms. */
+    float           distanceFilterCenterFreq;   /* [r/w] Optional. Specify 0 to ignore. For use with FMOD_INIT_DISTANCE_FILTERING.  The default center frequency in Hz for the distance filtering effect. Default = 1500.0. */
+} FMOD_ADVANCEDSETTINGS;
+
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]
+    Special channel index values for FMOD functions.
+
+    [REMARKS]
+    To get 'all' of the channels, use System::getMasterChannelGroup.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::playSound
+    System::playDSP
+    System::getChannel
+    System::getMasterChannelGroup
+]
+*/
+typedef enum
+{
+    FMOD_CHANNEL_FREE  = -1,      /* For a channel index, FMOD chooses a free voice using the priority system. */
+    FMOD_CHANNEL_REUSE = -2       /* For a channel index, re-use the channel handle that was passed in. */
+} FMOD_CHANNELINDEX;
+
+#include "fmod_codec.h"
+#include "fmod_dsp.h"
+#include "fmod_memoryinfo.h"
+
+/* ========================================================================================== */
+/* FUNCTION PROTOTYPES                                                                        */
+/* ========================================================================================== */
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+/*
+    FMOD global system functions (optional).
+*/
+
+FMOD_RESULT F_API FMOD_Memory_Initialize           (void *poolmem, int poollen, FMOD_MEMORY_ALLOCCALLBACK useralloc, FMOD_MEMORY_REALLOCCALLBACK userrealloc, FMOD_MEMORY_FREECALLBACK userfree, FMOD_MEMORY_TYPE memtypeflags);
+FMOD_RESULT F_API FMOD_Memory_GetStats             (int *currentalloced, int *maxalloced, FMOD_BOOL blocking);
+FMOD_RESULT F_API FMOD_Debug_SetLevel              (FMOD_DEBUGLEVEL level);
+FMOD_RESULT F_API FMOD_Debug_GetLevel              (FMOD_DEBUGLEVEL *level);
+FMOD_RESULT F_API FMOD_File_SetDiskBusy            (int busy);
+FMOD_RESULT F_API FMOD_File_GetDiskBusy            (int *busy);
+
+/*
+    FMOD System factory functions.  Use this to create an FMOD System Instance.  below you will see FMOD_System_Init/Close to get started.
+*/
+
+FMOD_RESULT F_API FMOD_System_Create               (FMOD_SYSTEM **system); 
+FMOD_RESULT F_API FMOD_System_Release              (FMOD_SYSTEM *system); 
+
+
+/*
+    'System' API
+*/
+
+/*
+     Pre-init functions.
+*/
+
+FMOD_RESULT F_API FMOD_System_SetOutput              (FMOD_SYSTEM *system, FMOD_OUTPUTTYPE output);
+FMOD_RESULT F_API FMOD_System_GetOutput              (FMOD_SYSTEM *system, FMOD_OUTPUTTYPE *output);
+FMOD_RESULT F_API FMOD_System_GetNumDrivers          (FMOD_SYSTEM *system, int *numdrivers);
+FMOD_RESULT F_API FMOD_System_GetDriverInfo          (FMOD_SYSTEM *system, int id, char *name, int namelen, FMOD_GUID *guid);
+FMOD_RESULT F_API FMOD_System_GetDriverInfoW         (FMOD_SYSTEM *system, int id, short *name, int namelen, FMOD_GUID *guid);
+FMOD_RESULT F_API FMOD_System_GetDriverCaps          (FMOD_SYSTEM *system, int id, FMOD_CAPS *caps, int *controlpaneloutputrate, FMOD_SPEAKERMODE *controlpanelspeakermode);
+FMOD_RESULT F_API FMOD_System_SetDriver              (FMOD_SYSTEM *system, int driver);
+FMOD_RESULT F_API FMOD_System_GetDriver              (FMOD_SYSTEM *system, int *driver);
+FMOD_RESULT F_API FMOD_System_SetHardwareChannels    (FMOD_SYSTEM *system, int numhardwarechannels);
+FMOD_RESULT F_API FMOD_System_SetSoftwareChannels    (FMOD_SYSTEM *system, int numsoftwarechannels);
+FMOD_RESULT F_API FMOD_System_GetSoftwareChannels    (FMOD_SYSTEM *system, int *numsoftwarechannels);
+FMOD_RESULT F_API FMOD_System_SetSoftwareFormat      (FMOD_SYSTEM *system, int samplerate, FMOD_SOUND_FORMAT format, int numoutputchannels, int maxinputchannels, FMOD_DSP_RESAMPLER resamplemethod);
+FMOD_RESULT F_API FMOD_System_GetSoftwareFormat      (FMOD_SYSTEM *system, int *samplerate, FMOD_SOUND_FORMAT *format, int *numoutputchannels, int *maxinputchannels, FMOD_DSP_RESAMPLER *resamplemethod, int *bits);
+FMOD_RESULT F_API FMOD_System_SetDSPBufferSize       (FMOD_SYSTEM *system, unsigned int bufferlength, int numbuffers);
+FMOD_RESULT F_API FMOD_System_GetDSPBufferSize       (FMOD_SYSTEM *system, unsigned int *bufferlength, int *numbuffers);
+FMOD_RESULT F_API FMOD_System_SetFileSystem          (FMOD_SYSTEM *system, FMOD_FILE_OPENCALLBACK useropen, FMOD_FILE_CLOSECALLBACK userclose, FMOD_FILE_READCALLBACK userread, FMOD_FILE_SEEKCALLBACK userseek, FMOD_FILE_ASYNCREADCALLBACK userasyncread, FMOD_FILE_ASYNCCANCELCALLBACK userasynccancel, int blockalign);
+FMOD_RESULT F_API FMOD_System_AttachFileSystem       (FMOD_SYSTEM *system, FMOD_FILE_OPENCALLBACK useropen, FMOD_FILE_CLOSECALLBACK userclose, FMOD_FILE_READCALLBACK userread, FMOD_FILE_SEEKCALLBACK userseek);
+FMOD_RESULT F_API FMOD_System_SetAdvancedSettings    (FMOD_SYSTEM *system, FMOD_ADVANCEDSETTINGS *settings);
+FMOD_RESULT F_API FMOD_System_GetAdvancedSettings    (FMOD_SYSTEM *system, FMOD_ADVANCEDSETTINGS *settings);
+FMOD_RESULT F_API FMOD_System_SetSpeakerMode         (FMOD_SYSTEM *system, FMOD_SPEAKERMODE speakermode);
+FMOD_RESULT F_API FMOD_System_GetSpeakerMode         (FMOD_SYSTEM *system, FMOD_SPEAKERMODE *speakermode);
+FMOD_RESULT F_API FMOD_System_SetCallback            (FMOD_SYSTEM *system, FMOD_SYSTEM_CALLBACK callback);
+
+/*
+     Plug-in support                       
+*/
+
+FMOD_RESULT F_API FMOD_System_SetPluginPath          (FMOD_SYSTEM *system, const char *path);
+FMOD_RESULT F_API FMOD_System_LoadPlugin             (FMOD_SYSTEM *system, const char *filename, unsigned int *handle, unsigned int priority);
+FMOD_RESULT F_API FMOD_System_UnloadPlugin           (FMOD_SYSTEM *system, unsigned int handle);
+FMOD_RESULT F_API FMOD_System_GetNumPlugins          (FMOD_SYSTEM *system, FMOD_PLUGINTYPE plugintype, int *numplugins);
+FMOD_RESULT F_API FMOD_System_GetPluginHandle        (FMOD_SYSTEM *system, FMOD_PLUGINTYPE plugintype, int index, unsigned int *handle);
+FMOD_RESULT F_API FMOD_System_GetPluginInfo          (FMOD_SYSTEM *system, unsigned int handle, FMOD_PLUGINTYPE *plugintype, char *name, int namelen, unsigned int *version);
+FMOD_RESULT F_API FMOD_System_SetOutputByPlugin      (FMOD_SYSTEM *system, unsigned int handle);
+FMOD_RESULT F_API FMOD_System_GetOutputByPlugin      (FMOD_SYSTEM *system, unsigned int *handle);
+FMOD_RESULT F_API FMOD_System_CreateDSPByPlugin      (FMOD_SYSTEM *system, unsigned int handle, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_System_RegisterCodec          (FMOD_SYSTEM *system, FMOD_CODEC_DESCRIPTION *description, unsigned int *handle, unsigned int priority);
+FMOD_RESULT F_API FMOD_System_RegisterDSP            (FMOD_SYSTEM *system, FMOD_DSP_DESCRIPTION *description, unsigned int *handle);
+
+/*
+     Init/Close                            
+*/
+
+FMOD_RESULT F_API FMOD_System_Init                   (FMOD_SYSTEM *system, int maxchannels, FMOD_INITFLAGS flags, void *extradriverdata);
+FMOD_RESULT F_API FMOD_System_Close                  (FMOD_SYSTEM *system);
+
+/*
+     General post-init system functions    
+*/
+
+FMOD_RESULT F_API FMOD_System_Update                 (FMOD_SYSTEM *system);
+
+FMOD_RESULT F_API FMOD_System_Set3DSettings          (FMOD_SYSTEM *system, float dopplerscale, float distancefactor, float rolloffscale);
+FMOD_RESULT F_API FMOD_System_Get3DSettings          (FMOD_SYSTEM *system, float *dopplerscale, float *distancefactor, float *rolloffscale);
+FMOD_RESULT F_API FMOD_System_Set3DNumListeners      (FMOD_SYSTEM *system, int numlisteners);
+FMOD_RESULT F_API FMOD_System_Get3DNumListeners      (FMOD_SYSTEM *system, int *numlisteners);
+FMOD_RESULT F_API FMOD_System_Set3DListenerAttributes(FMOD_SYSTEM *system, int listener, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel, const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+FMOD_RESULT F_API FMOD_System_Get3DListenerAttributes(FMOD_SYSTEM *system, int listener, FMOD_VECTOR *pos, FMOD_VECTOR *vel, FMOD_VECTOR *forward, FMOD_VECTOR *up);
+FMOD_RESULT F_API FMOD_System_Set3DRolloffCallback   (FMOD_SYSTEM *system, FMOD_3D_ROLLOFFCALLBACK callback);
+FMOD_RESULT F_API FMOD_System_Set3DSpeakerPosition   (FMOD_SYSTEM *system, FMOD_SPEAKER speaker, float x, float y, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_System_Get3DSpeakerPosition   (FMOD_SYSTEM *system, FMOD_SPEAKER speaker, float *x, float *y, FMOD_BOOL *active);
+
+FMOD_RESULT F_API FMOD_System_SetStreamBufferSize    (FMOD_SYSTEM *system, unsigned int filebuffersize, FMOD_TIMEUNIT filebuffersizetype);
+FMOD_RESULT F_API FMOD_System_GetStreamBufferSize    (FMOD_SYSTEM *system, unsigned int *filebuffersize, FMOD_TIMEUNIT *filebuffersizetype);
+
+/*
+     System information functions.        
+*/
+
+FMOD_RESULT F_API FMOD_System_GetVersion             (FMOD_SYSTEM *system, unsigned int *version);
+FMOD_RESULT F_API FMOD_System_GetOutputHandle        (FMOD_SYSTEM *system, void **handle);
+FMOD_RESULT F_API FMOD_System_GetChannelsPlaying     (FMOD_SYSTEM *system, int *channels);
+FMOD_RESULT F_API FMOD_System_GetHardwareChannels    (FMOD_SYSTEM *system, int *numhardwarechannels);
+FMOD_RESULT F_API FMOD_System_GetCPUUsage            (FMOD_SYSTEM *system, float *dsp, float *stream, float *geometry, float *update, float *total);
+FMOD_RESULT F_API FMOD_System_GetSoundRAM            (FMOD_SYSTEM *system, int *currentalloced, int *maxalloced, int *total);
+FMOD_RESULT F_API FMOD_System_GetNumCDROMDrives      (FMOD_SYSTEM *system, int *numdrives);
+FMOD_RESULT F_API FMOD_System_GetCDROMDriveName      (FMOD_SYSTEM *system, int drive, char *drivename, int drivenamelen, char *scsiname, int scsinamelen, char *devicename, int devicenamelen);
+FMOD_RESULT F_API FMOD_System_GetSpectrum            (FMOD_SYSTEM *system, float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+FMOD_RESULT F_API FMOD_System_GetWaveData            (FMOD_SYSTEM *system, float *wavearray, int numvalues, int channeloffset);
+
+/*
+     Sound/DSP/Channel/FX creation and retrieval.       
+*/
+
+FMOD_RESULT F_API FMOD_System_CreateSound            (FMOD_SYSTEM *system, const char *name_or_data, FMOD_MODE mode, FMOD_CREATESOUNDEXINFO *exinfo, FMOD_SOUND **sound);
+FMOD_RESULT F_API FMOD_System_CreateStream           (FMOD_SYSTEM *system, const char *name_or_data, FMOD_MODE mode, FMOD_CREATESOUNDEXINFO *exinfo, FMOD_SOUND **sound);
+FMOD_RESULT F_API FMOD_System_CreateDSP              (FMOD_SYSTEM *system, FMOD_DSP_DESCRIPTION *description, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_System_CreateDSPByType        (FMOD_SYSTEM *system, FMOD_DSP_TYPE type, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_System_CreateChannelGroup     (FMOD_SYSTEM *system, const char *name, FMOD_CHANNELGROUP **channelgroup);
+FMOD_RESULT F_API FMOD_System_CreateSoundGroup       (FMOD_SYSTEM *system, const char *name, FMOD_SOUNDGROUP **soundgroup);
+FMOD_RESULT F_API FMOD_System_CreateReverb           (FMOD_SYSTEM *system, FMOD_REVERB **reverb);
+
+FMOD_RESULT F_API FMOD_System_PlaySound              (FMOD_SYSTEM *system, FMOD_CHANNELINDEX channelid, FMOD_SOUND *sound, FMOD_BOOL paused, FMOD_CHANNEL **channel);
+FMOD_RESULT F_API FMOD_System_PlayDSP                (FMOD_SYSTEM *system, FMOD_CHANNELINDEX channelid, FMOD_DSP *dsp, FMOD_BOOL paused, FMOD_CHANNEL **channel);
+FMOD_RESULT F_API FMOD_System_GetChannel             (FMOD_SYSTEM *system, int channelid, FMOD_CHANNEL **channel);
+FMOD_RESULT F_API FMOD_System_GetMasterChannelGroup  (FMOD_SYSTEM *system, FMOD_CHANNELGROUP **channelgroup);
+FMOD_RESULT F_API FMOD_System_GetMasterSoundGroup    (FMOD_SYSTEM *system, FMOD_SOUNDGROUP **soundgroup);
+
+/*
+     Reverb API                           
+*/
+
+FMOD_RESULT F_API FMOD_System_SetReverbProperties    (FMOD_SYSTEM *system, const FMOD_REVERB_PROPERTIES *prop);
+FMOD_RESULT F_API FMOD_System_GetReverbProperties    (FMOD_SYSTEM *system, FMOD_REVERB_PROPERTIES *prop);
+FMOD_RESULT F_API FMOD_System_SetReverbAmbientProperties(FMOD_SYSTEM *system, FMOD_REVERB_PROPERTIES *prop);
+FMOD_RESULT F_API FMOD_System_GetReverbAmbientProperties(FMOD_SYSTEM *system, FMOD_REVERB_PROPERTIES *prop);
+
+/*
+     System level DSP access.
+*/
+
+FMOD_RESULT F_API FMOD_System_GetDSPHead             (FMOD_SYSTEM *system, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_System_AddDSP                 (FMOD_SYSTEM *system, FMOD_DSP *dsp, FMOD_DSPCONNECTION **connection);
+FMOD_RESULT F_API FMOD_System_LockDSP                (FMOD_SYSTEM *system);
+FMOD_RESULT F_API FMOD_System_UnlockDSP              (FMOD_SYSTEM *system);
+FMOD_RESULT F_API FMOD_System_GetDSPClock            (FMOD_SYSTEM *system, unsigned int *hi, unsigned int *lo);
+
+/*
+     Recording API.
+*/
+
+FMOD_RESULT F_API FMOD_System_GetRecordNumDrivers    (FMOD_SYSTEM *system, int *numdrivers);
+FMOD_RESULT F_API FMOD_System_GetRecordDriverInfo    (FMOD_SYSTEM *system, int id, char *name, int namelen, FMOD_GUID *guid);
+FMOD_RESULT F_API FMOD_System_GetRecordDriverInfoW   (FMOD_SYSTEM *system, int id, short *name, int namelen, FMOD_GUID *guid);
+FMOD_RESULT F_API FMOD_System_GetRecordDriverCaps    (FMOD_SYSTEM *system, int id, FMOD_CAPS *caps, int *minfrequency, int *maxfrequency);
+FMOD_RESULT F_API FMOD_System_GetRecordPosition      (FMOD_SYSTEM *system, int id, unsigned int *position);
+
+FMOD_RESULT F_API FMOD_System_RecordStart            (FMOD_SYSTEM *system, int id, FMOD_SOUND *sound, FMOD_BOOL loop);
+FMOD_RESULT F_API FMOD_System_RecordStop             (FMOD_SYSTEM *system, int id);
+FMOD_RESULT F_API FMOD_System_IsRecording            (FMOD_SYSTEM *system, int id, FMOD_BOOL *recording);
+
+/*
+     Geometry API.
+*/
+
+FMOD_RESULT F_API FMOD_System_CreateGeometry         (FMOD_SYSTEM *system, int maxpolygons, int maxvertices, FMOD_GEOMETRY **geometry);
+FMOD_RESULT F_API FMOD_System_SetGeometrySettings    (FMOD_SYSTEM *system, float maxworldsize);
+FMOD_RESULT F_API FMOD_System_GetGeometrySettings    (FMOD_SYSTEM *system, float *maxworldsize);
+FMOD_RESULT F_API FMOD_System_LoadGeometry           (FMOD_SYSTEM *system, const void *data, int datasize, FMOD_GEOMETRY **geometry);
+FMOD_RESULT F_API FMOD_System_GetGeometryOcclusion   (FMOD_SYSTEM *system, const FMOD_VECTOR *listener, const FMOD_VECTOR *source, float *direct, float *reverb);
+
+/*
+     Network functions.
+*/
+
+FMOD_RESULT F_API FMOD_System_SetNetworkProxy        (FMOD_SYSTEM *system, const char *proxy);
+FMOD_RESULT F_API FMOD_System_GetNetworkProxy        (FMOD_SYSTEM *system, char *proxy, int proxylen);
+FMOD_RESULT F_API FMOD_System_SetNetworkTimeout      (FMOD_SYSTEM *system, int timeout);
+FMOD_RESULT F_API FMOD_System_GetNetworkTimeout      (FMOD_SYSTEM *system, int *timeout);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_System_SetUserData            (FMOD_SYSTEM *system, void *userdata);
+FMOD_RESULT F_API FMOD_System_GetUserData            (FMOD_SYSTEM *system, void **userdata);
+
+FMOD_RESULT F_API FMOD_System_GetMemoryInfo          (FMOD_SYSTEM *system, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'Sound' API
+*/
+
+FMOD_RESULT F_API FMOD_Sound_Release                 (FMOD_SOUND *sound);
+FMOD_RESULT F_API FMOD_Sound_GetSystemObject         (FMOD_SOUND *sound, FMOD_SYSTEM **system);
+
+/*
+     Standard sound manipulation functions.                                                
+*/
+
+FMOD_RESULT F_API FMOD_Sound_Lock                    (FMOD_SOUND *sound, unsigned int offset, unsigned int length, void **ptr1, void **ptr2, unsigned int *len1, unsigned int *len2);
+FMOD_RESULT F_API FMOD_Sound_Unlock                  (FMOD_SOUND *sound, void *ptr1, void *ptr2, unsigned int len1, unsigned int len2);
+FMOD_RESULT F_API FMOD_Sound_SetDefaults             (FMOD_SOUND *sound, float frequency, float volume, float pan, int priority);
+FMOD_RESULT F_API FMOD_Sound_GetDefaults             (FMOD_SOUND *sound, float *frequency, float *volume, float *pan, int *priority);
+FMOD_RESULT F_API FMOD_Sound_SetVariations           (FMOD_SOUND *sound, float frequencyvar, float volumevar, float panvar);
+FMOD_RESULT F_API FMOD_Sound_GetVariations           (FMOD_SOUND *sound, float *frequencyvar, float *volumevar, float *panvar);
+FMOD_RESULT F_API FMOD_Sound_Set3DMinMaxDistance     (FMOD_SOUND *sound, float min, float max);
+FMOD_RESULT F_API FMOD_Sound_Get3DMinMaxDistance     (FMOD_SOUND *sound, float *min, float *max);
+FMOD_RESULT F_API FMOD_Sound_Set3DConeSettings       (FMOD_SOUND *sound, float insideconeangle, float outsideconeangle, float outsidevolume);
+FMOD_RESULT F_API FMOD_Sound_Get3DConeSettings       (FMOD_SOUND *sound, float *insideconeangle, float *outsideconeangle, float *outsidevolume);
+FMOD_RESULT F_API FMOD_Sound_Set3DCustomRolloff      (FMOD_SOUND *sound, FMOD_VECTOR *points, int numpoints);
+FMOD_RESULT F_API FMOD_Sound_Get3DCustomRolloff      (FMOD_SOUND *sound, FMOD_VECTOR **points, int *numpoints);
+FMOD_RESULT F_API FMOD_Sound_SetSubSound             (FMOD_SOUND *sound, int index, FMOD_SOUND *subsound);
+FMOD_RESULT F_API FMOD_Sound_GetSubSound             (FMOD_SOUND *sound, int index, FMOD_SOUND **subsound);
+FMOD_RESULT F_API FMOD_Sound_SetSubSoundSentence     (FMOD_SOUND *sound, int *subsoundlist, int numsubsounds);
+FMOD_RESULT F_API FMOD_Sound_GetName                 (FMOD_SOUND *sound, char *name, int namelen);
+FMOD_RESULT F_API FMOD_Sound_GetLength               (FMOD_SOUND *sound, unsigned int *length, FMOD_TIMEUNIT lengthtype);
+FMOD_RESULT F_API FMOD_Sound_GetFormat               (FMOD_SOUND *sound, FMOD_SOUND_TYPE *type, FMOD_SOUND_FORMAT *format, int *channels, int *bits);
+FMOD_RESULT F_API FMOD_Sound_GetNumSubSounds         (FMOD_SOUND *sound, int *numsubsounds);
+FMOD_RESULT F_API FMOD_Sound_GetNumTags              (FMOD_SOUND *sound, int *numtags, int *numtagsupdated);
+FMOD_RESULT F_API FMOD_Sound_GetTag                  (FMOD_SOUND *sound, const char *name, int index, FMOD_TAG *tag);
+FMOD_RESULT F_API FMOD_Sound_GetOpenState            (FMOD_SOUND *sound, FMOD_OPENSTATE *openstate, unsigned int *percentbuffered, FMOD_BOOL *starving, FMOD_BOOL *diskbusy);
+FMOD_RESULT F_API FMOD_Sound_ReadData                (FMOD_SOUND *sound, void *buffer, unsigned int lenbytes, unsigned int *read);
+FMOD_RESULT F_API FMOD_Sound_SeekData                (FMOD_SOUND *sound, unsigned int pcm);
+
+FMOD_RESULT F_API FMOD_Sound_SetSoundGroup           (FMOD_SOUND *sound, FMOD_SOUNDGROUP *soundgroup);
+FMOD_RESULT F_API FMOD_Sound_GetSoundGroup           (FMOD_SOUND *sound, FMOD_SOUNDGROUP **soundgroup);
+
+/*
+     Synchronization point API.  These points can come from markers embedded in wav files, and can also generate channel callbacks.        
+*/
+
+FMOD_RESULT F_API FMOD_Sound_GetNumSyncPoints        (FMOD_SOUND *sound, int *numsyncpoints);
+FMOD_RESULT F_API FMOD_Sound_GetSyncPoint            (FMOD_SOUND *sound, int index, FMOD_SYNCPOINT **point);
+FMOD_RESULT F_API FMOD_Sound_GetSyncPointInfo        (FMOD_SOUND *sound, FMOD_SYNCPOINT *point, char *name, int namelen, unsigned int *offset, FMOD_TIMEUNIT offsettype);
+FMOD_RESULT F_API FMOD_Sound_AddSyncPoint            (FMOD_SOUND *sound, unsigned int offset, FMOD_TIMEUNIT offsettype, const char *name, FMOD_SYNCPOINT **point);
+FMOD_RESULT F_API FMOD_Sound_DeleteSyncPoint         (FMOD_SOUND *sound, FMOD_SYNCPOINT *point);
+
+/*
+     Functions also in Channel class but here they are the 'default' to save having to change it in Channel all the time.
+*/
+
+FMOD_RESULT F_API FMOD_Sound_SetMode                 (FMOD_SOUND *sound, FMOD_MODE mode);
+FMOD_RESULT F_API FMOD_Sound_GetMode                 (FMOD_SOUND *sound, FMOD_MODE *mode);
+FMOD_RESULT F_API FMOD_Sound_SetLoopCount            (FMOD_SOUND *sound, int loopcount);
+FMOD_RESULT F_API FMOD_Sound_GetLoopCount            (FMOD_SOUND *sound, int *loopcount);
+FMOD_RESULT F_API FMOD_Sound_SetLoopPoints           (FMOD_SOUND *sound, unsigned int loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int loopend, FMOD_TIMEUNIT loopendtype);
+FMOD_RESULT F_API FMOD_Sound_GetLoopPoints           (FMOD_SOUND *sound, unsigned int *loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int *loopend, FMOD_TIMEUNIT loopendtype);
+
+/*
+     For MOD/S3M/XM/IT/MID sequenced formats only.
+*/
+
+FMOD_RESULT F_API FMOD_Sound_GetMusicNumChannels     (FMOD_SOUND *sound, int *numchannels);
+FMOD_RESULT F_API FMOD_Sound_SetMusicChannelVolume   (FMOD_SOUND *sound, int channel, float volume);
+FMOD_RESULT F_API FMOD_Sound_GetMusicChannelVolume   (FMOD_SOUND *sound, int channel, float *volume);
+FMOD_RESULT F_API FMOD_Sound_SetMusicSpeed           (FMOD_SOUND *sound, float speed);
+FMOD_RESULT F_API FMOD_Sound_GetMusicSpeed           (FMOD_SOUND *sound, float *speed);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_Sound_SetUserData             (FMOD_SOUND *sound, void *userdata);
+FMOD_RESULT F_API FMOD_Sound_GetUserData             (FMOD_SOUND *sound, void **userdata);
+
+FMOD_RESULT F_API FMOD_Sound_GetMemoryInfo           (FMOD_SOUND *sound, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'Channel' API
+*/
+
+FMOD_RESULT F_API FMOD_Channel_GetSystemObject       (FMOD_CHANNEL *channel, FMOD_SYSTEM **system);
+
+FMOD_RESULT F_API FMOD_Channel_Stop                  (FMOD_CHANNEL *channel);
+FMOD_RESULT F_API FMOD_Channel_SetPaused             (FMOD_CHANNEL *channel, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_Channel_GetPaused             (FMOD_CHANNEL *channel, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_Channel_SetVolume             (FMOD_CHANNEL *channel, float volume);
+FMOD_RESULT F_API FMOD_Channel_GetVolume             (FMOD_CHANNEL *channel, float *volume);
+FMOD_RESULT F_API FMOD_Channel_SetFrequency          (FMOD_CHANNEL *channel, float frequency);
+FMOD_RESULT F_API FMOD_Channel_GetFrequency          (FMOD_CHANNEL *channel, float *frequency);
+FMOD_RESULT F_API FMOD_Channel_SetPan                (FMOD_CHANNEL *channel, float pan);
+FMOD_RESULT F_API FMOD_Channel_GetPan                (FMOD_CHANNEL *channel, float *pan);
+FMOD_RESULT F_API FMOD_Channel_SetDelay              (FMOD_CHANNEL *channel, FMOD_DELAYTYPE delaytype, unsigned int delayhi, unsigned int delaylo);
+FMOD_RESULT F_API FMOD_Channel_GetDelay              (FMOD_CHANNEL *channel, FMOD_DELAYTYPE delaytype, unsigned int *delayhi, unsigned int *delaylo);
+FMOD_RESULT F_API FMOD_Channel_SetSpeakerMix         (FMOD_CHANNEL *channel, float frontleft, float frontright, float center, float lfe, float backleft, float backright, float sideleft, float sideright);
+FMOD_RESULT F_API FMOD_Channel_GetSpeakerMix         (FMOD_CHANNEL *channel, float *frontleft, float *frontright, float *center, float *lfe, float *backleft, float *backright, float *sideleft, float *sideright);
+FMOD_RESULT F_API FMOD_Channel_SetSpeakerLevels      (FMOD_CHANNEL *channel, FMOD_SPEAKER speaker, float *levels, int numlevels);
+FMOD_RESULT F_API FMOD_Channel_GetSpeakerLevels      (FMOD_CHANNEL *channel, FMOD_SPEAKER speaker, float *levels, int numlevels);
+FMOD_RESULT F_API FMOD_Channel_SetInputChannelMix    (FMOD_CHANNEL *channel, float *levels, int numlevels);
+FMOD_RESULT F_API FMOD_Channel_GetInputChannelMix    (FMOD_CHANNEL *channel, float *levels, int numlevels);
+FMOD_RESULT F_API FMOD_Channel_SetMute               (FMOD_CHANNEL *channel, FMOD_BOOL mute);
+FMOD_RESULT F_API FMOD_Channel_GetMute               (FMOD_CHANNEL *channel, FMOD_BOOL *mute);
+FMOD_RESULT F_API FMOD_Channel_SetPriority           (FMOD_CHANNEL *channel, int priority);
+FMOD_RESULT F_API FMOD_Channel_GetPriority           (FMOD_CHANNEL *channel, int *priority);
+FMOD_RESULT F_API FMOD_Channel_SetPosition           (FMOD_CHANNEL *channel, unsigned int position, FMOD_TIMEUNIT postype);
+FMOD_RESULT F_API FMOD_Channel_GetPosition           (FMOD_CHANNEL *channel, unsigned int *position, FMOD_TIMEUNIT postype);
+FMOD_RESULT F_API FMOD_Channel_SetReverbProperties   (FMOD_CHANNEL *channel, const FMOD_REVERB_CHANNELPROPERTIES *prop);
+FMOD_RESULT F_API FMOD_Channel_GetReverbProperties   (FMOD_CHANNEL *channel, FMOD_REVERB_CHANNELPROPERTIES *prop);
+FMOD_RESULT F_API FMOD_Channel_SetLowPassGain        (FMOD_CHANNEL *channel, float gain);
+FMOD_RESULT F_API FMOD_Channel_GetLowPassGain        (FMOD_CHANNEL *channel, float *gain);
+
+FMOD_RESULT F_API FMOD_Channel_SetChannelGroup       (FMOD_CHANNEL *channel, FMOD_CHANNELGROUP *channelgroup);
+FMOD_RESULT F_API FMOD_Channel_GetChannelGroup       (FMOD_CHANNEL *channel, FMOD_CHANNELGROUP **channelgroup);
+FMOD_RESULT F_API FMOD_Channel_SetCallback           (FMOD_CHANNEL *channel, FMOD_CHANNEL_CALLBACK callback);
+
+/*
+     3D functionality.
+*/
+
+FMOD_RESULT F_API FMOD_Channel_Set3DAttributes       (FMOD_CHANNEL *channel, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel);
+FMOD_RESULT F_API FMOD_Channel_Get3DAttributes       (FMOD_CHANNEL *channel, FMOD_VECTOR *pos, FMOD_VECTOR *vel);
+FMOD_RESULT F_API FMOD_Channel_Set3DMinMaxDistance   (FMOD_CHANNEL *channel, float mindistance, float maxdistance);
+FMOD_RESULT F_API FMOD_Channel_Get3DMinMaxDistance   (FMOD_CHANNEL *channel, float *mindistance, float *maxdistance);
+FMOD_RESULT F_API FMOD_Channel_Set3DConeSettings     (FMOD_CHANNEL *channel, float insideconeangle, float outsideconeangle, float outsidevolume);
+FMOD_RESULT F_API FMOD_Channel_Get3DConeSettings     (FMOD_CHANNEL *channel, float *insideconeangle, float *outsideconeangle, float *outsidevolume);
+FMOD_RESULT F_API FMOD_Channel_Set3DConeOrientation  (FMOD_CHANNEL *channel, FMOD_VECTOR *orientation);
+FMOD_RESULT F_API FMOD_Channel_Get3DConeOrientation  (FMOD_CHANNEL *channel, FMOD_VECTOR *orientation);
+FMOD_RESULT F_API FMOD_Channel_Set3DCustomRolloff    (FMOD_CHANNEL *channel, FMOD_VECTOR *points, int numpoints);
+FMOD_RESULT F_API FMOD_Channel_Get3DCustomRolloff    (FMOD_CHANNEL *channel, FMOD_VECTOR **points, int *numpoints);
+FMOD_RESULT F_API FMOD_Channel_Set3DOcclusion        (FMOD_CHANNEL *channel, float directocclusion, float reverbocclusion);
+FMOD_RESULT F_API FMOD_Channel_Get3DOcclusion        (FMOD_CHANNEL *channel, float *directocclusion, float *reverbocclusion);
+FMOD_RESULT F_API FMOD_Channel_Set3DSpread           (FMOD_CHANNEL *channel, float angle);
+FMOD_RESULT F_API FMOD_Channel_Get3DSpread           (FMOD_CHANNEL *channel, float *angle);
+FMOD_RESULT F_API FMOD_Channel_Set3DPanLevel         (FMOD_CHANNEL *channel, float level);
+FMOD_RESULT F_API FMOD_Channel_Get3DPanLevel         (FMOD_CHANNEL *channel, float *level);
+FMOD_RESULT F_API FMOD_Channel_Set3DDopplerLevel     (FMOD_CHANNEL *channel, float level);
+FMOD_RESULT F_API FMOD_Channel_Get3DDopplerLevel     (FMOD_CHANNEL *channel, float *level);
+FMOD_RESULT F_API FMOD_Channel_Set3DDistanceFilter   (FMOD_CHANNEL *channel, FMOD_BOOL custom, float customLevel, float centerFreq);
+FMOD_RESULT F_API FMOD_Channel_Get3DDistanceFilter   (FMOD_CHANNEL *channel, FMOD_BOOL *custom, float *customLevel, float *centerFreq);
+
+/*
+     DSP functionality only for channels playing sounds created with FMOD_SOFTWARE.
+*/
+
+FMOD_RESULT F_API FMOD_Channel_GetDSPHead            (FMOD_CHANNEL *channel, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_Channel_AddDSP                (FMOD_CHANNEL *channel, FMOD_DSP *dsp, FMOD_DSPCONNECTION **connection);
+
+/*
+     Information only functions.
+*/
+
+FMOD_RESULT F_API FMOD_Channel_IsPlaying             (FMOD_CHANNEL *channel, FMOD_BOOL *isplaying);
+FMOD_RESULT F_API FMOD_Channel_IsVirtual             (FMOD_CHANNEL *channel, FMOD_BOOL *isvirtual);
+FMOD_RESULT F_API FMOD_Channel_GetAudibility         (FMOD_CHANNEL *channel, float *audibility);
+FMOD_RESULT F_API FMOD_Channel_GetCurrentSound       (FMOD_CHANNEL *channel, FMOD_SOUND **sound);
+FMOD_RESULT F_API FMOD_Channel_GetSpectrum           (FMOD_CHANNEL *channel, float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+FMOD_RESULT F_API FMOD_Channel_GetWaveData           (FMOD_CHANNEL *channel, float *wavearray, int numvalues, int channeloffset);
+FMOD_RESULT F_API FMOD_Channel_GetIndex              (FMOD_CHANNEL *channel, int *index);
+
+/*
+     Functions also found in Sound class but here they can be set per channel.
+*/
+
+FMOD_RESULT F_API FMOD_Channel_SetMode               (FMOD_CHANNEL *channel, FMOD_MODE mode);
+FMOD_RESULT F_API FMOD_Channel_GetMode               (FMOD_CHANNEL *channel, FMOD_MODE *mode);
+FMOD_RESULT F_API FMOD_Channel_SetLoopCount          (FMOD_CHANNEL *channel, int loopcount);
+FMOD_RESULT F_API FMOD_Channel_GetLoopCount          (FMOD_CHANNEL *channel, int *loopcount);
+FMOD_RESULT F_API FMOD_Channel_SetLoopPoints         (FMOD_CHANNEL *channel, unsigned int loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int loopend, FMOD_TIMEUNIT loopendtype);
+FMOD_RESULT F_API FMOD_Channel_GetLoopPoints         (FMOD_CHANNEL *channel, unsigned int *loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int *loopend, FMOD_TIMEUNIT loopendtype);
+
+/*
+     Userdata set/get.                                                
+*/
+
+FMOD_RESULT F_API FMOD_Channel_SetUserData           (FMOD_CHANNEL *channel, void *userdata);
+FMOD_RESULT F_API FMOD_Channel_GetUserData           (FMOD_CHANNEL *channel, void **userdata);
+
+FMOD_RESULT F_API FMOD_Channel_GetMemoryInfo         (FMOD_CHANNEL *channel, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'ChannelGroup' API
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_Release          (FMOD_CHANNELGROUP *channelgroup);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetSystemObject  (FMOD_CHANNELGROUP *channelgroup, FMOD_SYSTEM **system);
+
+/*
+     Channelgroup scale values.  (changes attributes relative to the channels, doesn't overwrite them)
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_SetVolume        (FMOD_CHANNELGROUP *channelgroup, float volume);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetVolume        (FMOD_CHANNELGROUP *channelgroup, float *volume);
+FMOD_RESULT F_API FMOD_ChannelGroup_SetPitch         (FMOD_CHANNELGROUP *channelgroup, float pitch);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetPitch         (FMOD_CHANNELGROUP *channelgroup, float *pitch);
+FMOD_RESULT F_API FMOD_ChannelGroup_Set3DOcclusion   (FMOD_CHANNELGROUP *channelgroup, float directocclusion, float reverbocclusion);
+FMOD_RESULT F_API FMOD_ChannelGroup_Get3DOcclusion   (FMOD_CHANNELGROUP *channelgroup, float *directocclusion, float *reverbocclusion);
+FMOD_RESULT F_API FMOD_ChannelGroup_SetPaused        (FMOD_CHANNELGROUP *channelgroup, FMOD_BOOL paused);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetPaused        (FMOD_CHANNELGROUP *channelgroup, FMOD_BOOL *paused);
+FMOD_RESULT F_API FMOD_ChannelGroup_SetMute          (FMOD_CHANNELGROUP *channelgroup, FMOD_BOOL mute);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetMute          (FMOD_CHANNELGROUP *channelgroup, FMOD_BOOL *mute);
+
+/*
+     Channelgroup override values.  (recursively overwrites whatever settings the channels had)
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_Stop             (FMOD_CHANNELGROUP *channelgroup);
+FMOD_RESULT F_API FMOD_ChannelGroup_OverrideVolume   (FMOD_CHANNELGROUP *channelgroup, float volume);
+FMOD_RESULT F_API FMOD_ChannelGroup_OverrideFrequency(FMOD_CHANNELGROUP *channelgroup, float frequency);
+FMOD_RESULT F_API FMOD_ChannelGroup_OverridePan      (FMOD_CHANNELGROUP *channelgroup, float pan);
+FMOD_RESULT F_API FMOD_ChannelGroup_OverrideReverbProperties(FMOD_CHANNELGROUP *channelgroup, const FMOD_REVERB_CHANNELPROPERTIES *prop);
+FMOD_RESULT F_API FMOD_ChannelGroup_Override3DAttributes(FMOD_CHANNELGROUP *channelgroup, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel);
+FMOD_RESULT F_API FMOD_ChannelGroup_OverrideSpeakerMix(FMOD_CHANNELGROUP *channelgroup, float frontleft, float frontright, float center, float lfe, float backleft, float backright, float sideleft, float sideright);
+
+/*
+     Nested channel groups.
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_AddGroup         (FMOD_CHANNELGROUP *channelgroup, FMOD_CHANNELGROUP *group);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetNumGroups     (FMOD_CHANNELGROUP *channelgroup, int *numgroups);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetGroup         (FMOD_CHANNELGROUP *channelgroup, int index, FMOD_CHANNELGROUP **group);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetParentGroup   (FMOD_CHANNELGROUP *channelgroup, FMOD_CHANNELGROUP **group);
+
+/*
+     DSP functionality only for channel groups playing sounds created with FMOD_SOFTWARE.
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_GetDSPHead       (FMOD_CHANNELGROUP *channelgroup, FMOD_DSP **dsp);
+FMOD_RESULT F_API FMOD_ChannelGroup_AddDSP           (FMOD_CHANNELGROUP *channelgroup, FMOD_DSP *dsp, FMOD_DSPCONNECTION **connection);
+
+/*
+     Information only functions.
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_GetName          (FMOD_CHANNELGROUP *channelgroup, char *name, int namelen);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetNumChannels   (FMOD_CHANNELGROUP *channelgroup, int *numchannels);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetChannel       (FMOD_CHANNELGROUP *channelgroup, int index, FMOD_CHANNEL **channel);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetSpectrum      (FMOD_CHANNELGROUP *channelgroup, float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetWaveData      (FMOD_CHANNELGROUP *channelgroup, float *wavearray, int numvalues, int channeloffset);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_ChannelGroup_SetUserData      (FMOD_CHANNELGROUP *channelgroup, void *userdata);
+FMOD_RESULT F_API FMOD_ChannelGroup_GetUserData      (FMOD_CHANNELGROUP *channelgroup, void **userdata);
+
+FMOD_RESULT F_API FMOD_ChannelGroup_GetMemoryInfo    (FMOD_CHANNELGROUP *channelgroup, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'SoundGroup' API
+*/
+
+FMOD_RESULT F_API FMOD_SoundGroup_Release            (FMOD_SOUNDGROUP *soundgroup);
+FMOD_RESULT F_API FMOD_SoundGroup_GetSystemObject    (FMOD_SOUNDGROUP *soundgroup, FMOD_SYSTEM **system);
+
+/*
+     SoundGroup control functions.
+*/
+
+FMOD_RESULT F_API FMOD_SoundGroup_SetMaxAudible      (FMOD_SOUNDGROUP *soundgroup, int maxaudible);
+FMOD_RESULT F_API FMOD_SoundGroup_GetMaxAudible      (FMOD_SOUNDGROUP *soundgroup, int *maxaudible);
+FMOD_RESULT F_API FMOD_SoundGroup_SetMaxAudibleBehavior(FMOD_SOUNDGROUP *soundgroup, FMOD_SOUNDGROUP_BEHAVIOR behavior);
+FMOD_RESULT F_API FMOD_SoundGroup_GetMaxAudibleBehavior(FMOD_SOUNDGROUP *soundgroup, FMOD_SOUNDGROUP_BEHAVIOR *behavior);
+FMOD_RESULT F_API FMOD_SoundGroup_SetMuteFadeSpeed   (FMOD_SOUNDGROUP *soundgroup, float speed);
+FMOD_RESULT F_API FMOD_SoundGroup_GetMuteFadeSpeed   (FMOD_SOUNDGROUP *soundgroup, float *speed);
+FMOD_RESULT F_API FMOD_SoundGroup_SetVolume          (FMOD_SOUNDGROUP *soundgroup, float volume);
+FMOD_RESULT F_API FMOD_SoundGroup_GetVolume          (FMOD_SOUNDGROUP *soundgroup, float *volume);
+FMOD_RESULT F_API FMOD_SoundGroup_Stop               (FMOD_SOUNDGROUP *soundgroup);
+
+/*
+     Information only functions.
+*/
+
+FMOD_RESULT F_API FMOD_SoundGroup_GetName            (FMOD_SOUNDGROUP *soundgroup, char *name, int namelen);
+FMOD_RESULT F_API FMOD_SoundGroup_GetNumSounds       (FMOD_SOUNDGROUP *soundgroup, int *numsounds);
+FMOD_RESULT F_API FMOD_SoundGroup_GetSound           (FMOD_SOUNDGROUP *soundgroup, int index, FMOD_SOUND **sound);
+FMOD_RESULT F_API FMOD_SoundGroup_GetNumPlaying      (FMOD_SOUNDGROUP *soundgroup, int *numplaying);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_SoundGroup_SetUserData        (FMOD_SOUNDGROUP *soundgroup, void *userdata);
+FMOD_RESULT F_API FMOD_SoundGroup_GetUserData        (FMOD_SOUNDGROUP *soundgroup, void **userdata);
+
+FMOD_RESULT F_API FMOD_SoundGroup_GetMemoryInfo      (FMOD_SOUNDGROUP *soundgroup, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'DSP' API
+*/
+
+FMOD_RESULT F_API FMOD_DSP_Release                   (FMOD_DSP *dsp);
+FMOD_RESULT F_API FMOD_DSP_GetSystemObject           (FMOD_DSP *dsp, FMOD_SYSTEM **system);
+
+/*
+     Connection / disconnection / input and output enumeration.
+*/
+
+FMOD_RESULT F_API FMOD_DSP_AddInput                  (FMOD_DSP *dsp, FMOD_DSP *target, FMOD_DSPCONNECTION **connection);
+FMOD_RESULT F_API FMOD_DSP_DisconnectFrom            (FMOD_DSP *dsp, FMOD_DSP *target);
+FMOD_RESULT F_API FMOD_DSP_DisconnectAll             (FMOD_DSP *dsp, FMOD_BOOL inputs, FMOD_BOOL outputs);
+FMOD_RESULT F_API FMOD_DSP_Remove                    (FMOD_DSP *dsp);
+FMOD_RESULT F_API FMOD_DSP_GetNumInputs              (FMOD_DSP *dsp, int *numinputs);
+FMOD_RESULT F_API FMOD_DSP_GetNumOutputs             (FMOD_DSP *dsp, int *numoutputs);
+FMOD_RESULT F_API FMOD_DSP_GetInput                  (FMOD_DSP *dsp, int index, FMOD_DSP **input, FMOD_DSPCONNECTION **inputconnection);
+FMOD_RESULT F_API FMOD_DSP_GetOutput                 (FMOD_DSP *dsp, int index, FMOD_DSP **output, FMOD_DSPCONNECTION **outputconnection);
+
+/*
+     DSP unit control.
+*/
+
+FMOD_RESULT F_API FMOD_DSP_SetActive                 (FMOD_DSP *dsp, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_DSP_GetActive                 (FMOD_DSP *dsp, FMOD_BOOL *active);
+FMOD_RESULT F_API FMOD_DSP_SetBypass                 (FMOD_DSP *dsp, FMOD_BOOL bypass);
+FMOD_RESULT F_API FMOD_DSP_GetBypass                 (FMOD_DSP *dsp, FMOD_BOOL *bypass);
+FMOD_RESULT F_API FMOD_DSP_SetSpeakerActive          (FMOD_DSP *dsp, FMOD_SPEAKER speaker, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_DSP_GetSpeakerActive          (FMOD_DSP *dsp, FMOD_SPEAKER speaker, FMOD_BOOL *active);
+FMOD_RESULT F_API FMOD_DSP_Reset                     (FMOD_DSP *dsp);
+
+/*
+     DSP parameter control.
+*/
+
+FMOD_RESULT F_API FMOD_DSP_SetParameter              (FMOD_DSP *dsp, int index, float value);
+FMOD_RESULT F_API FMOD_DSP_GetParameter              (FMOD_DSP *dsp, int index, float *value, char *valuestr, int valuestrlen);
+FMOD_RESULT F_API FMOD_DSP_GetNumParameters          (FMOD_DSP *dsp, int *numparams);
+FMOD_RESULT F_API FMOD_DSP_GetParameterInfo          (FMOD_DSP *dsp, int index, char *name, char *label, char *description, int descriptionlen, float *min, float *max);
+FMOD_RESULT F_API FMOD_DSP_ShowConfigDialog          (FMOD_DSP *dsp, void *hwnd, FMOD_BOOL show);
+
+/*
+     DSP attributes.        
+*/
+
+FMOD_RESULT F_API FMOD_DSP_GetInfo                   (FMOD_DSP *dsp, char *name, unsigned int *version, int *channels, int *configwidth, int *configheight);
+FMOD_RESULT F_API FMOD_DSP_GetType                   (FMOD_DSP *dsp, FMOD_DSP_TYPE *type);
+FMOD_RESULT F_API FMOD_DSP_SetDefaults               (FMOD_DSP *dsp, float frequency, float volume, float pan, int priority);
+FMOD_RESULT F_API FMOD_DSP_GetDefaults               (FMOD_DSP *dsp, float *frequency, float *volume, float *pan, int *priority);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_DSP_SetUserData               (FMOD_DSP *dsp, void *userdata);
+FMOD_RESULT F_API FMOD_DSP_GetUserData               (FMOD_DSP *dsp, void **userdata);
+
+FMOD_RESULT F_API FMOD_DSP_GetMemoryInfo             (FMOD_DSP *dsp, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'DSPConnection' API
+*/
+
+FMOD_RESULT F_API FMOD_DSPConnection_GetInput        (FMOD_DSPCONNECTION *dspconnection, FMOD_DSP **input);
+FMOD_RESULT F_API FMOD_DSPConnection_GetOutput       (FMOD_DSPCONNECTION *dspconnection, FMOD_DSP **output);
+FMOD_RESULT F_API FMOD_DSPConnection_SetMix          (FMOD_DSPCONNECTION *dspconnection, float volume);
+FMOD_RESULT F_API FMOD_DSPConnection_GetMix          (FMOD_DSPCONNECTION *dspconnection, float *volume);
+FMOD_RESULT F_API FMOD_DSPConnection_SetLevels       (FMOD_DSPCONNECTION *dspconnection, FMOD_SPEAKER speaker, float *levels, int numlevels);
+FMOD_RESULT F_API FMOD_DSPConnection_GetLevels       (FMOD_DSPCONNECTION *dspconnection, FMOD_SPEAKER speaker, float *levels, int numlevels);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_DSPConnection_SetUserData     (FMOD_DSPCONNECTION *dspconnection, void *userdata);
+FMOD_RESULT F_API FMOD_DSPConnection_GetUserData     (FMOD_DSPCONNECTION *dspconnection, void **userdata);
+
+FMOD_RESULT F_API FMOD_DSPConnection_GetMemoryInfo   (FMOD_DSPCONNECTION *dspconnection, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'Geometry' API
+*/
+
+FMOD_RESULT F_API FMOD_Geometry_Release              (FMOD_GEOMETRY *geometry);
+
+/*
+     Polygon manipulation.
+*/
+
+FMOD_RESULT F_API FMOD_Geometry_AddPolygon           (FMOD_GEOMETRY *geometry, float directocclusion, float reverbocclusion, FMOD_BOOL doublesided, int numvertices, const FMOD_VECTOR *vertices, int *polygonindex);
+FMOD_RESULT F_API FMOD_Geometry_GetNumPolygons       (FMOD_GEOMETRY *geometry, int *numpolygons);
+FMOD_RESULT F_API FMOD_Geometry_GetMaxPolygons       (FMOD_GEOMETRY *geometry, int *maxpolygons, int *maxvertices);
+FMOD_RESULT F_API FMOD_Geometry_GetPolygonNumVertices(FMOD_GEOMETRY *geometry, int index, int *numvertices);
+FMOD_RESULT F_API FMOD_Geometry_SetPolygonVertex     (FMOD_GEOMETRY *geometry, int index, int vertexindex, const FMOD_VECTOR *vertex);
+FMOD_RESULT F_API FMOD_Geometry_GetPolygonVertex     (FMOD_GEOMETRY *geometry, int index, int vertexindex, FMOD_VECTOR *vertex);
+FMOD_RESULT F_API FMOD_Geometry_SetPolygonAttributes (FMOD_GEOMETRY *geometry, int index, float directocclusion, float reverbocclusion, FMOD_BOOL doublesided);
+FMOD_RESULT F_API FMOD_Geometry_GetPolygonAttributes (FMOD_GEOMETRY *geometry, int index, float *directocclusion, float *reverbocclusion, FMOD_BOOL *doublesided);
+
+/*
+     Object manipulation.
+*/
+
+FMOD_RESULT F_API FMOD_Geometry_SetActive            (FMOD_GEOMETRY *geometry, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_Geometry_GetActive            (FMOD_GEOMETRY *geometry, FMOD_BOOL *active);
+FMOD_RESULT F_API FMOD_Geometry_SetRotation          (FMOD_GEOMETRY *geometry, const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+FMOD_RESULT F_API FMOD_Geometry_GetRotation          (FMOD_GEOMETRY *geometry, FMOD_VECTOR *forward, FMOD_VECTOR *up);
+FMOD_RESULT F_API FMOD_Geometry_SetPosition          (FMOD_GEOMETRY *geometry, const FMOD_VECTOR *position);
+FMOD_RESULT F_API FMOD_Geometry_GetPosition          (FMOD_GEOMETRY *geometry, FMOD_VECTOR *position);
+FMOD_RESULT F_API FMOD_Geometry_SetScale             (FMOD_GEOMETRY *geometry, const FMOD_VECTOR *scale);
+FMOD_RESULT F_API FMOD_Geometry_GetScale             (FMOD_GEOMETRY *geometry, FMOD_VECTOR *scale);
+FMOD_RESULT F_API FMOD_Geometry_Save                 (FMOD_GEOMETRY *geometry, void *data, int *datasize);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_Geometry_SetUserData          (FMOD_GEOMETRY *geometry, void *userdata);
+FMOD_RESULT F_API FMOD_Geometry_GetUserData          (FMOD_GEOMETRY *geometry, void **userdata);
+
+FMOD_RESULT F_API FMOD_Geometry_GetMemoryInfo        (FMOD_GEOMETRY *geometry, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+/*
+    'Reverb' API
+*/
+
+FMOD_RESULT F_API FMOD_Reverb_Release                (FMOD_REVERB *reverb);
+
+/*
+     Reverb manipulation.
+*/
+
+FMOD_RESULT F_API FMOD_Reverb_Set3DAttributes        (FMOD_REVERB *reverb, const FMOD_VECTOR *position, float mindistance, float maxdistance);
+FMOD_RESULT F_API FMOD_Reverb_Get3DAttributes        (FMOD_REVERB *reverb, FMOD_VECTOR *position, float *mindistance, float *maxdistance);
+FMOD_RESULT F_API FMOD_Reverb_SetProperties          (FMOD_REVERB *reverb, const FMOD_REVERB_PROPERTIES *properties);
+FMOD_RESULT F_API FMOD_Reverb_GetProperties          (FMOD_REVERB *reverb, FMOD_REVERB_PROPERTIES *properties);
+FMOD_RESULT F_API FMOD_Reverb_SetActive              (FMOD_REVERB *reverb, FMOD_BOOL active);
+FMOD_RESULT F_API FMOD_Reverb_GetActive              (FMOD_REVERB *reverb, FMOD_BOOL *active);
+
+/*
+     Userdata set/get.
+*/
+
+FMOD_RESULT F_API FMOD_Reverb_SetUserData            (FMOD_REVERB *reverb, void *userdata);
+FMOD_RESULT F_API FMOD_Reverb_GetUserData            (FMOD_REVERB *reverb, void **userdata);
+
+FMOD_RESULT F_API FMOD_Reverb_GetMemoryInfo          (FMOD_REVERB *reverb, unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/moaicore/fmodinc/fmod.hpp
+++ b/src/moaicore/fmodinc/fmod.hpp
@@ -1,0 +1,608 @@
+/* ========================================================================================== */
+/* FMOD Ex - C++ header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.      */
+/*                                                                                            */
+/* Use this header in conjunction with fmod.h (which contains all the constants / callbacks)  */
+/* to develop using C++ classes.                                                              */
+/* ========================================================================================== */
+
+#ifndef _FMOD_HPP
+#define _FMOD_HPP
+
+#include "fmod.h"
+
+/*
+    Constant and defines
+*/
+
+/*
+    FMOD Namespace
+*/
+namespace FMOD
+{
+    class System;
+    class Sound;
+    class Channel;
+    class ChannelGroup;
+    class SoundGroup;
+    class Reverb;
+    class DSP;
+    class DSPConnection;
+    class Geometry;
+
+    /*
+        FMOD global system functions (optional).
+    */
+    inline FMOD_RESULT Memory_Initialize(void *poolmem, int poollen, FMOD_MEMORY_ALLOCCALLBACK useralloc, FMOD_MEMORY_REALLOCCALLBACK userrealloc, FMOD_MEMORY_FREECALLBACK userfree, FMOD_MEMORY_TYPE memtypeflags = FMOD_MEMORY_ALL) { return FMOD_Memory_Initialize(poolmem, poollen, useralloc, userrealloc, userfree, memtypeflags); }
+    inline FMOD_RESULT Memory_GetStats  (int *currentalloced, int *maxalloced, bool blocking = true) { return FMOD_Memory_GetStats(currentalloced, maxalloced, blocking); }
+    inline FMOD_RESULT Debug_SetLevel(FMOD_DEBUGLEVEL level)  { return FMOD_Debug_SetLevel(level); }
+    inline FMOD_RESULT Debug_GetLevel(FMOD_DEBUGLEVEL *level) { return FMOD_Debug_GetLevel(level); }
+    inline FMOD_RESULT File_SetDiskBusy(int busy) { return FMOD_File_SetDiskBusy(busy); }
+    inline FMOD_RESULT File_GetDiskBusy(int *busy) { return FMOD_File_GetDiskBusy(busy); }
+
+    /*
+        FMOD System factory functions.
+    */
+    inline FMOD_RESULT System_Create(System **system) { return FMOD_System_Create((FMOD_SYSTEM **)system); }
+
+    /*
+       'System' API
+    */
+
+    class System
+    {
+      private:
+
+        System();   /* Constructor made private so user cannot statically instance a System class.  
+                       System_Create must be used. */
+      public:
+
+        FMOD_RESULT F_API release                ();
+                                                 
+        // Pre-init functions.
+        FMOD_RESULT F_API setOutput              (FMOD_OUTPUTTYPE output);
+        FMOD_RESULT F_API getOutput              (FMOD_OUTPUTTYPE *output);
+        FMOD_RESULT F_API getNumDrivers          (int *numdrivers);
+        FMOD_RESULT F_API getDriverInfo          (int id, char *name, int namelen, FMOD_GUID *guid);
+        FMOD_RESULT F_API getDriverInfoW         (int id, short *name, int namelen, FMOD_GUID *guid);
+        FMOD_RESULT F_API getDriverCaps          (int id, FMOD_CAPS *caps, int *controlpaneloutputrate, FMOD_SPEAKERMODE *controlpanelspeakermode);
+        FMOD_RESULT F_API setDriver              (int driver);
+        FMOD_RESULT F_API getDriver              (int *driver);
+        FMOD_RESULT F_API setHardwareChannels    (int numhardwarechannels);
+        FMOD_RESULT F_API setSoftwareChannels    (int numsoftwarechannels);
+        FMOD_RESULT F_API getSoftwareChannels    (int *numsoftwarechannels);
+        FMOD_RESULT F_API setSoftwareFormat      (int samplerate, FMOD_SOUND_FORMAT format, int numoutputchannels, int maxinputchannels, FMOD_DSP_RESAMPLER resamplemethod);
+        FMOD_RESULT F_API getSoftwareFormat      (int *samplerate, FMOD_SOUND_FORMAT *format, int *numoutputchannels, int *maxinputchannels, FMOD_DSP_RESAMPLER *resamplemethod, int *bits);
+        FMOD_RESULT F_API setDSPBufferSize       (unsigned int bufferlength, int numbuffers);
+        FMOD_RESULT F_API getDSPBufferSize       (unsigned int *bufferlength, int *numbuffers);
+        FMOD_RESULT F_API setFileSystem          (FMOD_FILE_OPENCALLBACK useropen, FMOD_FILE_CLOSECALLBACK userclose, FMOD_FILE_READCALLBACK userread, FMOD_FILE_SEEKCALLBACK userseek, FMOD_FILE_ASYNCREADCALLBACK userasyncread, FMOD_FILE_ASYNCCANCELCALLBACK userasynccancel, int blockalign);
+        FMOD_RESULT F_API attachFileSystem       (FMOD_FILE_OPENCALLBACK useropen, FMOD_FILE_CLOSECALLBACK userclose, FMOD_FILE_READCALLBACK userread, FMOD_FILE_SEEKCALLBACK userseek);
+        FMOD_RESULT F_API setAdvancedSettings    (FMOD_ADVANCEDSETTINGS *settings);
+        FMOD_RESULT F_API getAdvancedSettings    (FMOD_ADVANCEDSETTINGS *settings);
+        FMOD_RESULT F_API setSpeakerMode         (FMOD_SPEAKERMODE speakermode);
+        FMOD_RESULT F_API getSpeakerMode         (FMOD_SPEAKERMODE *speakermode);
+        FMOD_RESULT F_API setCallback            (FMOD_SYSTEM_CALLBACK callback);
+                                                
+        // Plug-in support                       
+        FMOD_RESULT F_API setPluginPath          (const char *path);
+        FMOD_RESULT F_API loadPlugin             (const char *filename, unsigned int *handle, unsigned int priority = 0);
+        FMOD_RESULT F_API unloadPlugin           (unsigned int handle);
+        FMOD_RESULT F_API getNumPlugins          (FMOD_PLUGINTYPE plugintype, int *numplugins);
+        FMOD_RESULT F_API getPluginHandle        (FMOD_PLUGINTYPE plugintype, int index, unsigned int *handle);
+        FMOD_RESULT F_API getPluginInfo          (unsigned int handle, FMOD_PLUGINTYPE *plugintype, char *name, int namelen, unsigned int *version);
+        FMOD_RESULT F_API setOutputByPlugin      (unsigned int handle);
+        FMOD_RESULT F_API getOutputByPlugin      (unsigned int *handle);
+        FMOD_RESULT F_API createDSPByPlugin      (unsigned int handle, DSP **dsp);
+        FMOD_RESULT F_API registerCodec          (FMOD_CODEC_DESCRIPTION *description, unsigned int *handle, unsigned int priority = 0);
+        FMOD_RESULT F_API registerDSP            (FMOD_DSP_DESCRIPTION *description, unsigned int *handle);
+                                                 
+        // Init/Close                            
+        FMOD_RESULT F_API init                   (int maxchannels, FMOD_INITFLAGS flags, void *extradriverdata);
+        FMOD_RESULT F_API close                  ();
+                                                 
+        // General post-init system functions    
+        FMOD_RESULT F_API update                 ();        /* IMPORTANT! CALL THIS ONCE PER FRAME! */
+                                                 
+        FMOD_RESULT F_API set3DSettings          (float dopplerscale, float distancefactor, float rolloffscale);
+        FMOD_RESULT F_API get3DSettings          (float *dopplerscale, float *distancefactor, float *rolloffscale);
+        FMOD_RESULT F_API set3DNumListeners      (int numlisteners);
+        FMOD_RESULT F_API get3DNumListeners      (int *numlisteners);
+        FMOD_RESULT F_API set3DListenerAttributes(int listener, const FMOD_VECTOR *pos, const FMOD_VECTOR *vel, const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+        FMOD_RESULT F_API get3DListenerAttributes(int listener, FMOD_VECTOR *pos, FMOD_VECTOR *vel, FMOD_VECTOR *forward, FMOD_VECTOR *up);
+        FMOD_RESULT F_API set3DRolloffCallback   (FMOD_3D_ROLLOFFCALLBACK callback);
+        FMOD_RESULT F_API set3DSpeakerPosition   (FMOD_SPEAKER speaker, float x, float y, bool active);
+        FMOD_RESULT F_API get3DSpeakerPosition   (FMOD_SPEAKER speaker, float *x, float *y, bool *active);
+
+        FMOD_RESULT F_API setStreamBufferSize    (unsigned int filebuffersize, FMOD_TIMEUNIT filebuffersizetype);
+        FMOD_RESULT F_API getStreamBufferSize    (unsigned int *filebuffersize, FMOD_TIMEUNIT *filebuffersizetype);
+                                                
+        // System information functions.        
+        FMOD_RESULT F_API getVersion             (unsigned int *version);
+        FMOD_RESULT F_API getOutputHandle        (void **handle);
+        FMOD_RESULT F_API getChannelsPlaying     (int *channels);
+        FMOD_RESULT F_API getHardwareChannels    (int *numhardwarechannels);
+        FMOD_RESULT F_API getCPUUsage            (float *dsp, float *stream, float *geometry, float *update, float *total);
+        FMOD_RESULT F_API getSoundRAM            (int *currentalloced, int *maxalloced, int *total);
+        FMOD_RESULT F_API getNumCDROMDrives      (int *numdrives);
+        FMOD_RESULT F_API getCDROMDriveName      (int drive, char *drivename, int drivenamelen, char *scsiname, int scsinamelen, char *devicename, int devicenamelen);
+        FMOD_RESULT F_API getSpectrum            (float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+        FMOD_RESULT F_API getWaveData            (float *wavearray, int numvalues, int channeloffset);
+                                                
+        // Sound/DSP/Channel/FX creation and retrieval.       
+        FMOD_RESULT F_API createSound            (const char *name_or_data, FMOD_MODE mode, FMOD_CREATESOUNDEXINFO *exinfo, Sound **sound);
+        FMOD_RESULT F_API createStream           (const char *name_or_data, FMOD_MODE mode, FMOD_CREATESOUNDEXINFO *exinfo, Sound **sound);
+        FMOD_RESULT F_API createDSP              (FMOD_DSP_DESCRIPTION *description, DSP **dsp);
+        FMOD_RESULT F_API createDSPByType        (FMOD_DSP_TYPE type, DSP **dsp);
+        FMOD_RESULT F_API createChannelGroup     (const char *name, ChannelGroup **channelgroup);
+        FMOD_RESULT F_API createSoundGroup       (const char *name, SoundGroup **soundgroup);
+        FMOD_RESULT F_API createReverb           (Reverb **reverb); 
+                                                
+        FMOD_RESULT F_API playSound              (FMOD_CHANNELINDEX channelid, Sound *sound, bool paused, Channel **channel);
+        FMOD_RESULT F_API playDSP                (FMOD_CHANNELINDEX channelid, DSP *dsp, bool paused, Channel **channel);
+        FMOD_RESULT F_API getChannel             (int channelid, Channel **channel);
+        FMOD_RESULT F_API getMasterChannelGroup  (ChannelGroup **channelgroup);
+        FMOD_RESULT F_API getMasterSoundGroup    (SoundGroup **soundgroup);
+                                              
+        // Reverb API                           
+        FMOD_RESULT F_API setReverbProperties    (const FMOD_REVERB_PROPERTIES *prop);
+        FMOD_RESULT F_API getReverbProperties    (FMOD_REVERB_PROPERTIES *prop);
+        FMOD_RESULT F_API setReverbAmbientProperties(FMOD_REVERB_PROPERTIES *prop);
+        FMOD_RESULT F_API getReverbAmbientProperties(FMOD_REVERB_PROPERTIES *prop);
+                                                 
+        // System level DSP access.
+        FMOD_RESULT F_API getDSPHead             (DSP **dsp);
+        FMOD_RESULT F_API addDSP                 (DSP *dsp, DSPConnection **connection);
+        FMOD_RESULT F_API lockDSP                ();
+        FMOD_RESULT F_API unlockDSP              ();
+        FMOD_RESULT F_API getDSPClock            (unsigned int *hi, unsigned int *lo);
+                                               
+        // Recording API.
+        FMOD_RESULT F_API getRecordNumDrivers    (int *numdrivers);
+        FMOD_RESULT F_API getRecordDriverInfo    (int id, char *name, int namelen, FMOD_GUID *guid);
+        FMOD_RESULT F_API getRecordDriverInfoW   (int id, short *name, int namelen, FMOD_GUID *guid);
+        FMOD_RESULT F_API getRecordDriverCaps    (int id, FMOD_CAPS *caps, int *minfrequency, int *maxfrequency);
+        FMOD_RESULT F_API getRecordPosition      (int id, unsigned int *position);  
+
+        FMOD_RESULT F_API recordStart            (int id, Sound *sound, bool loop);
+        FMOD_RESULT F_API recordStop             (int id);
+        FMOD_RESULT F_API isRecording            (int id, bool *recording);
+
+        // Geometry API.
+        FMOD_RESULT F_API createGeometry         (int maxpolygons, int maxvertices, Geometry **geometry);
+        FMOD_RESULT F_API setGeometrySettings    (float maxworldsize);
+        FMOD_RESULT F_API getGeometrySettings    (float *maxworldsize);
+        FMOD_RESULT F_API loadGeometry           (const void *data, int datasize, Geometry **geometry);
+        FMOD_RESULT F_API getGeometryOcclusion   (const FMOD_VECTOR *listener, const FMOD_VECTOR *source, float *direct, float *reverb);
+
+        // Network functions.
+        FMOD_RESULT F_API setNetworkProxy        (const char *proxy);
+        FMOD_RESULT F_API getNetworkProxy        (char *proxy, int proxylen);
+        FMOD_RESULT F_API setNetworkTimeout      (int timeout);
+        FMOD_RESULT F_API getNetworkTimeout      (int *timeout);
+                                              
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+        'Sound' API
+    */
+    class Sound
+    {
+      private:
+
+        Sound();   /* Constructor made private so user cannot statically instance a Sound class.
+                      Appropriate Sound creation or retrieval function must be used. */
+      public:
+
+        FMOD_RESULT F_API release                ();
+        FMOD_RESULT F_API getSystemObject        (System **system);
+
+        // Standard sound manipulation functions.                                                
+        FMOD_RESULT F_API lock                   (unsigned int offset, unsigned int length, void **ptr1, void **ptr2, unsigned int *len1, unsigned int *len2);
+        FMOD_RESULT F_API unlock                 (void *ptr1, void *ptr2, unsigned int len1, unsigned int len2);
+        FMOD_RESULT F_API setDefaults            (float frequency, float volume, float pan, int priority);
+        FMOD_RESULT F_API getDefaults            (float *frequency, float *volume, float *pan,  int *priority);
+        FMOD_RESULT F_API setVariations          (float frequencyvar, float volumevar, float panvar);
+        FMOD_RESULT F_API getVariations          (float *frequencyvar, float *volumevar, float *panvar);
+        FMOD_RESULT F_API set3DMinMaxDistance    (float min, float max);
+        FMOD_RESULT F_API get3DMinMaxDistance    (float *min, float *max);
+        FMOD_RESULT F_API set3DConeSettings      (float insideconeangle, float outsideconeangle, float outsidevolume);
+        FMOD_RESULT F_API get3DConeSettings      (float *insideconeangle, float *outsideconeangle, float *outsidevolume);
+        FMOD_RESULT F_API set3DCustomRolloff     (FMOD_VECTOR *points, int numpoints);
+        FMOD_RESULT F_API get3DCustomRolloff     (FMOD_VECTOR **points, int *numpoints);
+        FMOD_RESULT F_API setSubSound            (int index, Sound *subsound);
+        FMOD_RESULT F_API getSubSound            (int index, Sound **subsound);
+        FMOD_RESULT F_API setSubSoundSentence    (int *subsoundlist, int numsubsounds);
+        FMOD_RESULT F_API getName                (char *name, int namelen);
+        FMOD_RESULT F_API getLength              (unsigned int *length, FMOD_TIMEUNIT lengthtype);
+        FMOD_RESULT F_API getFormat              (FMOD_SOUND_TYPE *type, FMOD_SOUND_FORMAT *format, int *channels, int *bits);
+        FMOD_RESULT F_API getNumSubSounds        (int *numsubsounds);
+        FMOD_RESULT F_API getNumTags             (int *numtags, int *numtagsupdated);
+        FMOD_RESULT F_API getTag                 (const char *name, int index, FMOD_TAG *tag);
+        FMOD_RESULT F_API getOpenState           (FMOD_OPENSTATE *openstate, unsigned int *percentbuffered, bool *starving, bool *diskbusy);
+        FMOD_RESULT F_API readData               (void *buffer, unsigned int lenbytes, unsigned int *read);
+        FMOD_RESULT F_API seekData               (unsigned int pcm);
+
+        FMOD_RESULT F_API setSoundGroup          (SoundGroup *soundgroup);
+        FMOD_RESULT F_API getSoundGroup          (SoundGroup **soundgroup);
+
+        // Synchronization point API.  These points can come from markers embedded in wav files, and can also generate channel callbacks.        
+        FMOD_RESULT F_API getNumSyncPoints       (int *numsyncpoints);
+        FMOD_RESULT F_API getSyncPoint           (int index, FMOD_SYNCPOINT **point);
+        FMOD_RESULT F_API getSyncPointInfo       (FMOD_SYNCPOINT *point, char *name, int namelen, unsigned int *offset, FMOD_TIMEUNIT offsettype);
+        FMOD_RESULT F_API addSyncPoint           (unsigned int offset, FMOD_TIMEUNIT offsettype, const char *name, FMOD_SYNCPOINT **point);
+        FMOD_RESULT F_API deleteSyncPoint        (FMOD_SYNCPOINT *point);
+
+        // Functions also in Channel class but here they are the 'default' to save having to change it in Channel all the time.
+        FMOD_RESULT F_API setMode                (FMOD_MODE mode);
+        FMOD_RESULT F_API getMode                (FMOD_MODE *mode);
+        FMOD_RESULT F_API setLoopCount           (int loopcount);
+        FMOD_RESULT F_API getLoopCount           (int *loopcount);
+        FMOD_RESULT F_API setLoopPoints          (unsigned int loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int loopend, FMOD_TIMEUNIT loopendtype);
+        FMOD_RESULT F_API getLoopPoints          (unsigned int *loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int *loopend, FMOD_TIMEUNIT loopendtype);
+
+        // For MOD/S3M/XM/IT/MID sequenced formats only.
+        FMOD_RESULT F_API getMusicNumChannels    (int *numchannels);
+        FMOD_RESULT F_API setMusicChannelVolume  (int channel, float volume);
+        FMOD_RESULT F_API getMusicChannelVolume  (int channel, float *volume);
+        FMOD_RESULT F_API setMusicSpeed          (float speed);
+        FMOD_RESULT F_API getMusicSpeed          (float *speed);
+                            
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+        'Channel' API.
+    */ 
+    class Channel
+    {
+      private:
+
+        Channel();   /* Constructor made private so user cannot statically instance a Channel class.  
+                        Appropriate Channel creation or retrieval function must be used. */
+      public:
+
+        FMOD_RESULT F_API getSystemObject        (System **system);
+
+        FMOD_RESULT F_API stop                   ();
+        FMOD_RESULT F_API setPaused              (bool paused);
+        FMOD_RESULT F_API getPaused              (bool *paused);
+        FMOD_RESULT F_API setVolume              (float volume);
+        FMOD_RESULT F_API getVolume              (float *volume);
+        FMOD_RESULT F_API setFrequency           (float frequency);
+        FMOD_RESULT F_API getFrequency           (float *frequency);
+        FMOD_RESULT F_API setPan                 (float pan);
+        FMOD_RESULT F_API getPan                 (float *pan);
+        FMOD_RESULT F_API setDelay               (FMOD_DELAYTYPE delaytype, unsigned int delayhi, unsigned int delaylo);
+        FMOD_RESULT F_API getDelay               (FMOD_DELAYTYPE delaytype, unsigned int *delayhi, unsigned int *delaylo);
+        FMOD_RESULT F_API setSpeakerMix          (float frontleft, float frontright, float center, float lfe, float backleft, float backright, float sideleft, float sideright);
+        FMOD_RESULT F_API getSpeakerMix          (float *frontleft, float *frontright, float *center, float *lfe, float *backleft, float *backright, float *sideleft, float *sideright);
+        FMOD_RESULT F_API setSpeakerLevels       (FMOD_SPEAKER speaker, float *levels, int numlevels);
+        FMOD_RESULT F_API getSpeakerLevels       (FMOD_SPEAKER speaker, float *levels, int numlevels);
+        FMOD_RESULT F_API setInputChannelMix     (float *levels, int numlevels);
+        FMOD_RESULT F_API getInputChannelMix     (float *levels, int numlevels);
+        FMOD_RESULT F_API setMute                (bool mute);
+        FMOD_RESULT F_API getMute                (bool *mute);
+        FMOD_RESULT F_API setPriority            (int priority);
+        FMOD_RESULT F_API getPriority            (int *priority);
+        FMOD_RESULT F_API setPosition            (unsigned int position, FMOD_TIMEUNIT postype);
+        FMOD_RESULT F_API getPosition            (unsigned int *position, FMOD_TIMEUNIT postype);
+        FMOD_RESULT F_API setReverbProperties    (const FMOD_REVERB_CHANNELPROPERTIES *prop);
+        FMOD_RESULT F_API getReverbProperties    (FMOD_REVERB_CHANNELPROPERTIES *prop);
+        FMOD_RESULT F_API setLowPassGain         (float gain);
+        FMOD_RESULT F_API getLowPassGain         (float *gain);
+
+        FMOD_RESULT F_API setChannelGroup        (ChannelGroup *channelgroup);
+        FMOD_RESULT F_API getChannelGroup        (ChannelGroup **channelgroup);
+        FMOD_RESULT F_API setCallback            (FMOD_CHANNEL_CALLBACK callback);
+
+        // 3D functionality.
+        FMOD_RESULT F_API set3DAttributes        (const FMOD_VECTOR *pos, const FMOD_VECTOR *vel);
+        FMOD_RESULT F_API get3DAttributes        (FMOD_VECTOR *pos, FMOD_VECTOR *vel);
+        FMOD_RESULT F_API set3DMinMaxDistance    (float mindistance, float maxdistance);
+        FMOD_RESULT F_API get3DMinMaxDistance    (float *mindistance, float *maxdistance);
+        FMOD_RESULT F_API set3DConeSettings      (float insideconeangle, float outsideconeangle, float outsidevolume);
+        FMOD_RESULT F_API get3DConeSettings      (float *insideconeangle, float *outsideconeangle, float *outsidevolume);
+        FMOD_RESULT F_API set3DConeOrientation   (FMOD_VECTOR *orientation);
+        FMOD_RESULT F_API get3DConeOrientation   (FMOD_VECTOR *orientation);
+        FMOD_RESULT F_API set3DCustomRolloff     (FMOD_VECTOR *points, int numpoints);
+        FMOD_RESULT F_API get3DCustomRolloff     (FMOD_VECTOR **points, int *numpoints);
+        FMOD_RESULT F_API set3DOcclusion         (float directocclusion, float reverbocclusion);
+        FMOD_RESULT F_API get3DOcclusion         (float *directocclusion, float *reverbocclusion);
+        FMOD_RESULT F_API set3DSpread            (float angle);
+        FMOD_RESULT F_API get3DSpread            (float *angle);
+        FMOD_RESULT F_API set3DPanLevel          (float level);
+        FMOD_RESULT F_API get3DPanLevel          (float *level);
+        FMOD_RESULT F_API set3DDopplerLevel      (float level);
+        FMOD_RESULT F_API get3DDopplerLevel      (float *level);
+        FMOD_RESULT F_API set3DDistanceFilter    (bool custom, float customLevel, float centerFreq);
+        FMOD_RESULT F_API get3DDistanceFilter    (bool *custom, float *customLevel, float *centerFreq);
+
+        // DSP functionality only for channels playing sounds created with FMOD_SOFTWARE.
+        FMOD_RESULT F_API getDSPHead             (DSP **dsp);
+        FMOD_RESULT F_API addDSP                 (DSP *dsp, DSPConnection **connection);
+
+        // Information only functions.
+        FMOD_RESULT F_API isPlaying              (bool *isplaying);
+        FMOD_RESULT F_API isVirtual              (bool *isvirtual);
+        FMOD_RESULT F_API getAudibility          (float *audibility);
+        FMOD_RESULT F_API getCurrentSound        (Sound **sound);
+        FMOD_RESULT F_API getSpectrum            (float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+        FMOD_RESULT F_API getWaveData            (float *wavearray, int numvalues, int channeloffset);
+        FMOD_RESULT F_API getIndex               (int *index);
+                                                
+        // Functions also found in Sound class but here they can be set per channel.
+        FMOD_RESULT F_API setMode                (FMOD_MODE mode);
+        FMOD_RESULT F_API getMode                (FMOD_MODE *mode);
+        FMOD_RESULT F_API setLoopCount           (int loopcount);
+        FMOD_RESULT F_API getLoopCount           (int *loopcount);
+        FMOD_RESULT F_API setLoopPoints          (unsigned int loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int loopend, FMOD_TIMEUNIT loopendtype);
+        FMOD_RESULT F_API getLoopPoints          (unsigned int *loopstart, FMOD_TIMEUNIT loopstarttype, unsigned int *loopend, FMOD_TIMEUNIT loopendtype);
+
+        // Userdata set/get.                                                
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+        'ChannelGroup' API
+    */
+    class ChannelGroup
+    {
+      private:
+
+        ChannelGroup();   /* Constructor made private so user cannot statically instance a ChannelGroup class.  
+                             Appropriate ChannelGroup creation or retrieval function must be used. */
+      public:
+
+        FMOD_RESULT F_API release                 ();
+        FMOD_RESULT F_API getSystemObject         (System **system);
+
+        // Channelgroup scale values.  (changes attributes relative to the channels, doesn't overwrite them)
+        FMOD_RESULT F_API setVolume               (float volume);
+        FMOD_RESULT F_API getVolume               (float *volume);
+        FMOD_RESULT F_API setPitch                (float pitch);
+        FMOD_RESULT F_API getPitch                (float *pitch);
+        FMOD_RESULT F_API set3DOcclusion          (float directocclusion, float reverbocclusion);
+        FMOD_RESULT F_API get3DOcclusion          (float *directocclusion, float *reverbocclusion);
+        FMOD_RESULT F_API setPaused               (bool paused);
+        FMOD_RESULT F_API getPaused               (bool *paused);
+        FMOD_RESULT F_API setMute                 (bool mute);
+        FMOD_RESULT F_API getMute                 (bool *mute);
+
+        // Channelgroup override values.  (recursively overwrites whatever settings the channels had)
+        FMOD_RESULT F_API stop                    ();
+        FMOD_RESULT F_API overrideVolume          (float volume);
+        FMOD_RESULT F_API overrideFrequency       (float frequency);
+        FMOD_RESULT F_API overridePan             (float pan);
+        FMOD_RESULT F_API overrideReverbProperties(const FMOD_REVERB_CHANNELPROPERTIES *prop);
+        FMOD_RESULT F_API override3DAttributes    (const FMOD_VECTOR *pos, const FMOD_VECTOR *vel);
+        FMOD_RESULT F_API overrideSpeakerMix      (float frontleft, float frontright, float center, float lfe, float backleft, float backright, float sideleft, float sideright);
+
+        // Nested channel groups.
+        FMOD_RESULT F_API addGroup                (ChannelGroup *group);
+        FMOD_RESULT F_API getNumGroups            (int *numgroups);
+        FMOD_RESULT F_API getGroup                (int index, ChannelGroup **group);
+        FMOD_RESULT F_API getParentGroup          (ChannelGroup **group);
+
+        // DSP functionality only for channel groups playing sounds created with FMOD_SOFTWARE.
+        FMOD_RESULT F_API getDSPHead              (DSP **dsp);
+        FMOD_RESULT F_API addDSP                  (DSP *dsp, DSPConnection **connection);
+
+        // Information only functions.
+        FMOD_RESULT F_API getName                 (char *name, int namelen);
+        FMOD_RESULT F_API getNumChannels          (int *numchannels);
+        FMOD_RESULT F_API getChannel              (int index, Channel **channel);
+        FMOD_RESULT F_API getSpectrum             (float *spectrumarray, int numvalues, int channeloffset, FMOD_DSP_FFT_WINDOW windowtype);
+        FMOD_RESULT F_API getWaveData             (float *wavearray, int numvalues, int channeloffset);
+
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData             (void *userdata);
+        FMOD_RESULT F_API getUserData             (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo           (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+        'SoundGroup' API
+    */
+    class SoundGroup
+    {
+      private:
+
+        SoundGroup();       /* Constructor made private so user cannot statically instance a SoundGroup class.  
+                               Appropriate SoundGroup creation or retrieval function must be used. */
+      public:
+
+        FMOD_RESULT F_API release                ();
+        FMOD_RESULT F_API getSystemObject        (System **system);
+
+        // SoundGroup control functions.
+        FMOD_RESULT F_API setMaxAudible          (int maxaudible);
+        FMOD_RESULT F_API getMaxAudible          (int *maxaudible);
+        FMOD_RESULT F_API setMaxAudibleBehavior  (FMOD_SOUNDGROUP_BEHAVIOR behavior);
+        FMOD_RESULT F_API getMaxAudibleBehavior  (FMOD_SOUNDGROUP_BEHAVIOR *behavior);
+        FMOD_RESULT F_API setMuteFadeSpeed       (float speed);
+        FMOD_RESULT F_API getMuteFadeSpeed       (float *speed);
+        FMOD_RESULT F_API setVolume              (float volume);
+        FMOD_RESULT F_API getVolume              (float *volume);
+        FMOD_RESULT F_API stop                   ();
+
+        // Information only functions.
+        FMOD_RESULT F_API getName                (char *name, int namelen);
+        FMOD_RESULT F_API getNumSounds           (int *numsounds);
+        FMOD_RESULT F_API getSound               (int index, Sound **sound);
+        FMOD_RESULT F_API getNumPlaying          (int *numplaying);
+
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+    
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+    /*
+        'DSP' API
+    */
+    class DSP
+    {
+      private:
+
+        DSP();   /* Constructor made private so user cannot statically instance a DSP class.  
+                    Appropriate DSP creation or retrieval function must be used. */
+      public:
+
+        FMOD_RESULT F_API release                ();
+        FMOD_RESULT F_API getSystemObject        (System **system);
+
+        // Connection / disconnection / input and output enumeration.
+        FMOD_RESULT F_API addInput               (DSP *target, DSPConnection **connection);
+        FMOD_RESULT F_API disconnectFrom         (DSP *target);
+        FMOD_RESULT F_API disconnectAll          (bool inputs, bool outputs);
+        FMOD_RESULT F_API remove                 ();
+        FMOD_RESULT F_API getNumInputs           (int *numinputs);
+        FMOD_RESULT F_API getNumOutputs          (int *numoutputs);
+        FMOD_RESULT F_API getInput               (int index, DSP **input, DSPConnection **inputconnection);
+        FMOD_RESULT F_API getOutput              (int index, DSP **output, DSPConnection **outputconnection);
+
+        // DSP unit control.
+        FMOD_RESULT F_API setActive              (bool active);
+        FMOD_RESULT F_API getActive              (bool *active);
+        FMOD_RESULT F_API setBypass              (bool bypass);
+        FMOD_RESULT F_API getBypass              (bool *bypass);
+        FMOD_RESULT F_API setSpeakerActive		 (FMOD_SPEAKER speaker, bool active);
+		FMOD_RESULT F_API getSpeakerActive		 (FMOD_SPEAKER speaker, bool *active);
+		FMOD_RESULT F_API reset                  ();
+		
+
+        // DSP parameter control.
+        FMOD_RESULT F_API setParameter           (int index, float value);
+        FMOD_RESULT F_API getParameter           (int index, float *value, char *valuestr, int valuestrlen);
+        FMOD_RESULT F_API getNumParameters       (int *numparams);
+        FMOD_RESULT F_API getParameterInfo       (int index, char *name, char *label, char *description, int descriptionlen, float *min, float *max);
+        FMOD_RESULT F_API showConfigDialog       (void *hwnd, bool show);
+        
+        // DSP attributes.        
+        FMOD_RESULT F_API getInfo                (char *name, unsigned int *version, int *channels, int *configwidth, int *configheight);
+        FMOD_RESULT F_API getType                (FMOD_DSP_TYPE *type); 
+        FMOD_RESULT F_API setDefaults            (float frequency, float volume, float pan, int priority);
+        FMOD_RESULT F_API getDefaults            (float *frequency, float *volume, float *pan, int *priority);
+                                                
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+
+    /*
+        'DSPConnection' API
+    */
+    class DSPConnection
+    {
+      private:
+
+        DSPConnection();    /* Constructor made private so user cannot statically instance a DSPConnection class.  
+                               Appropriate DSPConnection creation or retrieval function must be used. */
+
+      public:
+
+        FMOD_RESULT F_API getInput              (DSP **input);
+        FMOD_RESULT F_API getOutput             (DSP **output);
+        FMOD_RESULT F_API setMix                (float volume);
+        FMOD_RESULT F_API getMix                (float *volume);
+        FMOD_RESULT F_API setLevels             (FMOD_SPEAKER speaker, float *levels, int numlevels);
+        FMOD_RESULT F_API getLevels             (FMOD_SPEAKER speaker, float *levels, int numlevels);
+
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData           (void *userdata);
+        FMOD_RESULT F_API getUserData           (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo         (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+
+    /*
+        'Geometry' API
+    */
+    class Geometry
+    {
+      private:
+
+        Geometry();   /* Constructor made private so user cannot statically instance a Geometry class.  
+                         Appropriate Geometry creation or retrieval function must be used. */
+
+      public:        
+
+        FMOD_RESULT F_API release                ();
+
+        // Polygon manipulation.
+        FMOD_RESULT F_API addPolygon             (float directocclusion, float reverbocclusion, bool doublesided, int numvertices, const FMOD_VECTOR *vertices, int *polygonindex);
+        FMOD_RESULT F_API getNumPolygons         (int *numpolygons); 
+        FMOD_RESULT F_API getMaxPolygons         (int *maxpolygons, int *maxvertices);
+        FMOD_RESULT F_API getPolygonNumVertices  (int index, int *numvertices);
+        FMOD_RESULT F_API setPolygonVertex       (int index, int vertexindex, const FMOD_VECTOR *vertex); 
+        FMOD_RESULT F_API getPolygonVertex       (int index, int vertexindex, FMOD_VECTOR *vertex);
+        FMOD_RESULT F_API setPolygonAttributes   (int index, float directocclusion, float reverbocclusion, bool doublesided); 
+        FMOD_RESULT F_API getPolygonAttributes   (int index, float *directocclusion, float *reverbocclusion, bool *doublesided); 
+
+        // Object manipulation.
+        FMOD_RESULT F_API setActive              (bool active);                                                 
+        FMOD_RESULT F_API getActive              (bool *active);                                                 
+        FMOD_RESULT F_API setRotation            (const FMOD_VECTOR *forward, const FMOD_VECTOR *up);
+        FMOD_RESULT F_API getRotation            (FMOD_VECTOR *forward, FMOD_VECTOR *up);
+        FMOD_RESULT F_API setPosition            (const FMOD_VECTOR *position);
+        FMOD_RESULT F_API getPosition            (FMOD_VECTOR *position);
+        FMOD_RESULT F_API setScale               (const FMOD_VECTOR *scale);
+        FMOD_RESULT F_API getScale               (FMOD_VECTOR *scale);
+        FMOD_RESULT F_API save                   (void *data, int *datasize);
+
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+
+
+    /*
+        'Reverb' API
+    */
+    class Reverb
+    {
+      private:
+
+        Reverb();    /*  Constructor made private so user cannot statically instance a Reverb class.  
+                         Appropriate Reverb creation or retrieval function must be used. */
+
+      public:    
+
+        FMOD_RESULT F_API release                ();
+
+        // Reverb manipulation.
+        FMOD_RESULT F_API set3DAttributes        (const FMOD_VECTOR *position, float mindistance, float maxdistance);
+        FMOD_RESULT F_API get3DAttributes        (FMOD_VECTOR *position, float *mindistance,float *maxdistance);
+        FMOD_RESULT F_API setProperties          (const FMOD_REVERB_PROPERTIES *properties);
+        FMOD_RESULT F_API getProperties          (FMOD_REVERB_PROPERTIES *properties);
+        FMOD_RESULT F_API setActive              (bool active);
+        FMOD_RESULT F_API getActive              (bool *active);
+
+        // Userdata set/get.
+        FMOD_RESULT F_API setUserData            (void *userdata);
+        FMOD_RESULT F_API getUserData            (void **userdata);    
+
+        FMOD_RESULT F_API getMemoryInfo          (unsigned int memorybits, unsigned int event_memorybits, unsigned int *memoryused, FMOD_MEMORY_USAGE_DETAILS *memoryused_details);
+    };
+}
+
+#endif

--- a/src/moaicore/fmodinc/fmod_codec.h
+++ b/src/moaicore/fmodinc/fmod_codec.h
@@ -1,0 +1,159 @@
+/* ==================================================================================================== */
+/* FMOD Ex - codec development header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.  */
+/*                                                                                                      */
+/* Use this header if you are wanting to develop your own file format plugin to use with                */
+/* FMOD's codec system.  With this header you can make your own fileformat plugin that FMOD             */
+/* can register and use.  See the documentation and examples on how to make a working plugin.           */
+/*                                                                                                      */
+/* ==================================================================================================== */
+
+#ifndef _FMOD_CODEC_H
+#define _FMOD_CODEC_H
+
+typedef struct FMOD_CODEC_STATE FMOD_CODEC_STATE;
+typedef struct FMOD_CODEC_WAVEFORMAT FMOD_CODEC_WAVEFORMAT;
+
+/*
+    Codec callbacks
+*/ 
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_OPENCALLBACK)        (FMOD_CODEC_STATE *codec_state, FMOD_MODE usermode, FMOD_CREATESOUNDEXINFO *userexinfo);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_CLOSECALLBACK)       (FMOD_CODEC_STATE *codec_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_READCALLBACK)        (FMOD_CODEC_STATE *codec_state, void *buffer, unsigned int sizebytes, unsigned int *bytesread);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_GETLENGTHCALLBACK)   (FMOD_CODEC_STATE *codec_state, unsigned int *length, FMOD_TIMEUNIT lengthtype);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_SETPOSITIONCALLBACK) (FMOD_CODEC_STATE *codec_state, int subsound, unsigned int position, FMOD_TIMEUNIT postype);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_GETPOSITIONCALLBACK) (FMOD_CODEC_STATE *codec_state, unsigned int *position, FMOD_TIMEUNIT postype);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_SOUNDCREATECALLBACK) (FMOD_CODEC_STATE *codec_state, int subsound, FMOD_SOUND *sound);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_METADATACALLBACK)    (FMOD_CODEC_STATE *codec_state, FMOD_TAGTYPE tagtype, char *name, void *data, unsigned int datalen, FMOD_TAGDATATYPE datatype, int unique);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_CODEC_GETWAVEFORMAT)       (FMOD_CODEC_STATE *codec_state, int index, FMOD_CODEC_WAVEFORMAT *waveformat);
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    When creating a codec, declare one of these and provide the relevant callbacks and name for FMOD to use when it opens and reads a file.
+
+    [REMARKS]
+    Members marked with [in] mean the variable can be written to.  The user can set the value.
+    Members marked with [out] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_CODEC_STATE
+]
+*/
+typedef struct FMOD_CODEC_DESCRIPTION
+{
+    const char                     *name;            /* [in] Name of the codec. */
+    unsigned int                    version;         /* [in] Plugin writer's version number. */
+    int                             defaultasstream; /* [in] Tells FMOD to open the file as a stream when calling System::createSound, and not a static sample.  Should normally be 0 (FALSE), because generally the user wants to decode the file into memory when using System::createSound.   Mainly used for formats that decode for a very long time, or could use large amounts of memory when decoded.  Usually sequenced formats such as mod/s3m/xm/it/midi fall into this category.   It is mainly to stop users that don't know what they're doing from getting FMOD_ERR_MEMORY returned from createSound when they should have in fact called System::createStream or used FMOD_CREATESTREAM in System::createSound. */
+    FMOD_TIMEUNIT                   timeunits;       /* [in] When setposition codec is called, only these time formats will be passed to the codec. Use bitwise OR to accumulate different types. */
+    FMOD_CODEC_OPENCALLBACK         open;            /* [in] Open callback for the codec for when FMOD tries to open a sound using this codec. */
+    FMOD_CODEC_CLOSECALLBACK        close;           /* [in] Close callback for the codec for when FMOD tries to close a sound using this codec.  */
+    FMOD_CODEC_READCALLBACK         read;            /* [in] Read callback for the codec for when FMOD tries to read some data from the file to the destination format (specified in the open callback). */
+    FMOD_CODEC_GETLENGTHCALLBACK    getlength;       /* [in] Callback to return the length of the song in whatever format required when Sound::getLength is called. */
+    FMOD_CODEC_SETPOSITIONCALLBACK  setposition;     /* [in] Seek callback for the codec for when FMOD tries to seek within the file with Channel::setPosition. */
+    FMOD_CODEC_GETPOSITIONCALLBACK  getposition;     /* [in] Tell callback for the codec for when FMOD tries to get the current position within the with Channel::getPosition. */
+    FMOD_CODEC_SOUNDCREATECALLBACK  soundcreate;     /* [in] Sound creation callback for the codec when FMOD finishes creating the sound.  (So the codec can set more parameters for the related created sound, ie loop points/mode or 3D attributes etc). */
+    FMOD_CODEC_GETWAVEFORMAT        getwaveformat;   /* [in] Callback to tell FMOD about the waveformat of a particular subsound.  This is to save memory, rather than saving 1000 FMOD_CODEC_WAVEFORMAT structures in the codec, the codec might have a more optimal way of storing this information. */
+} FMOD_CODEC_DESCRIPTION;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Set these values marked 'in' to tell fmod what sort of sound to create.
+    The format, channels and frequency tell FMOD what sort of hardware buffer to create when you initialize your code.  So if you wrote an MP3 codec that decoded to stereo 16bit integer PCM, you would specify FMOD_SOUND_FORMAT_PCM16, and channels would be equal to 2.
+    Members marked as 'out' are set by fmod.  Do not modify these.  Simply specify 0 for these values when declaring the structure, FMOD will fill in the values for you after creation with the correct function pointers.
+
+    [REMARKS]
+    Members marked with [in] mean the variable can be written to.  The user can set the value.
+    Members marked with [out] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    
+    An FMOD file might be from disk, memory or network, however the file may be opened by the user.
+    
+    'numsubsounds' should be 0 if the file is a normal single sound stream or sound.  Examples of this would be .WAV, .WMA, .MP3, .AIFF.
+    'numsubsounds' should be 1+ if the file is a container format, and does not contain wav data itself.  Examples of these types would be CDDA (multiple CD tracks), FSB (contains multiple sounds), MIDI/MOD/S3M/XM/IT (contain instruments).
+    The arrays of format, channel, frequency, length and blockalign should point to arrays of information based on how many subsounds are in the format.  If the number of subsounds is 0 then it should point to 1 of each attribute, the same as if the number of subsounds was 1.  If subsounds was 100 for example, each pointer should point to an array of 100 of each attribute.
+    When a sound has 1 or more subsounds, you must play the individual sounds specified by first obtaining the subsound with Sound::getSubSound.
+    
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_SOUND_FORMAT
+    FMOD_FILE_READCALLBACK      
+    FMOD_FILE_SEEKCALLBACK      
+    FMOD_CODEC_METADATACALLBACK
+    Sound::getSubSound
+    Sound::getNumSubSounds
+]
+*/
+struct FMOD_CODEC_WAVEFORMAT
+{
+    char               name[256];     /* [in] Name of sound.*/
+    FMOD_SOUND_FORMAT  format;        /* [in] Format for (decompressed) codec output, ie FMOD_SOUND_FORMAT_PCM8, FMOD_SOUND_FORMAT_PCM16.*/
+    int                channels;      /* [in] Number of channels used by codec, ie mono = 1, stereo = 2. */
+    int                frequency;     /* [in] Default frequency in hz of the codec, ie 44100. */
+    unsigned int       lengthbytes;   /* [in] Length in bytes of the source data. */
+    unsigned int       lengthpcm;     /* [in] Length in decompressed, PCM samples of the file, ie length in seconds * frequency.  Used for Sound::getLength and for memory allocation of static decompressed sample data. */
+    int                blockalign;    /* [in] Blockalign in decompressed, PCM samples of the optimal decode chunk size for this format.  The codec read callback will be called in multiples of this value. */
+    int                loopstart;     /* [in] Loopstart in decompressed, PCM samples of file. */
+    int                loopend;       /* [in] Loopend in decompressed, PCM samples of file. */
+    FMOD_MODE          mode;          /* [in] Mode to determine whether the sound should by default load as looping, non looping, 2d or 3d. */
+    unsigned int       channelmask;   /* [in] Microsoft speaker channel mask, as defined for WAVEFORMATEXTENSIBLE and is found in ksmedia.h.  Leave at 0 to play in natural speaker order. */
+};
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Codec plugin structure that is passed into each callback.
+    
+    Set these numsubsounds and waveformat members when called in FMOD_CODEC_OPENCALLBACK to tell fmod what sort of sound to create.
+    
+    The format, channels and frequency tell FMOD what sort of hardware buffer to create when you initialize your code.  So if you wrote an MP3 codec that decoded to stereo 16bit integer PCM, you would specify FMOD_SOUND_FORMAT_PCM16, and channels would be equal to 2.
+
+    [REMARKS]
+    Members marked with [in] mean the variable can be written to.  The user can set the value.
+    Members marked with [out] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    
+    An FMOD file might be from disk, memory or internet, however the file may be opened by the user.
+    
+    'numsubsounds' should be 0 if the file is a normal single sound stream or sound.  Examples of this would be .WAV, .WMA, .MP3, .AIFF.
+    'numsubsounds' should be 1+ if the file is a container format, and does not contain wav data itself.  Examples of these types would be CDDA (multiple CD tracks), FSB (contains multiple sounds), DLS (contain instruments).
+    The arrays of format, channel, frequency, length and blockalign should point to arrays of information based on how many subsounds are in the format.  If the number of subsounds is 0 then it should point to 1 of each attribute, the same as if the number of subsounds was 1.  If subsounds was 100 for example, each pointer should point to an array of 100 of each attribute.
+    When a sound has 1 or more subsounds, you must play the individual sounds specified by first obtaining the subsound with Sound::getSubSound.
+    
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_SOUND_FORMAT
+    FMOD_FILE_READCALLBACK      
+    FMOD_FILE_SEEKCALLBACK      
+    FMOD_CODEC_METADATACALLBACK
+    Sound::getSubSound
+    Sound::getNumSubSounds
+]
+*/
+struct FMOD_CODEC_STATE
+{
+    int                         numsubsounds;  /* [in] Number of 'subsounds' in this sound.  Anything other than 0 makes it a 'container' format (ie CDDA/DLS/FSB etc which contain 1 or more su bsounds).  For most normal, single sound codec such as WAV/AIFF/MP3, this should be 0 as they are not a container for subsounds, they are the sound by itself. */
+    FMOD_CODEC_WAVEFORMAT      *waveformat;    /* [in] Pointer to an array of format structures containing information about each sample.  Can be 0 or NULL if FMOD_CODEC_GETWAVEFORMAT callback is preferred.  The number of entries here must equal the number of subsounds defined in the subsound parameter. If numsubsounds = 0 then there should be 1 instance of this structure. */
+    void                       *plugindata;    /* [in] Plugin writer created data the codec author wants to attach to this object. */
+                                               
+    void                       *filehandle;    /* [out] This will return an internal FMOD file handle to use with the callbacks provided.  */
+    unsigned int                filesize;      /* [out] This will contain the size of the file in bytes. */
+    FMOD_FILE_READCALLBACK      fileread;      /* [out] This will return a callable FMOD file function to use from codec. */
+    FMOD_FILE_SEEKCALLBACK      fileseek;      /* [out] This will return a callable FMOD file function to use from codec.  */
+    FMOD_CODEC_METADATACALLBACK metadata;      /* [out] This will return a callable FMOD metadata function to use from codec.  */
+};
+
+#endif
+
+

--- a/src/moaicore/fmodinc/fmod_dsp.h
+++ b/src/moaicore/fmodinc/fmod_dsp.h
@@ -1,0 +1,742 @@
+/* ========================================================================================== */
+/* FMOD Ex - DSP header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011.      */
+/*                                                                                            */
+/* Use this header if you are interested in delving deeper into the FMOD software mixing /    */
+/* DSP engine.  In this header you can find parameter structures for FMOD system reigstered   */
+/* DSP effects and generators.                                                                */
+/* Also use this header if you are wanting to develop your own DSP plugin to use with FMOD's  */
+/* dsp system.  With this header you can make your own DSP plugin that FMOD can               */
+/* register and use.  See the documentation and examples on how to make a working plugin.     */
+/*                                                                                            */
+/* ========================================================================================== */
+
+#ifndef _FMOD_DSP_H
+#define _FMOD_DSP_H
+
+typedef struct FMOD_DSP_STATE FMOD_DSP_STATE;
+
+/* 
+    DSP callbacks
+*/
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_CREATECALLBACK)     (FMOD_DSP_STATE *dsp_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_RELEASECALLBACK)    (FMOD_DSP_STATE *dsp_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_RESETCALLBACK)      (FMOD_DSP_STATE *dsp_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_READCALLBACK)       (FMOD_DSP_STATE *dsp_state, float *inbuffer, float *outbuffer, unsigned int length, int inchannels, int outchannels);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_SETPOSITIONCALLBACK)(FMOD_DSP_STATE *dsp_state, unsigned int pos);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_SETPARAMCALLBACK)   (FMOD_DSP_STATE *dsp_state, int index, float value);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_GETPARAMCALLBACK)   (FMOD_DSP_STATE *dsp_state, int index, float *value, char *valuestr);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_DSP_DIALOGCALLBACK)     (FMOD_DSP_STATE *dsp_state, void *hwnd, int show);
+
+/*
+[ENUM]
+[
+    [DESCRIPTION]   
+    These definitions can be used for creating FMOD defined special effects or DSP units.
+
+    [REMARKS]
+    To get them to be active, first create the unit, then add it somewhere into the DSP network, either at the front of the network near the soundcard unit to affect the global output (by using System::getDSPHead), or on a single channel (using Channel::getDSPHead).
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::createDSPByType
+]
+*/
+typedef enum
+{
+    FMOD_DSP_TYPE_UNKNOWN,            /* This unit was created via a non FMOD plugin so has an unknown purpose. */
+    FMOD_DSP_TYPE_MIXER,              /* This unit does nothing but take inputs and mix them together then feed the result to the soundcard unit. */
+    FMOD_DSP_TYPE_OSCILLATOR,         /* This unit generates sine/square/saw/triangle or noise tones. */
+    FMOD_DSP_TYPE_LOWPASS,            /* This unit filters sound using a high quality, resonant lowpass filter algorithm but consumes more CPU time. */
+    FMOD_DSP_TYPE_ITLOWPASS,          /* This unit filters sound using a resonant lowpass filter algorithm that is used in Impulse Tracker, but with limited cutoff range (0 to 8060hz). */
+    FMOD_DSP_TYPE_HIGHPASS,           /* This unit filters sound using a resonant highpass filter algorithm. */
+    FMOD_DSP_TYPE_ECHO,               /* This unit produces an echo on the sound and fades out at the desired rate. */
+    FMOD_DSP_TYPE_FLANGE,             /* This unit produces a flange effect on the sound. */
+    FMOD_DSP_TYPE_DISTORTION,         /* This unit distorts the sound. */
+    FMOD_DSP_TYPE_NORMALIZE,          /* This unit normalizes or amplifies the sound to a certain level. */
+    FMOD_DSP_TYPE_PARAMEQ,            /* This unit attenuates or amplifies a selected frequency range. */
+    FMOD_DSP_TYPE_PITCHSHIFT,         /* This unit bends the pitch of a sound without changing the speed of playback. */
+    FMOD_DSP_TYPE_CHORUS,             /* This unit produces a chorus effect on the sound. */
+    FMOD_DSP_TYPE_VSTPLUGIN,          /* This unit allows the use of Steinberg VST plugins */
+    FMOD_DSP_TYPE_WINAMPPLUGIN,       /* This unit allows the use of Nullsoft Winamp plugins */
+    FMOD_DSP_TYPE_ITECHO,             /* This unit produces an echo on the sound and fades out at the desired rate as is used in Impulse Tracker. */
+    FMOD_DSP_TYPE_COMPRESSOR,         /* This unit implements dynamic compression (linked multichannel, wideband) */
+    FMOD_DSP_TYPE_SFXREVERB,          /* This unit implements SFX reverb */
+    FMOD_DSP_TYPE_LOWPASS_SIMPLE,     /* This unit filters sound using a simple lowpass with no resonance, but has flexible cutoff and is fast. */
+    FMOD_DSP_TYPE_DELAY,              /* This unit produces different delays on individual channels of the sound. */
+    FMOD_DSP_TYPE_TREMOLO,            /* This unit produces a tremolo / chopper effect on the sound. */
+    FMOD_DSP_TYPE_LADSPAPLUGIN,       /* This unit allows the use of LADSPA standard plugins. */
+    FMOD_DSP_TYPE_HIGHPASS_SIMPLE,    /* This unit filters sound using a simple highpass with no resonance, but has flexible cutoff and is fast. */
+    FMOD_DSP_TYPE_FORCEINT = 65536    /* Makes sure this enum is signed 32bit. */
+} FMOD_DSP_TYPE;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Structure to define a parameter for a DSP unit.
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]    
+    System::createDSP
+    DSP::setParameter
+]
+*/
+typedef struct FMOD_DSP_PARAMETERDESC
+{
+    float       min;                                /* [w] Minimum value of the parameter (ie 100.0). */
+    float       max;                                /* [w] Maximum value of the parameter (ie 22050.0). */
+    float       defaultval;                         /* [w] Default value of parameter. */
+    char        name[16];                           /* [w] Name of the parameter to be displayed (ie "Cutoff frequency"). */
+    char        label[16];                          /* [w] Short string to be put next to value to denote the unit type (ie "hz"). */
+    const char *description;                        /* [w] Description of the parameter to be displayed as a help item / tooltip for this parameter. */
+} FMOD_DSP_PARAMETERDESC;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    When creating a DSP unit, declare one of these and provide the relevant callbacks and name for FMOD to use when it creates and uses a DSP unit of this type.
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+    
+    There are 2 different ways to change a parameter in this architecture.
+    One is to use DSP::setParameter / DSP::getParameter.  This is platform independant and is dynamic, so new unknown plugins can have their parameters enumerated and used.
+    The other is to use DSP::showConfigDialog.  This is platform specific and requires a GUI, and will display a dialog box to configure the plugin.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]    
+    System::createDSP
+    FMOD_DSP_STATE
+]
+*/
+typedef struct FMOD_DSP_DESCRIPTION
+{
+    char                         name[32];           /* [w] Name of the unit to be displayed in the network. */
+    unsigned int                 version;            /* [w] Plugin writer's version number. */
+    int                          channels;           /* [w] Number of channels.  Use 0 to process whatever number of channels is currently in the network.  >0 would be mostly used if the unit is a unit that only generates sound. */
+    FMOD_DSP_CREATECALLBACK      create;             /* [w] Create callback.  This is called when DSP unit is created.  Can be null. */
+    FMOD_DSP_RELEASECALLBACK     release;            /* [w] Release callback.  This is called just before the unit is freed so the user can do any cleanup needed for the unit.  Can be null. */
+    FMOD_DSP_RESETCALLBACK       reset;              /* [w] Reset callback.  This is called by the user to reset any history buffers that may need resetting for a filter, when it is to be used or re-used for the first time to its initial clean state.  Use to avoid clicks or artifacts. */
+    FMOD_DSP_READCALLBACK        read;               /* [w] Read callback.  Processing is done here.  Can be null. */
+    FMOD_DSP_SETPOSITIONCALLBACK setposition;        /* [w] Set position callback.  This is called if the unit wants to update its position info but not process data, or reset a cursor position internally if it is reading data from a certain source.  Can be null. */
+
+    int                          numparameters;      /* [w] Number of parameters used in this filter.  The user finds this with DSP::getNumParameters */
+    FMOD_DSP_PARAMETERDESC      *paramdesc;          /* [w] Variable number of parameter structures. */
+    FMOD_DSP_SETPARAMCALLBACK    setparameter;       /* [w] This is called when the user calls DSP::setParameter.  Can be null. */
+    FMOD_DSP_GETPARAMCALLBACK    getparameter;       /* [w] This is called when the user calls DSP::getParameter.  Can be null. */
+    FMOD_DSP_DIALOGCALLBACK      config;             /* [w] This is called when the user calls DSP::showConfigDialog.  Can be used to display a dialog to configure the filter.  Can be null. */
+    int                          configwidth;        /* [w] Width of config dialog graphic if there is one.  0 otherwise.*/
+    int                          configheight;       /* [w] Height of config dialog graphic if there is one.  0 otherwise.*/
+    void                        *userdata;           /* [w] Optional. Specify 0 to ignore. This is user data to be attached to the DSP unit during creation.  Access via DSP::getUserData. */
+} FMOD_DSP_DESCRIPTION;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    DSP plugin structure that is passed into each callback.
+
+    [REMARKS]
+    Members marked with [r] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+    Members marked with [w] mean the variable can be written to.  The user can set the value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_DSP_DESCRIPTION
+]
+*/
+struct FMOD_DSP_STATE
+{
+    FMOD_DSP      *instance;      /* [r] Handle to the DSP hand the user created.  Not to be modified.  C++ users cast to FMOD::DSP to use.  */
+    void          *plugindata;    /* [w] Plugin writer created data the output author wants to attach to this object. */
+	unsigned short speakermask;	  /* [w] Specifies which speakers the DSP effect is active on */
+};
+
+
+/*
+    ===================================================================================================
+
+    FMOD built in effect parameters.  
+    Use DSP::setParameter with these enums for the 'index' parameter.
+
+    ===================================================================================================
+*/
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_OSCILLATOR filter.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_OSCILLATOR_TYPE,   /* Waveform type.  0 = sine.  1 = square. 2 = sawup. 3 = sawdown. 4 = triangle. 5 = noise.  */
+    FMOD_DSP_OSCILLATOR_RATE    /* Frequency of the sinewave in hz.  1.0 to 22000.0.  Default = 220.0. */
+} FMOD_DSP_OSCILLATOR;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_LOWPASS filter.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_LOWPASS_CUTOFF,    /* Lowpass cutoff frequency in hz.   10.0 to 22000.0.  Default = 5000.0. */
+    FMOD_DSP_LOWPASS_RESONANCE  /* Lowpass resonance Q value. 1.0 to 10.0.  Default = 1.0. */
+} FMOD_DSP_LOWPASS;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_ITLOWPASS filter.
+    This is different to the default FMOD_DSP_TYPE_ITLOWPASS filter in that it uses a different quality algorithm and is 
+    the filter used to produce the correct sounding playback in .IT files. 
+    FMOD Ex's .IT playback uses this filter.
+
+    [REMARKS]
+    Note! This filter actually has a limited cutoff frequency below the specified maximum, due to its limited design, 
+    so for a more  open range filter use FMOD_DSP_LOWPASS or if you don't mind not having resonance, 
+    FMOD_DSP_LOWPASS_SIMPLE.
+    The effective maximum cutoff is about 8060hz.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_ITLOWPASS_CUTOFF,    /* Lowpass cutoff frequency in hz.  1.0 to 22000.0.  Default = 5000.0/ */
+    FMOD_DSP_ITLOWPASS_RESONANCE  /* Lowpass resonance Q value.  0.0 to 127.0.  Default = 1.0. */
+} FMOD_DSP_ITLOWPASS;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_HIGHPASS filter.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_HIGHPASS_CUTOFF,    /* Highpass cutoff frequency in hz.  1.0 to output 22000.0.  Default = 5000.0. */
+    FMOD_DSP_HIGHPASS_RESONANCE  /* Highpass resonance Q value.  1.0 to 10.0.  Default = 1.0. */
+} FMOD_DSP_HIGHPASS;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_ECHO filter.
+
+    [REMARKS]
+    Note.  Every time the delay is changed, the plugin re-allocates the echo buffer.  This means the echo will dissapear at that time while it refills its new buffer.
+    Larger echo delays result in larger amounts of memory allocated.
+    
+    '<i>maxchannels</i>' also dictates the amount of memory allocated.  By default, the maxchannels value is 0.  If FMOD is set to stereo, the echo unit will allocate enough memory for 2 channels.  If it is 5.1, it will allocate enough memory for a 6 channel echo, etc.
+    If the echo effect is only ever applied to the global mix (ie it was added with System::addDSP), then 0 is the value to set as it will be enough to handle all speaker modes.
+    When the echo is added to a channel (ie Channel::addDSP) then the channel count that comes in could be anything from 1 to 8 possibly.  It is only in this case where you might want to increase the channel count above the output's channel count.
+    If a channel echo is set to a lower number than the sound's channel count that is coming in, it will not echo the sound.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_ECHO_DELAY,       /* Echo delay in ms.  10  to 5000.  Default = 500. */
+    FMOD_DSP_ECHO_DECAYRATIO,  /* Echo decay per delay.  0 to 1.  1.0 = No decay, 0.0 = total decay (ie simple 1 line delay).  Default = 0.5. */
+    FMOD_DSP_ECHO_MAXCHANNELS, /* Maximum channels supported.  0 to 16.  0 = same as fmod's default output polyphony, 1 = mono, 2 = stereo etc.  See remarks for more.  Default = 0.  It is suggested to leave at 0! */
+    FMOD_DSP_ECHO_DRYMIX,      /* Volume of original signal to pass to output.  0.0 to 1.0. Default = 1.0. */
+    FMOD_DSP_ECHO_WETMIX       /* Volume of echo signal to pass to output.  0.0 to 1.0. Default = 1.0. */
+} FMOD_DSP_ECHO;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_DELAY filter.
+
+    [REMARKS]
+    Note.  Every time MaxDelay is changed, the plugin re-allocates the delay buffer.  This means the delay will dissapear at that time while it refills its new buffer.
+    A larger MaxDelay results in larger amounts of memory allocated.
+    Channel delays above MaxDelay will be clipped to MaxDelay and the delay buffer will not be resized.
+    
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_DELAY_CH0,      /* Channel #0 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH1,      /* Channel #1 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH2,      /* Channel #2 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH3,      /* Channel #3 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH4,      /* Channel #4 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH5,      /* Channel #5 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH6,      /* Channel #6 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH7,      /* Channel #7 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH8,      /* Channel #8 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH9,      /* Channel #9 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH10,     /* Channel #10 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH11,     /* Channel #11 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH12,     /* Channel #12 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH13,     /* Channel #13 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH14,     /* Channel #14 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_CH15,     /* Channel #15 Delay in ms.  0  to 10000.  Default = 0. */
+    FMOD_DSP_DELAY_MAXDELAY  /* Maximum delay in ms.  0  to 10000.  Default = 10. */
+} FMOD_DSP_DELAY;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_FLANGE filter.
+
+    [REMARKS]
+    Flange is an effect where the signal is played twice at the same time, and one copy slides back and forth creating a whooshing or flanging effect.
+    As there are 2 copies of the same signal, by default each signal is given 50% mix, so that the total is not louder than the original unaffected signal.
+    
+    Flange depth is a percentage of a 10ms shift from the original signal.  Anything above 10ms is not considered flange because to the ear it begins to 'echo' so 10ms is the highest value possible.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_FLANGE_DRYMIX,      /* Volume of original signal to pass to output.  0.0 to 1.0. Default = 0.45. */
+    FMOD_DSP_FLANGE_WETMIX,      /* Volume of flange signal to pass to output.  0.0 to 1.0. Default = 0.55. */
+    FMOD_DSP_FLANGE_DEPTH,       /* Flange depth (percentage of 40ms delay).  0.01 to 1.0.  Default = 1.0. */
+    FMOD_DSP_FLANGE_RATE         /* Flange speed in hz.  0.0 to 20.0.  Default = 0.1. */
+} FMOD_DSP_FLANGE;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_TREMOLO filter.
+
+    [REMARKS]
+    The tremolo effect varies the amplitude of a sound. Depending on the settings, this unit can produce a tremolo, chopper or auto-pan effect.
+    
+    The shape of the LFO (low freq. oscillator) can morphed between sine, triangle and sawtooth waves using the FMOD_DSP_TREMOLO_SHAPE and FMOD_DSP_TREMOLO_SKEW parameters.
+    FMOD_DSP_TREMOLO_DUTY and FMOD_DSP_TREMOLO_SQUARE are useful for a chopper-type effect where the first controls the on-time duration and second controls the flatness of the envelope.
+    FMOD_DSP_TREMOLO_SPREAD varies the LFO phase between channels to get an auto-pan effect. This works best with a sine shape LFO.
+    The LFO can be synchronized using the FMOD_DSP_TREMOLO_PHASE parameter which sets its instantaneous phase.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_TREMOLO_FREQUENCY,     /* LFO frequency in Hz.  0.1 to 20.  Default = 4. */
+    FMOD_DSP_TREMOLO_DEPTH,         /* Tremolo depth.  0 to 1.  Default = 0. */
+    FMOD_DSP_TREMOLO_SHAPE,         /* LFO shape morph between triangle and sine.  0 to 1.  Default = 0. */
+    FMOD_DSP_TREMOLO_SKEW,          /* Time-skewing of LFO cycle.  -1 to 1.  Default = 0. */
+    FMOD_DSP_TREMOLO_DUTY,          /* LFO on-time.  0 to 1.  Default = 0.5. */
+    FMOD_DSP_TREMOLO_SQUARE,        /* Flatness of the LFO shape.  0 to 1.  Default = 0. */
+    FMOD_DSP_TREMOLO_PHASE,         /* Instantaneous LFO phase.  0 to 1.  Default = 0. */
+    FMOD_DSP_TREMOLO_SPREAD         /* Rotation / auto-pan effect.  -1 to 1.  Default = 0. */
+} FMOD_DSP_TREMOLO;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_DISTORTION filter.
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_DISTORTION_LEVEL    /* Distortion value.  0.0 to 1.0.  Default = 0.5. */
+} FMOD_DSP_DISTORTION;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_NORMALIZE filter.
+
+    [REMARKS]
+    Normalize amplifies the sound based on the maximum peaks within the signal.
+    For example if the maximum peaks in the signal were 50% of the bandwidth, it would scale the whole sound by 2.
+    The lower threshold value makes the normalizer ignores peaks below a certain point, to avoid over-amplification if a loud signal suddenly came in, and also to avoid amplifying to maximum things like background hiss.
+    
+    Because FMOD is a realtime audio processor, it doesn't have the luxury of knowing the peak for the whole sound (ie it can't see into the future), so it has to process data as it comes in.
+    To avoid very sudden changes in volume level based on small samples of new data, fmod fades towards the desired amplification which makes for smooth gain control.  The fadetime parameter can control this.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_NORMALIZE_FADETIME,    /* Time to ramp the silence to full in ms.  0.0 to 20000.0. Default = 5000.0. */
+    FMOD_DSP_NORMALIZE_THRESHHOLD,  /* Lower volume range threshold to ignore.  0.0 to 1.0.  Default = 0.1.  Raise higher to stop amplification of very quiet signals. */
+    FMOD_DSP_NORMALIZE_MAXAMP       /* Maximum amplification allowed.  1.0 to 100000.0.  Default = 20.0.  1.0 = no amplifaction, higher values allow more boost. */
+} FMOD_DSP_NORMALIZE;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_PARAMEQ filter.
+
+    [REMARKS]
+    Parametric EQ is a bandpass filter that attenuates or amplifies a selected frequency and its neighbouring frequencies.
+    
+    To create a multi-band EQ create multiple FMOD_DSP_TYPE_PARAMEQ units and set each unit to different frequencies, for example 1000hz, 2000hz, 4000hz, 8000hz, 16000hz with a range of 1 octave each.
+    
+    When a frequency has its gain set to 1.0, the sound will be unaffected and represents the original signal exactly.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_PARAMEQ_CENTER,     /* Frequency center.  20.0 to 22000.0.  Default = 8000.0. */
+    FMOD_DSP_PARAMEQ_BANDWIDTH,  /* Octave range around the center frequency to filter.  0.2 to 5.0.  Default = 1.0. */
+    FMOD_DSP_PARAMEQ_GAIN        /* Frequency Gain.  0.05 to 3.0.  Default = 1.0.  */
+} FMOD_DSP_PARAMEQ;
+
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_PITCHSHIFT filter.
+
+    [REMARKS]
+    This pitch shifting unit can be used to change the pitch of a sound without speeding it up or slowing it down.
+    It can also be used for time stretching or scaling, for example if the pitch was doubled, and the frequency of the sound was halved, the pitch of the sound would sound correct but it would be twice as slow.
+    
+    <b>Warning!</b> This filter is very computationally expensive!  Similar to a vocoder, it requires several overlapping FFT and IFFT's to produce smooth output, and can require around 440mhz for 1 stereo 48khz signal using the default settings.
+    Reducing the signal to mono will half the cpu usage.
+    Reducing this will lower audio quality, but what settings to use are largely dependant on the sound being played.  A noisy polyphonic signal will need higher fft size compared to a speaking voice for example.
+    
+    This pitch shifter is based on the pitch shifter code at http://www.dspdimension.com, written by Stephan M. Bernsee.
+    The original code is COPYRIGHT 1999-2003 Stephan M. Bernsee <smb@dspdimension.com>.
+    
+    '<i>maxchannels</i>' dictates the amount of memory allocated.  By default, the maxchannels value is 0.  If FMOD is set to stereo, the pitch shift unit will allocate enough memory for 2 channels.  If it is 5.1, it will allocate enough memory for a 6 channel pitch shift, etc.
+    If the pitch shift effect is only ever applied to the global mix (ie it was added with System::addDSP), then 0 is the value to set as it will be enough to handle all speaker modes.
+    When the pitch shift is added to a channel (ie Channel::addDSP) then the channel count that comes in could be anything from 1 to 8 possibly.  It is only in this case where you might want to increase the channel count above the output's channel count.
+    If a channel pitch shift is set to a lower number than the sound's channel count that is coming in, it will not pitch shift the sound.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_PITCHSHIFT_PITCH,       /* Pitch value.  0.5 to 2.0.  Default = 1.0. 0.5 = one octave down, 2.0 = one octave up.  1.0 does not change the pitch. */
+    FMOD_DSP_PITCHSHIFT_FFTSIZE,     /* FFT window size.  256, 512, 1024, 2048, 4096.  Default = 1024.  Increase this to reduce 'smearing'.  This effect is a warbling sound similar to when an mp3 is encoded at very low bitrates. */
+    FMOD_DSP_PITCHSHIFT_OVERLAP,     /* Removed.  Do not use.  FMOD now uses 4 overlaps and cannot be changed. */
+    FMOD_DSP_PITCHSHIFT_MAXCHANNELS  /* Maximum channels supported.  0 to 16.  0 = same as fmod's default output polyphony, 1 = mono, 2 = stereo etc.  See remarks for more.  Default = 0.  It is suggested to leave at 0! */
+} FMOD_DSP_PITCHSHIFT;
+
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_CHORUS filter.
+
+    [REMARKS]
+    Chrous is an effect where the sound is more 'spacious' due to 1 to 3 versions of the sound being played along side the original signal but with the pitch of each copy modulating on a sine wave.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_CHORUS_DRYMIX,   /* Volume of original signal to pass to output.  0.0 to 1.0. Default = 0.5. */
+    FMOD_DSP_CHORUS_WETMIX1,  /* Volume of 1st chorus tap.  0.0 to 1.0.  Default = 0.5. */
+    FMOD_DSP_CHORUS_WETMIX2,  /* Volume of 2nd chorus tap. This tap is 90 degrees out of phase of the first tap.  0.0 to 1.0.  Default = 0.5. */
+    FMOD_DSP_CHORUS_WETMIX3,  /* Volume of 3rd chorus tap. This tap is 90 degrees out of phase of the second tap.  0.0 to 1.0.  Default = 0.5. */
+    FMOD_DSP_CHORUS_DELAY,    /* Chorus delay in ms.  0.1 to 100.0.  Default = 40.0 ms. */
+    FMOD_DSP_CHORUS_RATE,     /* Chorus modulation rate in hz.  0.0 to 20.0.  Default = 0.8 hz. */
+    FMOD_DSP_CHORUS_DEPTH     /* Chorus modulation depth.  0.0 to 1.0.  Default = 0.03. */
+} FMOD_DSP_CHORUS;
+
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_ITECHO filter.
+    This is effectively a software based echo filter that emulates the DirectX DMO echo effect.  Impulse tracker files can support this, and FMOD will produce the effect on ANY platform, not just those that support DirectX effects!
+
+    [REMARKS]
+    Note.  Every time the delay is changed, the plugin re-allocates the echo buffer.  This means the echo will dissapear at that time while it refills its new buffer.
+    Larger echo delays result in larger amounts of memory allocated.
+    
+    As this is a stereo filter made mainly for IT playback, it is targeted for stereo signals.
+    With mono signals only the FMOD_DSP_ITECHO_LEFTDELAY is used.
+    For multichannel signals (>2) there will be no echo on those channels.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::SetParameter
+    DSP::GetParameter
+    FMOD_DSP_TYPE
+    System::addDSP
+]
+*/
+typedef enum
+{
+    FMOD_DSP_ITECHO_WETDRYMIX,      /* Ratio of wet (processed) signal to dry (unprocessed) signal. Must be in the range from 0.0 through 100.0 (all wet). The default value is 50. */
+    FMOD_DSP_ITECHO_FEEDBACK,       /* Percentage of output fed back into input, in the range from 0.0 through 100.0. The default value is 50. */
+    FMOD_DSP_ITECHO_LEFTDELAY,      /* Delay for left channel, in milliseconds, in the range from 1.0 through 2000.0. The default value is 500 ms. */
+    FMOD_DSP_ITECHO_RIGHTDELAY,     /* Delay for right channel, in milliseconds, in the range from 1.0 through 2000.0. The default value is 500 ms. */
+    FMOD_DSP_ITECHO_PANDELAY        /* Value that specifies whether to swap left and right delays with each successive echo. The default value is zero, meaning no swap. Possible values are defined as 0.0 (equivalent to FALSE) and 1.0 (equivalent to TRUE).  CURRENTLY NOT SUPPORTED. */
+} FMOD_DSP_ITECHO;
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_COMPRESSOR unit.
+    This is a simple linked multichannel software limiter that is uniform across the whole spectrum.
+
+    [REMARKS]
+    The limiter is not guaranteed to catch every peak above the threshold level,
+    because it cannot apply gain reduction instantaneously - the time delay is
+    determined by the attack time. However setting the attack time too short will
+    distort the sound, so it is a compromise. High level peaks can be avoided by
+    using a short attack time - but not too short, and setting the threshold a few
+    decibels below the critical level.
+    
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::SetParameter
+    DSP::GetParameter
+    FMOD_DSP_TYPE
+    System::addDSP
+]
+*/
+typedef enum
+{
+    FMOD_DSP_COMPRESSOR_THRESHOLD,  /* Threshold level (dB) in the range from -60 through 0. The default value is 0. */ 
+    FMOD_DSP_COMPRESSOR_ATTACK,     /* Gain reduction attack time (milliseconds), in the range from 10 through 200. The default value is 50. */
+    FMOD_DSP_COMPRESSOR_RELEASE,    /* Gain reduction release time (milliseconds), in the range from 20 through 1000. The default value is 50. */
+    FMOD_DSP_COMPRESSOR_GAINMAKEUP  /* Make-up gain (dB) applied after limiting, in the range from 0 through 30. The default value is 0. */
+} FMOD_DSP_COMPRESSOR;
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_SFXREVERB unit.
+    
+    [REMARKS]
+    This is a high quality I3DL2 based reverb.
+    On top of the I3DL2 property set, "Dry Level" is also included to allow the dry mix to be changed.
+    
+    These properties can be set with presets in FMOD_REVERB_PRESETS.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::SetParameter
+    DSP::GetParameter
+    FMOD_DSP_TYPE
+    System::addDSP
+    FMOD_REVERB_PRESETS
+]
+*/
+typedef enum
+{
+    FMOD_DSP_SFXREVERB_DRYLEVEL,            /* Dry Level      : Mix level of dry signal in output in mB.  Ranges from -10000.0 to 0.0.  Default is 0. */
+    FMOD_DSP_SFXREVERB_ROOM,                /* Room           : Room effect level at low frequencies in mB.  Ranges from -10000.0 to 0.0.  Default is -10000.0. */
+    FMOD_DSP_SFXREVERB_ROOMHF,              /* Room HF        : Room effect high-frequency level re. low frequency level in mB.  Ranges from -10000.0 to 0.0.  Default is 0.0. */
+    FMOD_DSP_SFXREVERB_DECAYTIME,           /* Decay Time     : Reverberation decay time at low-frequencies in seconds.  Ranges from 0.1 to 20.0. Default is 1.0. */
+    FMOD_DSP_SFXREVERB_DECAYHFRATIO,        /* Decay HF Ratio : High-frequency to low-frequency decay time ratio.  Ranges from 0.1 to 2.0. Default is 0.5. */
+    FMOD_DSP_SFXREVERB_REFLECTIONSLEVEL,    /* Reflections    : Early reflections level relative to room effect in mB.  Ranges from -10000.0 to 1000.0.  Default is -10000.0. */
+    FMOD_DSP_SFXREVERB_REFLECTIONSDELAY,    /* Reflect Delay  : Delay time of first reflection in seconds.  Ranges from 0.0 to 0.3.  Default is 0.02. */
+    FMOD_DSP_SFXREVERB_REVERBLEVEL,         /* Reverb         : Late reverberation level relative to room effect in mB.  Ranges from -10000.0 to 2000.0.  Default is 0.0. */
+    FMOD_DSP_SFXREVERB_REVERBDELAY,         /* Reverb Delay   : Late reverberation delay time relative to first reflection in seconds.  Ranges from 0.0 to 0.1.  Default is 0.04. */
+    FMOD_DSP_SFXREVERB_DIFFUSION,           /* Diffusion      : Reverberation diffusion (echo density) in percent.  Ranges from 0.0 to 100.0.  Default is 100.0. */
+    FMOD_DSP_SFXREVERB_DENSITY,             /* Density        : Reverberation density (modal density) in percent.  Ranges from 0.0 to 100.0.  Default is 100.0. */
+    FMOD_DSP_SFXREVERB_HFREFERENCE,         /* HF Reference   : Reference high frequency in Hz.  Ranges from 20.0 to 20000.0. Default is 5000.0. */
+    FMOD_DSP_SFXREVERB_ROOMLF,              /* Room LF        : Room effect low-frequency level in mB.  Ranges from -10000.0 to 0.0.  Default is 0.0. */
+    FMOD_DSP_SFXREVERB_LFREFERENCE          /* LF Reference   : Reference low-frequency in Hz.  Ranges from 20.0 to 1000.0. Default is 250.0. */
+} FMOD_DSP_SFXREVERB;
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_LOWPASS_SIMPLE filter.
+    This is a very simple low pass filter, based on two single-pole RC time-constant modules.
+    The emphasis is on speed rather than accuracy, so this should not be used for task requiring critical filtering. 
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_LOWPASS_SIMPLE_CUTOFF     /* Lowpass cutoff frequency in hz.  10.0 to 22000.0.  Default = 5000.0 */
+} FMOD_DSP_LOWPASS_SIMPLE;
+
+/*
+[ENUM]
+[  
+    [DESCRIPTION]   
+    Parameter types for the FMOD_DSP_TYPE_HIGHPASS_SIMPLE filter.
+    This is a very simple single-order high pass filter.
+    The emphasis is on speed rather than accuracy, so this should not be used for task requiring critical filtering. 
+
+    [REMARKS]
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]      
+    DSP::setParameter
+    DSP::getParameter
+    FMOD_DSP_TYPE
+]
+*/
+typedef enum
+{
+    FMOD_DSP_HIGHPASS_SIMPLE_CUTOFF     /* Highpass cutoff frequency in hz.  10.0 to 22000.0.  Default = 1000.0 */
+} FMOD_DSP_HIGHPASS_SIMPLE;
+
+#endif
+

--- a/src/moaicore/fmodinc/fmod_errors.h
+++ b/src/moaicore/fmodinc/fmod_errors.h
@@ -1,0 +1,123 @@
+
+/* ============================================================================================== */
+/* FMOD Ex - Error string header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011. */
+/*                                                                                                */
+/* Use this header if you want to store or display a string version / english explanation of      */
+/* the FMOD error codes.                                                                          */
+/*                                                                                                */
+/* ============================================================================================== */
+
+#ifndef _FMOD_ERRORS_H
+#define _FMOD_ERRORS_H
+
+#include "fmod.h"
+
+#ifdef __GNUC__ 
+static const char *FMOD_ErrorString(FMOD_RESULT errcode) __attribute__((unused));
+#endif
+
+static const char *FMOD_ErrorString(FMOD_RESULT errcode)
+{
+    switch (errcode)
+    {
+        case FMOD_ERR_ALREADYLOCKED:          return "Tried to call lock a second time before unlock was called. ";
+        case FMOD_ERR_BADCOMMAND:             return "Tried to call a function on a data type that does not allow this type of functionality (ie calling Sound::lock on a streaming sound). ";
+        case FMOD_ERR_CDDA_DRIVERS:           return "Neither NTSCSI nor ASPI could be initialised. ";
+        case FMOD_ERR_CDDA_INIT:              return "An error occurred while initialising the CDDA subsystem. ";
+        case FMOD_ERR_CDDA_INVALID_DEVICE:    return "Couldn't find the specified device. ";
+        case FMOD_ERR_CDDA_NOAUDIO:           return "No audio tracks on the specified disc. ";
+        case FMOD_ERR_CDDA_NODEVICES:         return "No CD/DVD devices were found. ";
+        case FMOD_ERR_CDDA_NODISC:            return "No disc present in the specified drive. ";
+        case FMOD_ERR_CDDA_READ:              return "A CDDA read error occurred. ";
+        case FMOD_ERR_CHANNEL_ALLOC:          return "Error trying to allocate a channel. ";
+        case FMOD_ERR_CHANNEL_STOLEN:         return "The specified channel has been reused to play another sound. ";
+        case FMOD_ERR_COM:                    return "A Win32 COM related error occured. COM failed to initialize or a QueryInterface failed meaning a Windows codec or driver was not installed properly. ";
+        case FMOD_ERR_DMA:                    return "DMA Failure.  See debug output for more information. ";
+        case FMOD_ERR_DSP_CONNECTION:         return "DSP connection error.  Connection possibly caused a cyclic dependancy.  Or tried to connect a tree too many units deep (more than 128). ";
+        case FMOD_ERR_DSP_FORMAT:             return "DSP Format error.  A DSP unit may have attempted to connect to this network with the wrong format. ";
+        case FMOD_ERR_DSP_NOTFOUND:           return "DSP connection error.  Couldn't find the DSP unit specified. ";
+        case FMOD_ERR_DSP_RUNNING:            return "DSP error.  Cannot perform this operation while the network is in the middle of running.  This will most likely happen if a connection or disconnection is attempted in a DSP callback. ";
+        case FMOD_ERR_DSP_TOOMANYCONNECTIONS: return "DSP connection error.  The unit being connected to or disconnected should only have 1 input or output. ";
+        case FMOD_ERR_EVENT_ALREADY_LOADED:   return "The specified project or bank has already been loaded. Having multiple copies of the same project loaded simultaneously is forbidden. ";
+        case FMOD_ERR_EVENT_FAILED:           return "An Event failed to be retrieved, most likely due to 'just fail' being specified as the max playbacks behavior. ";
+        case FMOD_ERR_EVENT_GUIDCONFLICT:     return "An event with the same GUID already exists. ";
+        case FMOD_ERR_EVENT_INFOONLY:         return "Can't execute this command on an EVENT_INFOONLY event. ";
+        case FMOD_ERR_EVENT_INTERNAL:         return "An error occured that wasn't supposed to.  See debug log for reason. ";
+        case FMOD_ERR_EVENT_MAXSTREAMS:       return "Event failed because 'Max streams' was hit when FMOD_EVENT_INIT_FAIL_ON_MAXSTREAMS was specified. ";
+        case FMOD_ERR_EVENT_MISMATCH:         return "FSB mismatches the FEV it was compiled with, the stream/sample mode it was meant to be created with was different, or the FEV was built for a different platform. ";
+        case FMOD_ERR_EVENT_NAMECONFLICT:     return "A category with the same name already exists. ";
+        case FMOD_ERR_EVENT_NEEDSSIMPLE:      return "Tried to call a function on a complex event that's only supported by simple events. ";
+        case FMOD_ERR_EVENT_NOTFOUND:         return "The requested event, event group, event category or event property could not be found. ";
+        case FMOD_ERR_FILE_BAD:               return "Error loading file. ";
+        case FMOD_ERR_FILE_COULDNOTSEEK:      return "Couldn't perform seek operation.  This is a limitation of the medium (ie netstreams) or the file format. ";
+        case FMOD_ERR_FILE_DISKEJECTED:       return "Media was ejected while reading. ";
+        case FMOD_ERR_FILE_EOF:               return "End of file unexpectedly reached while trying to read essential data (truncated data?). ";
+        case FMOD_ERR_FILE_NOTFOUND:          return "File not found. ";
+        case FMOD_ERR_FILE_UNWANTED:          return "Unwanted file access occured. ";
+        case FMOD_ERR_FORMAT:                 return "Unsupported file or audio format. ";
+        case FMOD_ERR_HTTP:                   return "A HTTP error occurred. This is a catch-all for HTTP errors not listed elsewhere. ";
+        case FMOD_ERR_HTTP_ACCESS:            return "The specified resource requires authentication or is forbidden. ";
+        case FMOD_ERR_HTTP_PROXY_AUTH:        return "Proxy authentication is required to access the specified resource. ";
+        case FMOD_ERR_HTTP_SERVER_ERROR:      return "A HTTP server error occurred. ";
+        case FMOD_ERR_HTTP_TIMEOUT:           return "The HTTP request timed out. ";
+        case FMOD_ERR_INITIALIZATION:         return "FMOD was not initialized correctly to support this function. ";
+        case FMOD_ERR_INITIALIZED:            return "Cannot call this command after System::init. ";
+        case FMOD_ERR_INTERNAL:               return "An error occured that wasn't supposed to.  Contact support. ";
+        case FMOD_ERR_INVALID_ADDRESS:        return "On Xbox 360, this memory address passed to FMOD must be physical, (ie allocated with XPhysicalAlloc.) ";
+        case FMOD_ERR_INVALID_FLOAT:          return "Value passed in was a NaN, Inf or denormalized float. ";
+        case FMOD_ERR_INVALID_HANDLE:         return "An invalid object handle was used. ";
+        case FMOD_ERR_INVALID_PARAM:          return "An invalid parameter was passed to this function. ";
+        case FMOD_ERR_INVALID_POSITION:       return "An invalid seek position was passed to this function. ";
+        case FMOD_ERR_INVALID_SPEAKER:        return "An invalid speaker was passed to this function based on the current speaker mode. ";
+        case FMOD_ERR_INVALID_SYNCPOINT:      return "The syncpoint did not come from this sound handle. ";
+        case FMOD_ERR_INVALID_VECTOR:         return "The vectors passed in are not unit length, or perpendicular. ";
+        case FMOD_ERR_MAXAUDIBLE:             return "Reached maximum audible playback count for this sound's soundgroup. ";
+        case FMOD_ERR_MEMORY:                 return "Not enough memory or resources. ";
+        case FMOD_ERR_MEMORY_CANTPOINT:       return "Can't use FMOD_OPENMEMORY_POINT on non PCM source data, or non mp3/xma/adpcm data if FMOD_CREATECOMPRESSEDSAMPLE was used. ";
+        case FMOD_ERR_MEMORY_SRAM:            return "Not enough memory or resources on console sound ram. ";
+        case FMOD_ERR_MUSIC_NOCALLBACK:       return "The music callback is required, but it has not been set. ";
+        case FMOD_ERR_MUSIC_NOTFOUND:         return "The requested music entity could not be found. ";
+        case FMOD_ERR_MUSIC_UNINITIALIZED:    return "Music system is not initialized probably because no music data is loaded. ";
+        case FMOD_ERR_NEEDS2D:                return "Tried to call a command on a 3d sound when the command was meant for 2d sound. ";
+        case FMOD_ERR_NEEDS3D:                return "Tried to call a command on a 2d sound when the command was meant for 3d sound. ";
+        case FMOD_ERR_NEEDSHARDWARE:          return "Tried to use a feature that requires hardware support.  (ie trying to play a GCADPCM compressed sound in software on Wii). ";
+        case FMOD_ERR_NEEDSSOFTWARE:          return "Tried to use a feature that requires the software engine.  Software engine has either been turned off, or command was executed on a hardware channel which does not support this feature. ";
+        case FMOD_ERR_NET_CONNECT:            return "Couldn't connect to the specified host. ";
+        case FMOD_ERR_NET_SOCKET_ERROR:       return "A socket error occurred.  This is a catch-all for socket-related errors not listed elsewhere. ";
+        case FMOD_ERR_NET_URL:                return "The specified URL couldn't be resolved. ";
+        case FMOD_ERR_NET_WOULD_BLOCK:        return "Operation on a non-blocking socket could not complete immediately. ";
+        case FMOD_ERR_NOTREADY:               return "Operation could not be performed because specified sound/DSP connection is not ready. ";
+        case FMOD_ERR_OUTPUT_ALLOCATED:       return "Error initializing output device, but more specifically, the output device is already in use and cannot be reused. ";
+        case FMOD_ERR_OUTPUT_CREATEBUFFER:    return "Error creating hardware sound buffer. ";
+        case FMOD_ERR_OUTPUT_DRIVERCALL:      return "A call to a standard soundcard driver failed, which could possibly mean a bug in the driver or resources were missing or exhausted. ";
+        case FMOD_ERR_OUTPUT_ENUMERATION:     return "Error enumerating the available driver list. List may be inconsistent due to a recent device addition or removal. ";
+        case FMOD_ERR_OUTPUT_FORMAT:          return "Soundcard does not support the minimum features needed for this soundsystem (16bit stereo output). ";
+        case FMOD_ERR_OUTPUT_INIT:            return "Error initializing output device. ";
+        case FMOD_ERR_OUTPUT_NOHARDWARE:      return "FMOD_HARDWARE was specified but the sound card does not have the resources necessary to play it. ";
+        case FMOD_ERR_OUTPUT_NOSOFTWARE:      return "Attempted to create a software sound but no software channels were specified in System::init. ";
+        case FMOD_ERR_PAN:                    return "Panning only works with mono or stereo sound sources. ";
+        case FMOD_ERR_PLUGIN:                 return "An unspecified error has been returned from a 3rd party plugin. ";
+        case FMOD_ERR_PLUGIN_INSTANCES:       return "The number of allowed instances of a plugin has been exceeded. ";
+        case FMOD_ERR_PLUGIN_MISSING:         return "A requested output, dsp unit type or codec was not available. ";
+        case FMOD_ERR_PLUGIN_RESOURCE:        return "A resource that the plugin requires cannot be found. (ie the DLS file for MIDI playback) ";
+        case FMOD_ERR_PRELOADED:              return "The specified sound is still in use by the event system, call EventSystem::unloadFSB before trying to release it. ";
+        case FMOD_ERR_PROGRAMMERSOUND:        return "The specified sound is still in use by the event system, wait for the event which is using it finish with it. ";
+        case FMOD_ERR_RECORD:                 return "An error occured trying to initialize the recording device. ";
+        case FMOD_ERR_REVERB_INSTANCE:        return "Specified instance in FMOD_REVERB_PROPERTIES couldn't be set. Most likely because it is an invalid instance number or the reverb doesnt exist. ";
+        case FMOD_ERR_SUBSOUNDS:              return "The error occured because the sound referenced contains subsounds when it shouldn't have, or it doesn't contain subsounds when it should have.  The operation may also not be able to be performed on a parent sound, or a parent sound was played without setting up a sentence first. ";
+        case FMOD_ERR_SUBSOUND_ALLOCATED:     return "This subsound is already being used by another sound, you cannot have more than one parent to a sound.  Null out the other parent's entry first. ";
+        case FMOD_ERR_SUBSOUND_CANTMOVE:      return "Shared subsounds cannot be replaced or moved from their parent stream, such as when the parent stream is an FSB file. ";
+        case FMOD_ERR_SUBSOUND_MODE:          return "The subsound's mode bits do not match with the parent sound's mode bits.  See documentation for function that it was called with. ";
+        case FMOD_ERR_TAGNOTFOUND:            return "The specified tag could not be found or there are no tags. ";
+        case FMOD_ERR_TOOMANYCHANNELS:        return "The sound created exceeds the allowable input channel count.  This can be increased using the maxinputchannels parameter in System::setSoftwareFormat. ";
+        case FMOD_ERR_UNIMPLEMENTED:          return "Something in FMOD hasn't been implemented when it should be! contact support! ";
+        case FMOD_ERR_UNINITIALIZED:          return "This command failed because System::init or System::setDriver was not called. ";
+        case FMOD_ERR_UNSUPPORTED:            return "A command issued was not supported by this object.  Possibly a plugin without certain callbacks specified. ";
+        case FMOD_ERR_UPDATE:                 return "An error caused by System::update occured. ";
+        case FMOD_ERR_VERSION:                return "The version number of this file format is not supported. ";
+        case FMOD_OK:                         return "No errors.";
+        default :                             return "Unknown error.";
+    };
+}
+
+#endif

--- a/src/moaicore/fmodinc/fmod_memoryinfo.h
+++ b/src/moaicore/fmodinc/fmod_memoryinfo.h
@@ -1,0 +1,201 @@
+/* ============================================================================================= */
+/* FMOD Ex - Memory info header file. Copyright (c), Firelight Technologies Pty, Ltd. 2008-2011. */
+/*                                                                                               */
+/* Use this header if you are interested in getting detailed information on FMOD's memory        */
+/* usage. See the documentation for more details.                                                */
+/*                                                                                               */
+/* ============================================================================================= */
+
+#ifndef _FMOD_MEMORYINFO_H
+#define _FMOD_MEMORYINFO_H
+
+/*
+[STRUCTURE]
+[
+    [DESCRIPTION]
+    Structure to be filled with detailed memory usage information of an FMOD object
+
+    [REMARKS]
+    Every public FMOD class has a getMemoryInfo function which can be used to get detailed information on what memory resources are associated with the object in question. 
+    On return from getMemoryInfo, each member of this structure will hold the amount of memory used for its type in bytes.
+    
+    Members marked with [in] mean the user sets the value before passing it to the function.
+    Members marked with [out] mean FMOD sets the value to be used after the function exits.
+
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    System::getMemoryInfo
+    EventSystem::getMemoryInfo
+    FMOD_MEMBITS    
+    FMOD_EVENT_MEMBITS
+]
+*/
+typedef struct FMOD_MEMORY_USAGE_DETAILS
+{
+    unsigned int other;                          /* [out] Memory not accounted for by other types */
+    unsigned int string;                         /* [out] String data */
+    unsigned int system;                         /* [out] System object and various internals */
+    unsigned int plugins;                        /* [out] Plugin objects and internals */
+    unsigned int output;                         /* [out] Output module object and internals */
+    unsigned int channel;                        /* [out] Channel related memory */
+    unsigned int channelgroup;                   /* [out] ChannelGroup objects and internals */
+    unsigned int codec;                          /* [out] Codecs allocated for streaming */
+    unsigned int file;                           /* [out] File buffers and structures */
+    unsigned int sound;                          /* [out] Sound objects and internals */
+    unsigned int secondaryram;                   /* [out] Sound data stored in secondary RAM */
+    unsigned int soundgroup;                     /* [out] SoundGroup objects and internals */
+    unsigned int streambuffer;                   /* [out] Stream buffer memory */
+    unsigned int dspconnection;                  /* [out] DSPConnection objects and internals */
+    unsigned int dsp;                            /* [out] DSP implementation objects */
+    unsigned int dspcodec;                       /* [out] Realtime file format decoding DSP objects */
+    unsigned int profile;                        /* [out] Profiler memory footprint. */
+    unsigned int recordbuffer;                   /* [out] Buffer used to store recorded data from microphone */
+    unsigned int reverb;                         /* [out] Reverb implementation objects */
+    unsigned int reverbchannelprops;             /* [out] Reverb channel properties structs */
+    unsigned int geometry;                       /* [out] Geometry objects and internals */
+    unsigned int syncpoint;                      /* [out] Sync point memory. */
+    unsigned int eventsystem;                    /* [out] EventSystem and various internals */
+    unsigned int musicsystem;                    /* [out] MusicSystem and various internals */
+    unsigned int fev;                            /* [out] Definition of objects contained in all loaded projects e.g. events, groups, categories */
+    unsigned int memoryfsb;                      /* [out] Data loaded with preloadFSB */
+    unsigned int eventproject;                   /* [out] EventProject objects and internals */
+    unsigned int eventgroupi;                    /* [out] EventGroup objects and internals */
+    unsigned int soundbankclass;                 /* [out] Objects used to manage wave banks */
+    unsigned int soundbanklist;                  /* [out] Data used to manage lists of wave bank usage */
+    unsigned int streaminstance;                 /* [out] Stream objects and internals */
+    unsigned int sounddefclass;                  /* [out] Sound definition objects */
+    unsigned int sounddefdefclass;               /* [out] Sound definition static data objects */
+    unsigned int sounddefpool;                   /* [out] Sound definition pool data */
+    unsigned int reverbdef;                      /* [out] Reverb definition objects */
+    unsigned int eventreverb;                    /* [out] Reverb objects */
+    unsigned int userproperty;                   /* [out] User property objects */
+    unsigned int eventinstance;                  /* [out] Event instance base objects */
+    unsigned int eventinstance_complex;          /* [out] Complex event instance objects */
+    unsigned int eventinstance_simple;           /* [out] Simple event instance objects */
+    unsigned int eventinstance_layer;            /* [out] Event layer instance objects */
+    unsigned int eventinstance_sound;            /* [out] Event sound instance objects */
+    unsigned int eventenvelope;                  /* [out] Event envelope objects */
+    unsigned int eventenvelopedef;               /* [out] Event envelope definition objects */
+    unsigned int eventparameter;                 /* [out] Event parameter objects */
+    unsigned int eventcategory;                  /* [out] Event category objects */
+    unsigned int eventenvelopepoint;             /* [out] Event envelope point objects */
+    unsigned int eventinstancepool;              /* [out] Event instance pool memory */
+} FMOD_MEMORY_USAGE_DETAILS;
+
+
+/*
+[DEFINE]
+[
+    [NAME]
+    FMOD_MEMBITS
+
+    [DESCRIPTION]
+    Bitfield used to request specific memory usage information from the getMemoryInfo function of every public FMOD Ex class.
+    Use with the "memorybits" parameter of getMemoryInfo to get information on FMOD Ex memory usage.
+
+    [REMARKS]
+    Every public FMOD class has a getMemoryInfo function which can be used to get detailed information on what memory resources are associated with the object in question. 
+    The FMOD_MEMBITS defines can be OR'd together to specify precisely what memory usage you'd like to get information on. See System::getMemoryInfo for an example.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_EVENT_MEMBITS
+    System::getMemoryInfo
+]
+*/
+#define FMOD_MEMBITS_OTHER                       0x00000001  /* Memory not accounted for by other types */
+#define FMOD_MEMBITS_STRING                      0x00000002  /* String data */
+
+#define FMOD_MEMBITS_SYSTEM                      0x00000004  /* System object and various internals */
+#define FMOD_MEMBITS_PLUGINS                     0x00000008  /* Plugin objects and internals */
+#define FMOD_MEMBITS_OUTPUT                      0x00000010  /* Output module object and internals */
+#define FMOD_MEMBITS_CHANNEL                     0x00000020  /* Channel related memory */
+#define FMOD_MEMBITS_CHANNELGROUP                0x00000040  /* ChannelGroup objects and internals */
+#define FMOD_MEMBITS_CODEC                       0x00000080  /* Codecs allocated for streaming */
+#define FMOD_MEMBITS_FILE                        0x00000100  /* Codecs allocated for streaming */
+#define FMOD_MEMBITS_SOUND                       0x00000200  /* Sound objects and internals */
+#define FMOD_MEMBITS_SOUND_SECONDARYRAM          0x00000400  /* Sound data stored in secondary RAM */
+#define FMOD_MEMBITS_SOUNDGROUP                  0x00000800  /* SoundGroup objects and internals */
+#define FMOD_MEMBITS_STREAMBUFFER                0x00001000  /* Stream buffer memory */
+#define FMOD_MEMBITS_DSPCONNECTION               0x00002000  /* DSPConnection objects and internals */
+#define FMOD_MEMBITS_DSP                         0x00004000  /* DSP implementation objects */
+#define FMOD_MEMBITS_DSPCODEC                    0x00008000  /* Realtime file format decoding DSP objects */
+#define FMOD_MEMBITS_PROFILE                     0x00010000  /* Profiler memory footprint. */
+#define FMOD_MEMBITS_RECORDBUFFER                0x00020000  /* Buffer used to store recorded data from microphone */
+#define FMOD_MEMBITS_REVERB                      0x00040000  /* Reverb implementation objects */
+#define FMOD_MEMBITS_REVERBCHANNELPROPS          0x00080000  /* Reverb channel properties structs */
+#define FMOD_MEMBITS_GEOMETRY                    0x00100000  /* Geometry objects and internals */
+#define FMOD_MEMBITS_SYNCPOINT                   0x00200000  /* Sync point memory. */
+#define FMOD_MEMBITS_ALL                         0xffffffff  /* All memory used by FMOD Ex */
+/* [DEFINE_END] */
+
+
+/*
+[DEFINE]
+[
+    [NAME]
+    FMOD_EVENT_MEMBITS
+
+    [DESCRIPTION]
+    Bitfield used to request specific memory usage information from the getMemoryInfo function of every public FMOD Event System class.
+    Use with the "event_memorybits" parameter of getMemoryInfo to get information on FMOD Event System memory usage.
+
+    [REMARKS]
+    Every public FMOD Event System class has a getMemoryInfo function which can be used to get detailed information on what memory resources are associated with the object in question. 
+    The FMOD_EVENT_MEMBITS defines can be OR'd together to specify precisely what memory usage you'd like to get information on. See EventSystem::getMemoryInfo for an example.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_MEMBITS
+    System::getMemoryInfo
+]
+*/                                               
+#define FMOD_EVENT_MEMBITS_EVENTSYSTEM           0x00000001  /* EventSystem and various internals */
+#define FMOD_EVENT_MEMBITS_MUSICSYSTEM           0x00000002  /* MusicSystem and various internals */
+#define FMOD_EVENT_MEMBITS_FEV                   0x00000004  /* Definition of objects contained in all loaded projects e.g. events, groups, categories */
+#define FMOD_EVENT_MEMBITS_MEMORYFSB             0x00000008  /* Data loaded with preloadFSB */
+#define FMOD_EVENT_MEMBITS_EVENTPROJECT          0x00000010  /* EventProject objects and internals */
+#define FMOD_EVENT_MEMBITS_EVENTGROUPI           0x00000020  /* EventGroup objects and internals */
+#define FMOD_EVENT_MEMBITS_SOUNDBANKCLASS        0x00000040  /* Objects used to manage wave banks */
+#define FMOD_EVENT_MEMBITS_SOUNDBANKLIST         0x00000080  /* Data used to manage lists of wave bank usage */
+#define FMOD_EVENT_MEMBITS_STREAMINSTANCE        0x00000100  /* Stream objects and internals */
+#define FMOD_EVENT_MEMBITS_SOUNDDEFCLASS         0x00000200  /* Sound definition objects */
+#define FMOD_EVENT_MEMBITS_SOUNDDEFDEFCLASS      0x00000400  /* Sound definition static data objects */
+#define FMOD_EVENT_MEMBITS_SOUNDDEFPOOL          0x00000800  /* Sound definition pool data */
+#define FMOD_EVENT_MEMBITS_REVERBDEF             0x00001000  /* Reverb definition objects */
+#define FMOD_EVENT_MEMBITS_EVENTREVERB           0x00002000  /* Reverb objects */
+#define FMOD_EVENT_MEMBITS_USERPROPERTY          0x00004000  /* User property objects */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE         0x00008000  /* Event instance base objects */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE_COMPLEX 0x00010000  /* Complex event instance objects */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE_SIMPLE  0x00020000  /* Simple event instance objects */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE_LAYER   0x00040000  /* Event layer instance objects */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE_SOUND   0x00080000  /* Event sound instance objects */
+#define FMOD_EVENT_MEMBITS_EVENTENVELOPE         0x00100000  /* Event envelope objects */
+#define FMOD_EVENT_MEMBITS_EVENTENVELOPEDEF      0x00200000  /* Event envelope definition objects */
+#define FMOD_EVENT_MEMBITS_EVENTPARAMETER        0x00400000  /* Event parameter objects */
+#define FMOD_EVENT_MEMBITS_EVENTCATEGORY         0x00800000  /* Event category objects */
+#define FMOD_EVENT_MEMBITS_EVENTENVELOPEPOINT    0x01000000  /* Event envelope point object+s */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCEPOOL     0x02000000  /* Event instance pool data */
+#define FMOD_EVENT_MEMBITS_ALL                   0xffffffff  /* All memory used by FMOD Event System */
+
+/* All event instance memory */
+#define FMOD_EVENT_MEMBITS_EVENTINSTANCE_GROUP   (FMOD_EVENT_MEMBITS_EVENTINSTANCE            | \
+                                                     FMOD_EVENT_MEMBITS_EVENTINSTANCE_COMPLEX | \
+                                                     FMOD_EVENT_MEMBITS_EVENTINSTANCE_SIMPLE  | \
+                                                     FMOD_EVENT_MEMBITS_EVENTINSTANCE_LAYER   | \
+                                                     FMOD_EVENT_MEMBITS_EVENTINSTANCE_SOUND)
+
+/* All sound definition memory */
+#define FMOD_EVENT_MEMBITS_SOUNDDEF_GROUP        (FMOD_EVENT_MEMBITS_SOUNDDEFCLASS            | \
+                                                     FMOD_EVENT_MEMBITS_SOUNDDEFDEFCLASS      | \
+                                                     FMOD_EVENT_MEMBITS_SOUNDDEFPOOL)
+/* [DEFINE_END] */
+
+#endif

--- a/src/moaicore/fmodinc/fmod_output.h
+++ b/src/moaicore/fmodinc/fmod_output.h
@@ -1,0 +1,93 @@
+/* ==================================================================================================== */
+/* FMOD Ex - output development header file. Copyright (c), Firelight Technologies Pty, Ltd. 2004-2011. */
+/*                                                                                                      */
+/* Use this header if you are wanting to develop your own output plugin to use with                     */
+/* FMOD's output system.  With this header you can make your own output plugin that FMOD                */
+/* can register and use.  See the documentation and examples on how to make a working plugin.           */
+/*                                                                                                      */
+/* ==================================================================================================== */
+
+#ifndef _FMOD_OUTPUT_H
+#define _FMOD_OUTPUT_H
+
+#include "fmod.h"
+
+typedef struct FMOD_OUTPUT_STATE FMOD_OUTPUT_STATE;
+
+/*
+    Output callbacks
+*/ 
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_GETNUMDRIVERSCALLBACK)(FMOD_OUTPUT_STATE *output_state, int *numdrivers);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_GETDRIVERNAMECALLBACK)(FMOD_OUTPUT_STATE *output_state, int id, char *name, int namelen);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_GETDRIVERCAPSCALLBACK)(FMOD_OUTPUT_STATE *output_state, int id, FMOD_CAPS *caps);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_INITCALLBACK)         (FMOD_OUTPUT_STATE *output_state, int selecteddriver, FMOD_INITFLAGS flags, int *outputrate, int outputchannels, FMOD_SOUND_FORMAT *outputformat, int dspbufferlength, int dspnumbuffers, void *extradriverdata);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_CLOSECALLBACK)        (FMOD_OUTPUT_STATE *output_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_UPDATECALLBACK)       (FMOD_OUTPUT_STATE *output_state);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_GETHANDLECALLBACK)    (FMOD_OUTPUT_STATE *output_state, void **handle);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_GETPOSITIONCALLBACK)  (FMOD_OUTPUT_STATE *output_state, unsigned int *pcm);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_LOCKCALLBACK)         (FMOD_OUTPUT_STATE *output_state, unsigned int offset, unsigned int length, void **ptr1, void **ptr2, unsigned int *len1, unsigned int *len2);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_UNLOCKCALLBACK)       (FMOD_OUTPUT_STATE *output_state, void *ptr1, void *ptr2, unsigned int len1, unsigned int len2);
+typedef FMOD_RESULT (F_CALLBACK *FMOD_OUTPUT_READFROMMIXER)        (FMOD_OUTPUT_STATE *output_state, void *buffer, unsigned int length);
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    When creating an output, declare one of these and provide the relevant callbacks and name for FMOD to use when it opens and reads a file of this type.
+
+    [REMARKS]
+    Members marked with [in] mean the variable can be written to.  The user can set the value.
+    Members marked with [out] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_OUTPUT_STATE
+]
+*/
+typedef struct FMOD_OUTPUT_DESCRIPTION
+{
+    const char                        *name;                  /* [in] Name of the output. */
+    unsigned int                       version;               /* [in] Plugin writer's version number. */
+    int                                polling;               /* [in] If TRUE (non zero), this tells FMOD to start a thread and call getposition / lock / unlock for feeding data.  If 0, the output is probably callback based, so all the plugin needs to do is call readfrommixer to the appropriate pointer. */ 
+    FMOD_OUTPUT_GETNUMDRIVERSCALLBACK  getnumdrivers;         /* [in] For sound device enumeration.  This callback is to give System::getNumDrivers somthing to return. */
+    FMOD_OUTPUT_GETDRIVERNAMECALLBACK  getdrivername;         /* [in] For sound device enumeration.  This callback is to give System::getDriverName somthing to return. */
+    FMOD_OUTPUT_GETDRIVERCAPSCALLBACK  getdrivercaps;         /* [in] For sound device enumeration.  This callback is to give System::getDriverCaps somthing to return. */
+    FMOD_OUTPUT_INITCALLBACK           init;                  /* [in] Initialization function for the output device.  This is called from System::init. */
+    FMOD_OUTPUT_CLOSECALLBACK          close;                 /* [in] Cleanup / close down function for the output device.  This is called from System::close. */
+    FMOD_OUTPUT_UPDATECALLBACK         update;                /* [in] Update function that is called once a frame by the user.  This is called from System::update. */
+    FMOD_OUTPUT_GETHANDLECALLBACK      gethandle;             /* [in] This is called from System::getOutputHandle.  This is just to return a pointer to the internal system device object that the system may be using.*/
+    FMOD_OUTPUT_GETPOSITIONCALLBACK    getposition;           /* [in] This is called from the FMOD software mixer thread if 'polling' = true.  This returns a position value in samples so that FMOD knows where and when to fill its buffer. */
+    FMOD_OUTPUT_LOCKCALLBACK           lock;                  /* [in] This is called from the FMOD software mixer thread if 'polling' = true.  This function provides a pointer to data that FMOD can write to when software mixing. */
+    FMOD_OUTPUT_UNLOCKCALLBACK         unlock;                /* [in] This is called from the FMOD software mixer thread if 'polling' = true.  This optional function accepts the data that has been mixed and copies it or does whatever it needs to before sending it to the hardware. */
+} FMOD_OUTPUT_DESCRIPTION;
+
+
+/*
+[STRUCTURE] 
+[
+    [DESCRIPTION]
+    Output plugin structure that is passed into each callback.
+
+    [REMARKS]
+    Members marked with [in] mean the variable can be written to.  The user can set the value.
+    Members marked with [out] mean the variable is modified by FMOD and is for reading purposes only.  Do not change this value.
+
+    [PLATFORMS]
+    Win32, Win64, Linux, Linux64, Macintosh, Xbox360, PlayStation Portable, PlayStation 3, Wii, iPhone, 3GS, NGP, Android
+
+    [SEE_ALSO]
+    FMOD_OUTPUT_DESCRIPTION
+]
+*/
+struct FMOD_OUTPUT_STATE
+{
+    void                      *plugindata;      /* [in] Plugin writer created data the output author wants to attach to this object. */
+    FMOD_OUTPUT_READFROMMIXER  readfrommixer;   /* [out] Function to update mixer and write the result to the provided pointer.  Used from callback based output only.  Polling based output uses lock/unlock/getposition. */
+};
+
+#endif
+
+

--- a/src/moaicore/moaicore.cpp
+++ b/src/moaicore/moaicore.cpp
@@ -217,6 +217,13 @@ void moaicore::InitGlobals ( MOAIGlobals* globals ) {
 		REGISTER_LUA_CLASS ( MOAICpSpace )
 	#endif
 	
+	#if USE_FMODMUSICSYSTEM
+		REGISTER_LUA_CLASS(MOAIFmodMusicSystem)
+		REGISTER_LUA_CLASS(MOAIFmodMusicEntity)
+		REGISTER_LUA_CLASS(MOAIFmodMusicInfo)
+		REGISTER_LUA_CLASS(MOAIFmodReverbChannelproperties)
+	#endif
+	
 	#if USE_FREETYPE
 		REGISTER_LUA_CLASS ( MOAIFreeTypeFontReader )
 	#endif

--- a/src/moaicore/moaicore.h
+++ b/src/moaicore/moaicore.h
@@ -187,6 +187,13 @@
 	#include <moaicore/MOAIUrlMgrCurl.h>
 #endif
 
+#if USE_FMODMUSICSYSTEM
+	#include <moaicore/MOAIFmodMusicSystem.h>
+	#include <moaicore/MOAIFmodMusicEntity.h>
+	#include <moaicore/MOAIFmodMusicInfo.h>
+	#include <moaicore/MOAIFmodReverbChannelproperties.h>
+#endif
+
 #if MOAI_OS_NACL
 	#include <moaicore/MOAIHttpTaskNaCl.h>
 	#include <moaicore/MOAIUrlMgrNaCl.h>


### PR DESCRIPTION
As a part of a course in my master studies we had to implement FMod Wrapper classes for MOAI. Me and my colleague implemented the MusicSystem and some more classes like MusicInfo and MusicEntity that are needed within MusicSystem.
The code itself was compiled and tested as far as we could but is not guarenteed to work since the class MOAIFmodEventSystem is still missing and needed for our class to work.

The includes and classed are included/registered in moaicore if USE_FMODMUSICSYSTEM is defined

It is required by our advisor to do a pull reqest
