### PR TITLE
fix edge case that new-created-paused action cannot receive further upda...

### DIFF
--- a/src/moaicore/MOAIAction.cpp
+++ b/src/moaicore/MOAIAction.cpp
@@ -393,8 +393,15 @@ void MOAIAction::Update ( float step, u32 pass, bool checkPass ) {
 
 	bool profilingEnabled = MOAIActionMgr::Get ().GetProfilingEnabled ();
 
-	if ( this->mIsPaused ) return;
-	if ( this->IsBlocked ()) return;
+	if ( this->mIsPaused || this->IsBlocked()){
+		if ( this->mNew ) { 		//avoid edge case that a new-created-paused action cannot receive further update
+			step = 0.0f;
+			checkPass = false;
+			this->mPass = 0;
+			this->mNew = false;
+		}
+		return;
+	} 
 	if (( checkPass ) && ( pass < this->mPass )) return;
 
 	double t0 = 0.0;


### PR DESCRIPTION
If a newly created Action is paused/blocked before its first update, its mPass will never be set to 0. It may cause it fail to receive further update after resuming.

I found this problem when I was implementing an action chain (use EVENT_STOP) today.
The chain worked fine until I put it inside a MOAICoroutine.
