### PR TITLE
Fixed MOAIEnvironemnt.screenDpi nil issue for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Thumbs.db
 .DS_Store
+*~
 /vs2010/ipch
 /vs2010/bin
 /vs2008/bin

--- a/ant/host-source/source/project/src/app/MoaiView.java
+++ b/ant/host-source/source/project/src/app/MoaiView.java
@@ -14,6 +14,7 @@ import android.opengl.GLSurfaceView;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.MotionEvent;
+import android.util.DisplayMetrics;
 
 // Moai
 import com.ziplinegames.moai.*;
@@ -48,7 +49,9 @@ public class MoaiView extends GLSurfaceView {
 		
 		setScreenDimensions ( width, height );
 		Moai.setScreenSize ( mWidth, mHeight );
-		
+		DisplayMetrics metrics = getResources().getDisplayMetrics();
+		Moai.setScreenDpi(metrics.densityDpi);
+
 		if ( glesVersion >= 0x20000 ) {
 			
 			// NOTE: Must be set before the renderer is set.

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -171,6 +171,7 @@ public class Moai {
 	protected static native void 	AKUSetInputDeviceLocation 		( int deviceId, int sensorId, String name );
 	protected static native void	AKUSetInputDeviceTouch 			( int deviceId, int sensorId, String name );
 	protected static native void 	AKUSetScreenSize				( int width, int height );
+	protected static native void    AKUSetScreenDpi                         ( int dpi );
 	protected static native void 	AKUSetViewSize					( int width, int height );
 	protected static native void 	AKUSetWorkingDirectory 			( String path );
 	protected static native void 	AKUUntzInit			 			();
@@ -478,6 +479,14 @@ public class Moai {
 		
 		synchronized ( sAkuLock ) {
 			AKUSetScreenSize ( width, height );
+		}
+	}	
+
+	//----------------------------------------------------------------//
+	public static void setScreenDpi ( int dpi ) {
+		
+		synchronized ( sAkuLock ) {
+			AKUSetScreenDpi ( dpi );
 		}
 	}	
 

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -63,6 +63,23 @@ long AKUGetIphoneNetworkReachability ( ) {
 }
 
 //----------------------------------------------------------------//
+float AKUCalcScreenDpi( UIScreen* screen ) {
+	float scale = 1;
+	if ([[	UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
+		scale = [[UIScreen mainScreen] scale];
+	}
+	float dpi;
+	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+		dpi = 132 * scale;
+	} else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+		dpi = 163 * scale;
+	} else {
+		dpi = 160 * scale;
+	}
+	return dpi;
+}
+
+//----------------------------------------------------------------//
 void AKUIphoneInit ( UIApplication* application ) {
 
 	loadMoaiLib_NSArray ();
@@ -126,6 +143,7 @@ void AKUIphoneInit ( UIApplication* application ) {
 	environment.SetValue ( MOAI_ENV_openUdid,			[[ MOAIOpenUDID value] UTF8String ]);
 	environment.SetValue ( MOAI_ENV_horizontalResolution, [[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ] );
 	environment.SetValue ( MOAI_ENV_verticalResolution, [[ UIScreen mainScreen ] bounds ].size.height * [[ UIScreen mainScreen ] scale ] );
+	environment.SetValue ( MOAI_ENV_screenDpi, AKUCalcScreenDpi( [ UIScreen mainScreen ] ));
 }
 
 //----------------------------------------------------------------//

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -141,8 +141,20 @@ void AKUIphoneInit ( UIApplication* application ) {
 	environment.SetValue ( MOAI_ENV_osVersion,			[[ UIDevice currentDevice ].systemVersion UTF8String ]);
 	environment.SetValue ( MOAI_ENV_resourceDirectory,	[[[ NSBundle mainBundle ] resourcePath ] UTF8String ]);
 	environment.SetValue ( MOAI_ENV_openUdid,			[[ MOAIOpenUDID value] UTF8String ]);
-	environment.SetValue ( MOAI_ENV_horizontalResolution, [[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ] );
-	environment.SetValue ( MOAI_ENV_verticalResolution, [[ UIScreen mainScreen ] bounds ].size.height * [[ UIScreen mainScreen ] scale ] );
+	
+	//Screen orientation fix. TODO: support other orientation masks.
+	BOOL landscapeOnly = ([[[application keyWindow] rootViewController] supportedInterfaceOrientations] == UIInterfaceOrientationMaskLandscape);
+	CGFloat screenWidth = [[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ];
+	CGFloat screenHeight = [[ UIScreen mainScreen ] bounds ].size.height * [[ UIScreen mainScreen ] scale ];
+	if (landscapeOnly) {
+		if (screenHeight > screenWidth) {
+			CGFloat temp = screenHeight;
+			screenHeight = screenWidth;
+			screenWidth = temp;
+		}
+	}
+	environment.SetValue ( MOAI_ENV_horizontalResolution, screenWidth);
+	environment.SetValue ( MOAI_ENV_verticalResolution,  screenHeight);
 	environment.SetValue ( MOAI_ENV_screenDpi, AKUCalcScreenDpi( [ UIScreen mainScreen ] ));
 }
 

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -70,10 +70,9 @@ static float AKUCalcScreenDpi( UIScreen* screen ) {
 	}
 	float dpi;
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+		//Not working for iPad Mini
 		dpi = 132 * scale;
-	} else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
-		dpi = 163 * scale;
-	} else {
+	}else{
 		dpi = 160 * scale;
 	}
 	return dpi;

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -63,10 +63,10 @@ long AKUGetIphoneNetworkReachability ( ) {
 }
 
 //----------------------------------------------------------------//
-float AKUCalcScreenDpi( UIScreen* screen ) {
+static float AKUCalcScreenDpi( UIScreen* screen ) {
 	float scale = 1;
-	if ([[	UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-		scale = [[UIScreen mainScreen] scale];
+	if ([screen respondsToSelector:@selector(scale)]) {
+		scale = [screen scale];
 	}
 	float dpi;
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {

--- a/src/moaicore/MOAISim.cpp
+++ b/src/moaicore/MOAISim.cpp
@@ -322,7 +322,7 @@ int MOAISim::_getTaskSubscriber ( lua_State* L ) {
 
 	MOAISim& device = MOAISim::Get ();
 	MOAILuaState state ( L );
-	state.Push ( device.mTaskSubscriber );
+	state.Push ( (int)device.mTaskSubscriber );
 
 	return 1;
 }

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -170,6 +170,142 @@
 		FA6515AE16AD8F9F005C79BA /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A716AD8F9F005C79BA /* libmoai-ios.a */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		FA347C7A16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03C2F6F4104DE130009A2D5D;
+			remoteInfo = "libmoai-ios";
+		};
+		FA347C7C16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0379C5961333ECD800E89DDC;
+			remoteInfo = "libmoai-ios-3rdparty";
+		};
+		FA347C7E16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0705D8C014F46A6D009537C3;
+			remoteInfo = "libmoai-ios-adcolony";
+		};
+		FA347C8016B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E98DBD571537A1C500514387;
+			remoteInfo = "libmoai-ios-chartboost";
+		};
+		FA347C8216B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 07F4C7B014FC440500FB78BA;
+			remoteInfo = "libmoai-ios-facebook";
+		};
+		FA347C8416B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDDD30921574AE0000C410A0;
+			remoteInfo = "libmoai-ios-fmod-designer";
+		};
+		FA347C8616B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD5089F9155E3A1B0002FC3B;
+			remoteInfo = "libmoai-ios-fmod-ex";
+		};
+		FA347C8816B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDD06BD01398822500AB0420;
+			remoteInfo = "libmoai-ios-luaext";
+		};
+		FA347C8A16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 073D58591459269600289D5C;
+			remoteInfo = "libmoai-ios-tapjoy";
+		};
+		FA347C8C16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD07C3CD13A182AA00C9386C;
+			remoteInfo = "libmoai-ios-untz";
+		};
+		FA347C8E16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 663BA372159D041D00F80FE9;
+			remoteInfo = "libmoai-ios-vungle";
+		};
+		FA347C9016B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD04ACB414725568009C20E5;
+			remoteInfo = "libmoai-ios-zlcore";
+		};
+		FA347C9216B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0324E2BB1356485F000ADC60;
+			remoteInfo = "libmoai-osx";
+		};
+		FA347C9416B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 0324E2AF1356485F000ADC60;
+			remoteInfo = "libmoai-osx-3rdparty";
+		};
+		FA347C9616B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDDD30A51574AE0F00C410A0;
+			remoteInfo = "libmoai-osx-fmod-designer";
+		};
+		FA347C9816B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDE8A802155E42EF00C2DFF5;
+			remoteInfo = "libmoai-osx-fmod-ex";
+		};
+		FA347C9A16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDD06D87139882D900AB0420;
+			remoteInfo = "libmoai-osx-luaext";
+		};
+		FA347C9C16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD07C4E513A1918600C9386C;
+			remoteInfo = "libmoai-osx-untz";
+		};
+		FA347C9E16B1653300252A0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD04AE7F1472557F009C20E5;
+			remoteInfo = "libmoai-osx-zlcore";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		037ED45813CD1FD2009CBA72 /* package.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = package.sh; sourceTree = "<group>"; };
 		03CC904F13B3C1B700B2724C /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-72.png"; sourceTree = "<group>"; };
@@ -486,6 +622,32 @@
 			path = "/usr/local/moai-sdk/xcode/ios";
 			sourceTree = "<absolute>";
 		};
+		FA347C6516B1653300252A0E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FA347C7B16B1653300252A0E /* libmoai-ios.a */,
+				FA347C7D16B1653300252A0E /* libmoai-ios-3rdparty.a */,
+				FA347C7F16B1653300252A0E /* libmoai-ios-adcolony.a */,
+				FA347C8116B1653300252A0E /* libmoai-ios-chartboost.a */,
+				FA347C8316B1653300252A0E /* libmoai-ios-facebook.a */,
+				FA347C8516B1653300252A0E /* liblibmoai-ios-fmod-designer.a */,
+				FA347C8716B1653300252A0E /* libmoai-ios-fmod-ex.a */,
+				FA347C8916B1653300252A0E /* libmoai-ios-luaext.a */,
+				FA347C8B16B1653300252A0E /* libmoai-ios-tapjoy.a */,
+				FA347C8D16B1653300252A0E /* libmoai-ios-untz.a */,
+				FA347C8F16B1653300252A0E /* libmoai-ios-vungle.a */,
+				FA347C9116B1653300252A0E /* libmoai-ios-zlcore.a */,
+				FA347C9316B1653300252A0E /* libmoai-osx.a */,
+				FA347C9516B1653300252A0E /* libmoai-osx-3rdparty.a */,
+				FA347C9716B1653300252A0E /* liblibmoai-osx-fmod-designer.a */,
+				FA347C9916B1653300252A0E /* libmoai-osx-fmod-ex.a */,
+				FA347C9B16B1653300252A0E /* libmoai-osx-luaext.a */,
+				FA347C9D16B1653300252A0E /* libmoai-osx-untz.a */,
+				FA347C9F16B1653300252A0E /* libmoai-osx-zlcore.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -563,6 +725,12 @@
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = FA347C6516B1653300252A0E /* Products */;
+					ProjectRef = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* moai */,
@@ -571,6 +739,142 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		FA347C7B16B1653300252A0E /* libmoai-ios.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios.a";
+			remoteRef = FA347C7A16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C7D16B1653300252A0E /* libmoai-ios-3rdparty.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-3rdparty.a";
+			remoteRef = FA347C7C16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C7F16B1653300252A0E /* libmoai-ios-adcolony.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-adcolony.a";
+			remoteRef = FA347C7E16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8116B1653300252A0E /* libmoai-ios-chartboost.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-chartboost.a";
+			remoteRef = FA347C8016B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8316B1653300252A0E /* libmoai-ios-facebook.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-facebook.a";
+			remoteRef = FA347C8216B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8516B1653300252A0E /* liblibmoai-ios-fmod-designer.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "liblibmoai-ios-fmod-designer.a";
+			remoteRef = FA347C8416B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8716B1653300252A0E /* libmoai-ios-fmod-ex.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-fmod-ex.a";
+			remoteRef = FA347C8616B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8916B1653300252A0E /* libmoai-ios-luaext.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-luaext.a";
+			remoteRef = FA347C8816B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8B16B1653300252A0E /* libmoai-ios-tapjoy.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-tapjoy.a";
+			remoteRef = FA347C8A16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8D16B1653300252A0E /* libmoai-ios-untz.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-untz.a";
+			remoteRef = FA347C8C16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C8F16B1653300252A0E /* libmoai-ios-vungle.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-vungle.a";
+			remoteRef = FA347C8E16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9116B1653300252A0E /* libmoai-ios-zlcore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-zlcore.a";
+			remoteRef = FA347C9016B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9316B1653300252A0E /* libmoai-osx.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx.a";
+			remoteRef = FA347C9216B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9516B1653300252A0E /* libmoai-osx-3rdparty.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-3rdparty.a";
+			remoteRef = FA347C9416B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9716B1653300252A0E /* liblibmoai-osx-fmod-designer.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "liblibmoai-osx-fmod-designer.a";
+			remoteRef = FA347C9616B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9916B1653300252A0E /* libmoai-osx-fmod-ex.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-fmod-ex.a";
+			remoteRef = FA347C9816B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9B16B1653300252A0E /* libmoai-osx-luaext.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-luaext.a";
+			remoteRef = FA347C9A16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9D16B1653300252A0E /* libmoai-osx-untz.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-untz.a";
+			remoteRef = FA347C9C16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		FA347C9F16B1653300252A0E /* libmoai-osx-zlcore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-zlcore.a";
+			remoteRef = FA347C9E16B1653300252A0E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1D60588D0D05DD3D006BFB54 /* Resources */ = {

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -37,20 +37,14 @@
 		079362FF161128BF00A47687 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F0160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a */; };
 		079530CE1447A0FF00143A72 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 079530CD1447A0FF00143A72 /* MediaPlayer.framework */; };
 		07E6C6A1140C5EBD004D1227 /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07E6C6A0140C5EBD004D1227 /* GameKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		07E9F73E13B50582006396F3 /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BD13B3C39D00B2724C /* libmoai-ios.a */; };
-		07E9F73F13B50582006396F3 /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */; };
-		07E9F74013B50582006396F3 /* libmoai-ios-luaext.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */; };
-		07E9F74113B50582006396F3 /* libmoai-ios-untz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90C313B3C39D00B2724C /* libmoai-ios-untz.a */; };
 		07EF3E44147BAAA5006CFDCE /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07EF3E43147BAAA5006CFDCE /* Twitter.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
-		6630C511151005BB00F2F031 /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6676D5D115100458004EA27A /* libmoai-ios-facebook.a */; };
 		665383F1160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F0160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a */; };
 		665383F3160A798F003D5529 /* FacebookSDKResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 665383F2160A798F003D5529 /* FacebookSDKResources.bundle */; };
 		665383F5160A7B65003D5529 /* libfacebook_ios_sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */; };
 		665383F7160A8466003D5529 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F6160A8466003D5529 /* MessageUI.framework */; };
-		CD464CE0147259EA00501E4E /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */; };
 		CD508A1A155E3AF90002FC3B /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC904F13B3C1B700B2724C /* Icon-72.png */; };
 		CD508A1B155E3AF90002FC3B /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905013B3C1B700B2724C /* Icon-Small-50.png */; };
 		CD508A1C155E3AF90002FC3B /* Icon-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905113B3C1B700B2724C /* Icon-Small.png */; };
@@ -85,12 +79,6 @@
 		CD508A84155E3AF90002FC3B /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A813B3C37C00B2724C /* main.mm */; };
 		CD508A85155E3AF90002FC3B /* MoaiVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 078D630013BA9EA30072F273 /* MoaiVC.mm */; };
 		CD508A86155E3AF90002FC3B /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
-		CD508A8A155E3AF90002FC3B /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BD13B3C39D00B2724C /* libmoai-ios.a */; };
-		CD508A8B155E3AF90002FC3B /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */; };
-		CD508A8C155E3AF90002FC3B /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6676D5D115100458004EA27A /* libmoai-ios-facebook.a */; };
-		CD508A8D155E3AF90002FC3B /* libmoai-ios-luaext.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */; };
-		CD508A8E155E3AF90002FC3B /* libmoai-ios-tapjoy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */; };
-		CD508A90155E3AF90002FC3B /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */; };
 		CD508A91155E3AF90002FC3B /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0711070413C637F000EE7C53 /* CoreTelephony.framework */; };
 		CD508A92155E3AF90002FC3B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		CD508A93155E3AF90002FC3B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
@@ -106,7 +94,6 @@
 		CD508A9D155E3AF90002FC3B /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 079530CD1447A0FF00143A72 /* MediaPlayer.framework */; };
 		CD508A9E155E3AF90002FC3B /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07EF3E43147BAAA5006CFDCE /* Twitter.framework */; };
 		CD7C73AE13B95516006CFA19 /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
-		CDB9F12414593A66007DE94C /* libmoai-ios-tapjoy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */; };
 		CDDD2FF61574AC7300C410A0 /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC904F13B3C1B700B2724C /* Icon-72.png */; };
 		CDDD2FF71574AC7300C410A0 /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905013B3C1B700B2724C /* Icon-Small-50.png */; };
 		CDDD2FF81574AC7300C410A0 /* Icon-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905113B3C1B700B2724C /* Icon-Small.png */; };
@@ -141,13 +128,6 @@
 		CDDD30601574AC7300C410A0 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A813B3C37C00B2724C /* main.mm */; };
 		CDDD30611574AC7300C410A0 /* MoaiVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 078D630013BA9EA30072F273 /* MoaiVC.mm */; };
 		CDDD30621574AC7300C410A0 /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
-		CDDD30661574AC7300C410A0 /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BD13B3C39D00B2724C /* libmoai-ios.a */; };
-		CDDD30671574AC7300C410A0 /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */; };
-		CDDD30681574AC7300C410A0 /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6676D5D115100458004EA27A /* libmoai-ios-facebook.a */; };
-		CDDD30691574AC7300C410A0 /* libmoai-ios-fmod-ex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD508AA7155E3AF90002FC3B /* libmoai-ios-fmod-ex.a */; };
-		CDDD306A1574AC7300C410A0 /* libmoai-ios-luaext.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */; };
-		CDDD306B1574AC7300C410A0 /* libmoai-ios-tapjoy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */; };
-		CDDD306C1574AC7300C410A0 /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */; };
 		CDDD306D1574AC7300C410A0 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC910B13B3C48400B2724C /* AudioToolbox.framework */; };
 		CDDD306E1574AC7300C410A0 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC910313B3C47600B2724C /* CoreAudio.framework */; };
 		CDDD306F1574AC7300C410A0 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
@@ -181,291 +161,14 @@
 		E92D4808153CA7D800CB1E8A /* TJCVGPageView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E92D4803153CA7D800CB1E8A /* TJCVGPageView.xib */; };
 		E92D4809153CA7D800CB1E8A /* TJCVGTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E92D4804153CA7D800CB1E8A /* TJCVGTableViewCell.xib */; };
 		E92D480A153CA7D800CB1E8A /* TJCVGView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E92D4805153CA7D800CB1E8A /* TJCVGView.xib */; };
-		E96915DC1561D57C007E977B /* libmoai-ios-fmod-ex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD508AA7155E3AF90002FC3B /* libmoai-ios-fmod-ex.a */; };
+		FA6515A816AD8F9F005C79BA /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A116AD8F9E005C79BA /* libmoai-ios-3rdparty.a */; };
+		FA6515A916AD8F9F005C79BA /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A216AD8F9E005C79BA /* libmoai-ios-facebook.a */; };
+		FA6515AA16AD8F9F005C79BA /* libmoai-ios-luaext.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A316AD8F9E005C79BA /* libmoai-ios-luaext.a */; };
+		FA6515AB16AD8F9F005C79BA /* libmoai-ios-tapjoy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A416AD8F9E005C79BA /* libmoai-ios-tapjoy.a */; };
+		FA6515AC16AD8F9F005C79BA /* libmoai-ios-untz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A516AD8F9E005C79BA /* libmoai-ios-untz.a */; };
+		FA6515AD16AD8F9F005C79BA /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A616AD8F9E005C79BA /* libmoai-ios-zlcore.a */; };
+		FA6515AE16AD8F9F005C79BA /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6515A716AD8F9F005C79BA /* libmoai-ios.a */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		03CC90BC13B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 03C2F6F4104DE130009A2D5D;
-			remoteInfo = "libmoai-iphone";
-		};
-		03CC90BE13B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0379C5961333ECD800E89DDC;
-			remoteInfo = "libmoai-iphone-3rdparty";
-		};
-		03CC90C013B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CDD06BD01398822500AB0420;
-			remoteInfo = "libmoai-iphone-luaext";
-		};
-		03CC90C213B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CD07C3CD13A182AA00C9386C;
-			remoteInfo = "libmoai-iphone-untz";
-		};
-		03CC90C413B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0324E2BB1356485F000ADC60;
-			remoteInfo = "libmoai-osx";
-		};
-		03CC90C613B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0324E2AF1356485F000ADC60;
-			remoteInfo = "libmoai-osx-3rdparty";
-		};
-		03CC90C813B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CDD06D87139882D900AB0420;
-			remoteInfo = "libmoai-osx-luaext";
-		};
-		03CC90CA13B3C39D00B2724C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CD07C4E513A1918600C9386C;
-			remoteInfo = "libmoai-osx-untz";
-		};
-		0730448D15AD00130046422F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 663BA372159D041D00F80FE9;
-			remoteInfo = "libmoai-ios-vungle";
-		};
-		07E9F73613B50574006396F3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 03C2F6F3104DE130009A2D5D;
-			remoteInfo = "libmoai-iphone";
-		};
-		07E9F73813B50574006396F3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 0379C3D51333ECD800E89DDC;
-			remoteInfo = "libmoai-iphone-3rdparty";
-		};
-		07E9F73A13B50574006396F3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CDD06A061398822500AB0420;
-			remoteInfo = "libmoai-iphone-luaext";
-		};
-		07E9F73C13B50574006396F3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CD07C3A313A182AA00C9386C;
-			remoteInfo = "libmoai-iphone-untz";
-		};
-		6630C50F151005AB00F2F031 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 07F4C7A514FC440500FB78BA;
-			remoteInfo = "libmoai-ios-facebook";
-		};
-		6676D5CE15100458004EA27A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 0705D8C014F46A6D009537C3;
-			remoteInfo = "libmoai-ios-adcolony";
-		};
-		6676D5D015100458004EA27A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 07F4C7B014FC440500FB78BA;
-			remoteInfo = "libmoai-ios-facebook";
-		};
-		CD04AF1114725736009C20E5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CD04ACB414725568009C20E5;
-			remoteInfo = "libmoai-ios-zipfs";
-		};
-		CD04AF1314725736009C20E5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CD04AE7F1472557F009C20E5;
-			remoteInfo = "libmoai-osx-zipfs";
-		};
-		CD508A09155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 07F4C7A514FC440500FB78BA;
-			remoteInfo = "libmoai-ios-facebook";
-		};
-		CD508A0D155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 073D52EC1459269600289D5C;
-			remoteInfo = "libmoai-ios-tapjoy";
-		};
-		CD508A0F155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CD04AABB14725568009C20E5;
-			remoteInfo = "libmoai-ios-zipfs";
-		};
-		CD508A11155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 03C2F6F3104DE130009A2D5D;
-			remoteInfo = "libmoai-iphone";
-		};
-		CD508A13155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 0379C3D51333ECD800E89DDC;
-			remoteInfo = "libmoai-iphone-3rdparty";
-		};
-		CD508A15155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CDD06A061398822500AB0420;
-			remoteInfo = "libmoai-iphone-luaext";
-		};
-		CD508AA6155E3AF90002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CD5089F9155E3A1B0002FC3B;
-			remoteInfo = "libmoai-ios-fmod";
-		};
-		CD508AA8155E3B1A0002FC3B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CD5089C6155E3A1B0002FC3B;
-			remoteInfo = "libmoai-ios-fmod";
-		};
-		CD8F4811155E4736001A579F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CDE8A802155E42EF00C2DFF5;
-			remoteInfo = "libmoai-osx-fmod";
-		};
-		CDB9F122145937C1007DE94C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 073D58591459269600289D5C;
-			remoteInfo = "libmoai-ios-tapjoy";
-		};
-		CDDD2FE71574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 03C2F6F3104DE130009A2D5D;
-			remoteInfo = "libmoai-iphone";
-		};
-		CDDD2FE91574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 0379C3D51333ECD800E89DDC;
-			remoteInfo = "libmoai-iphone-3rdparty";
-		};
-		CDDD2FEB1574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 07F4C7A514FC440500FB78BA;
-			remoteInfo = "libmoai-ios-facebook";
-		};
-		CDDD2FEF1574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CDD06A061398822500AB0420;
-			remoteInfo = "libmoai-iphone-luaext";
-		};
-		CDDD2FF11574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 073D52EC1459269600289D5C;
-			remoteInfo = "libmoai-ios-tapjoy";
-		};
-		CDDD2FF31574AC7300C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CD04AABB14725568009C20E5;
-			remoteInfo = "libmoai-ios-zipfs";
-		};
-		CDDD30A81574AE2100C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CDDD30921574AE0000C410A0;
-			remoteInfo = "libmoai-ios-fmod-designer";
-		};
-		CDDD30AA1574AE2100C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = CDDD30A51574AE0F00C410A0;
-			remoteInfo = "libmoai-osx-fmod-designer";
-		};
-		CDDD30AC1574AEBB00C410A0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CDDD30811574AE0000C410A0;
-			remoteInfo = "libmoai-ios-fmod-designer";
-		};
-		E92D47E2153CA6FC00CB1E8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E98DBD571537A1C500514387;
-			remoteInfo = "libmoai-ios-chartboost";
-		};
-		E9AA1CC114D8C4750086E9DE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 073D52EC1459269600289D5C;
-			remoteInfo = "libmoai-ios-tapjoy";
-		};
-		E9AA1CC314D8C4750086E9DE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CD04AABB14725568009C20E5;
-			remoteInfo = "libmoai-ios-zipfs";
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		037ED45813CD1FD2009CBA72 /* package.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = package.sh; sourceTree = "<group>"; };
@@ -487,7 +190,7 @@
 		03CC90A313B3C37200B2724C /* RefPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefPtr.h; sourceTree = "<group>"; };
 		03CC90A813B3C37C00B2724C /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		03CC90AA13B3C38800B2724C /* Entitlements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
-		03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libmoai.xcodeproj; path = ../libmoai/libmoai.xcodeproj; sourceTree = SOURCE_ROOT; };
+		03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libmoai.xcodeproj; path = "/usr/local/moai-sdk/xcode/ios/../libmoai/libmoai.xcodeproj"; sourceTree = "<absolute>"; };
 		03CC90F713B3C45A00B2724C /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		03CC90FD13B3C46A00B2724C /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		03CC910313B3C47600B2724C /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
@@ -508,9 +211,9 @@
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		288765A40DF7441C002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		32CA4F630368D1EE00C91783 /* MoaiSample_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoaiSample_Prefix.pch; sourceTree = "<group>"; };
-		665383F0160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libCrittercismCrashOnly_v3_3_3.a; path = "../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly/libCrittercismCrashOnly_v3_3_3.a"; sourceTree = "<group>"; };
+		665383F0160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libCrittercismCrashOnly_v3_3_3.a; path = "/usr/local/moai-sdk/xcode/ios/../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly/libCrittercismCrashOnly_v3_3_3.a"; sourceTree = "<absolute>"; };
 		665383F2160A798F003D5529 /* FacebookSDKResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = FacebookSDKResources.bundle; path = "../../3rdparty/facebookiOS-3.0.6.b/FacebookSDKResources.bundle"; sourceTree = "<group>"; };
-		665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfacebook_ios_sdk.a; path = "../../3rdparty/facebookiOS-3.0.6.b/libfacebook_ios_sdk.a"; sourceTree = "<group>"; };
+		665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfacebook_ios_sdk.a; path = "/usr/local/moai-sdk/xcode/ios/../../3rdparty/facebookiOS-3.0.6.b/libfacebook_ios_sdk.a"; sourceTree = "<absolute>"; };
 		665383F6160A8466003D5529 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		CD508AA2155E3AF90002FC3B /* moai-fmod-ex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "moai-fmod-ex.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParticlePresets.cpp; path = ../../src/hosts/ParticlePresets.cpp; sourceTree = SOURCE_ROOT; };
@@ -535,6 +238,13 @@
 		E92D4803153CA7D800CB1E8A /* TJCVGPageView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TJCVGPageView.xib; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCVirtualGoods/TJCVG_Views/TJCVGPageView.xib"; sourceTree = "<group>"; };
 		E92D4804153CA7D800CB1E8A /* TJCVGTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TJCVGTableViewCell.xib; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCVirtualGoods/TJCVG_Views/TJCVGTableViewCell.xib"; sourceTree = "<group>"; };
 		E92D4805153CA7D800CB1E8A /* TJCVGView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TJCVGView.xib; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCVirtualGoods/TJCVG_Views/TJCVGView.xib"; sourceTree = "<group>"; };
+		FA6515A116AD8F9E005C79BA /* libmoai-ios-3rdparty.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-3rdparty.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-3rdparty.a"; sourceTree = "<absolute>"; };
+		FA6515A216AD8F9E005C79BA /* libmoai-ios-facebook.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-facebook.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-facebook.a"; sourceTree = "<absolute>"; };
+		FA6515A316AD8F9E005C79BA /* libmoai-ios-luaext.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-luaext.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-luaext.a"; sourceTree = "<absolute>"; };
+		FA6515A416AD8F9E005C79BA /* libmoai-ios-tapjoy.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-tapjoy.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-tapjoy.a"; sourceTree = "<absolute>"; };
+		FA6515A516AD8F9E005C79BA /* libmoai-ios-untz.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-untz.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-untz.a"; sourceTree = "<absolute>"; };
+		FA6515A616AD8F9E005C79BA /* libmoai-ios-zlcore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios-zlcore.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios-zlcore.a"; sourceTree = "<absolute>"; };
+		FA6515A716AD8F9F005C79BA /* libmoai-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmoai-ios.a"; path = "/usr/local/moai-sdk/xcode/ios/../../bin/ios/libmoai-ios.a"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -542,15 +252,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA6515AE16AD8F9F005C79BA /* libmoai-ios.a in Frameworks */,
+				FA6515A816AD8F9F005C79BA /* libmoai-ios-3rdparty.a in Frameworks */,
+				FA6515A916AD8F9F005C79BA /* libmoai-ios-facebook.a in Frameworks */,
+				FA6515AA16AD8F9F005C79BA /* libmoai-ios-luaext.a in Frameworks */,
+				FA6515AB16AD8F9F005C79BA /* libmoai-ios-tapjoy.a in Frameworks */,
+				FA6515AC16AD8F9F005C79BA /* libmoai-ios-untz.a in Frameworks */,
+				FA6515AD16AD8F9F005C79BA /* libmoai-ios-zlcore.a in Frameworks */,
 				665383F5160A7B65003D5529 /* libfacebook_ios_sdk.a in Frameworks */,
 				665383F1160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */,
-				07E9F73E13B50582006396F3 /* libmoai-ios.a in Frameworks */,
-				07E9F73F13B50582006396F3 /* libmoai-ios-3rdparty.a in Frameworks */,
-				6630C511151005BB00F2F031 /* libmoai-ios-facebook.a in Frameworks */,
-				07E9F74013B50582006396F3 /* libmoai-ios-luaext.a in Frameworks */,
-				CDB9F12414593A66007DE94C /* libmoai-ios-tapjoy.a in Frameworks */,
-				07E9F74113B50582006396F3 /* libmoai-ios-untz.a in Frameworks */,
-				CD464CE0147259EA00501E4E /* libmoai-ios-zlcore.a in Frameworks */,
 				03CC910C13B3C48400B2724C /* AudioToolbox.framework in Frameworks */,
 				03CC910413B3C47600B2724C /* CoreAudio.framework in Frameworks */,
 				288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */,
@@ -576,13 +286,6 @@
 				079362FF161128BF00A47687 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */,
 				079362FE161128B200A47687 /* libfacebook_ios_sdk.a in Frameworks */,
 				079362FD161128A600A47687 /* MessageUI.framework in Frameworks */,
-				CD508A8A155E3AF90002FC3B /* libmoai-ios.a in Frameworks */,
-				CD508A8B155E3AF90002FC3B /* libmoai-ios-3rdparty.a in Frameworks */,
-				CD508A8C155E3AF90002FC3B /* libmoai-ios-facebook.a in Frameworks */,
-				E96915DC1561D57C007E977B /* libmoai-ios-fmod-ex.a in Frameworks */,
-				CD508A8D155E3AF90002FC3B /* libmoai-ios-luaext.a in Frameworks */,
-				CD508A8E155E3AF90002FC3B /* libmoai-ios-tapjoy.a in Frameworks */,
-				CD508A90155E3AF90002FC3B /* libmoai-ios-zlcore.a in Frameworks */,
 				CD508A98155E3AF90002FC3B /* AudioToolbox.framework in Frameworks */,
 				CD508A97155E3AF90002FC3B /* CoreAudio.framework in Frameworks */,
 				CD508A94155E3AF90002FC3B /* CoreGraphics.framework in Frameworks */,
@@ -607,13 +310,6 @@
 				079362FC1611289A00A47687 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */,
 				079362FB1611288900A47687 /* libfacebook_ios_sdk.a in Frameworks */,
 				079362FA1611287500A47687 /* MessageUI.framework in Frameworks */,
-				CDDD30661574AC7300C410A0 /* libmoai-ios.a in Frameworks */,
-				CDDD30671574AC7300C410A0 /* libmoai-ios-3rdparty.a in Frameworks */,
-				CDDD30681574AC7300C410A0 /* libmoai-ios-facebook.a in Frameworks */,
-				CDDD30691574AC7300C410A0 /* libmoai-ios-fmod-ex.a in Frameworks */,
-				CDDD306A1574AC7300C410A0 /* libmoai-ios-luaext.a in Frameworks */,
-				CDDD306B1574AC7300C410A0 /* libmoai-ios-tapjoy.a in Frameworks */,
-				CDDD306C1574AC7300C410A0 /* libmoai-ios-zlcore.a in Frameworks */,
 				CDDD306D1574AC7300C410A0 /* AudioToolbox.framework in Frameworks */,
 				CDDD306E1574AC7300C410A0 /* CoreAudio.framework in Frameworks */,
 				CDDD306F1574AC7300C410A0 /* CoreGraphics.framework in Frameworks */,
@@ -634,32 +330,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		03CC90AF13B3C39D00B2724C /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				03CC90BD13B3C39D00B2724C /* libmoai-ios.a */,
-				03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */,
-				6676D5CF15100458004EA27A /* libmoai-ios-adcolony.a */,
-				E92D47E3153CA6FC00CB1E8A /* libmoai-ios-chartboost.a */,
-				6676D5D115100458004EA27A /* libmoai-ios-facebook.a */,
-				CDDD30A91574AE2100C410A0 /* liblibmoai-ios-fmod-designer.a */,
-				CD508AA7155E3AF90002FC3B /* libmoai-ios-fmod-ex.a */,
-				03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */,
-				CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */,
-				03CC90C313B3C39D00B2724C /* libmoai-ios-untz.a */,
-				0730448E15AD00130046422F /* libmoai-ios-vungle.a */,
-				CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */,
-				03CC90C513B3C39D00B2724C /* libmoai-osx.a */,
-				03CC90C713B3C39D00B2724C /* libmoai-osx-3rdparty.a */,
-				CDDD30AB1574AE2100C410A0 /* liblibmoai-osx-fmod-designer.a */,
-				CD8F4812155E4736001A579F /* libmoai-osx-fmod-ex.a */,
-				03CC90C913B3C39D00B2724C /* libmoai-osx-luaext.a */,
-				03CC90CB13B3C39D00B2724C /* libmoai-osx-untz.a */,
-				CD04AF1414725736009C20E5 /* libmoai-osx-zlcore.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		03E2806113C7CC4800EE3B0D /* build */ = {
 			isa = PBXGroup;
 			children = (
@@ -703,6 +373,13 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				FA6515A116AD8F9E005C79BA /* libmoai-ios-3rdparty.a */,
+				FA6515A216AD8F9E005C79BA /* libmoai-ios-facebook.a */,
+				FA6515A316AD8F9E005C79BA /* libmoai-ios-luaext.a */,
+				FA6515A416AD8F9E005C79BA /* libmoai-ios-tapjoy.a */,
+				FA6515A516AD8F9E005C79BA /* libmoai-ios-untz.a */,
+				FA6515A616AD8F9E005C79BA /* libmoai-ios-zlcore.a */,
+				FA6515A716AD8F9F005C79BA /* libmoai-ios.a */,
 				665383F6160A8466003D5529 /* MessageUI.framework */,
 				665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */,
 				665383F0160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a */,
@@ -789,7 +466,8 @@
 				E92D47F7153CA7B000CB1E8A /* localVGStore.sql */,
 			);
 			name = Tapjoy;
-			sourceTree = "<group>";
+			path = "/usr/local/moai-sdk/xcode/ios";
+			sourceTree = "<absolute>";
 		};
 		E91A4CCD151921910008F1A5 /* Facebook */ = {
 			isa = PBXGroup;
@@ -797,14 +475,16 @@
 				665383F2160A798F003D5529 /* FacebookSDKResources.bundle */,
 			);
 			name = Facebook;
-			sourceTree = "<group>";
+			path = "/usr/local/moai-sdk/xcode/ios";
+			sourceTree = "<absolute>";
 		};
 		E9AA1CD514D8C6860086E9DE /* Crittercism */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Crittercism;
-			sourceTree = "<group>";
+			path = "/usr/local/moai-sdk/xcode/ios";
+			sourceTree = "<absolute>";
 		};
 /* End PBXGroup section */
 
@@ -821,13 +501,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				07E9F73713B50574006396F3 /* PBXTargetDependency */,
-				07E9F73913B50574006396F3 /* PBXTargetDependency */,
-				6630C510151005AB00F2F031 /* PBXTargetDependency */,
-				07E9F73B13B50574006396F3 /* PBXTargetDependency */,
-				E9AA1CC214D8C4750086E9DE /* PBXTargetDependency */,
-				07E9F73D13B50574006396F3 /* PBXTargetDependency */,
-				E9AA1CC414D8C4750086E9DE /* PBXTargetDependency */,
 			);
 			name = moai;
 			productName = MoaiSample;
@@ -846,13 +519,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CD508A10155E3AF90002FC3B /* PBXTargetDependency */,
-				CD508A12155E3AF90002FC3B /* PBXTargetDependency */,
-				CD508A08155E3AF90002FC3B /* PBXTargetDependency */,
-				CD508AA9155E3B1A0002FC3B /* PBXTargetDependency */,
-				CD508A14155E3AF90002FC3B /* PBXTargetDependency */,
-				CD508A0C155E3AF90002FC3B /* PBXTargetDependency */,
-				CD508A0E155E3AF90002FC3B /* PBXTargetDependency */,
 			);
 			name = "moai-fmod-ex";
 			productName = MoaiSample;
@@ -871,13 +537,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CDDD2FE61574AC7300C410A0 /* PBXTargetDependency */,
-				CDDD2FE81574AC7300C410A0 /* PBXTargetDependency */,
-				CDDD2FEA1574AC7300C410A0 /* PBXTargetDependency */,
-				CDDD30AD1574AEBB00C410A0 /* PBXTargetDependency */,
-				CDDD2FEE1574AC7300C410A0 /* PBXTargetDependency */,
-				CDDD2FF01574AC7300C410A0 /* PBXTargetDependency */,
-				CDDD2FF21574AC7300C410A0 /* PBXTargetDependency */,
 			);
 			name = "moai-fmod-designer";
 			productName = MoaiSample;
@@ -904,12 +563,6 @@
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 03CC90AF13B3C39D00B2724C /* Products */;
-					ProjectRef = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* moai */,
@@ -918,142 +571,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		03CC90BD13B3C39D00B2724C /* libmoai-ios.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios.a";
-			remoteRef = 03CC90BC13B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-3rdparty.a";
-			remoteRef = 03CC90BE13B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-luaext.a";
-			remoteRef = 03CC90C013B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90C313B3C39D00B2724C /* libmoai-ios-untz.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-untz.a";
-			remoteRef = 03CC90C213B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90C513B3C39D00B2724C /* libmoai-osx.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx.a";
-			remoteRef = 03CC90C413B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90C713B3C39D00B2724C /* libmoai-osx-3rdparty.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx-3rdparty.a";
-			remoteRef = 03CC90C613B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90C913B3C39D00B2724C /* libmoai-osx-luaext.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx-luaext.a";
-			remoteRef = 03CC90C813B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		03CC90CB13B3C39D00B2724C /* libmoai-osx-untz.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx-untz.a";
-			remoteRef = 03CC90CA13B3C39D00B2724C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0730448E15AD00130046422F /* libmoai-ios-vungle.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-vungle.a";
-			remoteRef = 0730448D15AD00130046422F /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6676D5CF15100458004EA27A /* libmoai-ios-adcolony.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-adcolony.a";
-			remoteRef = 6676D5CE15100458004EA27A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6676D5D115100458004EA27A /* libmoai-ios-facebook.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-facebook.a";
-			remoteRef = 6676D5D015100458004EA27A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-zlcore.a";
-			remoteRef = CD04AF1114725736009C20E5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CD04AF1414725736009C20E5 /* libmoai-osx-zlcore.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx-zlcore.a";
-			remoteRef = CD04AF1314725736009C20E5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CD508AA7155E3AF90002FC3B /* libmoai-ios-fmod-ex.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-fmod-ex.a";
-			remoteRef = CD508AA6155E3AF90002FC3B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CD8F4812155E4736001A579F /* libmoai-osx-fmod-ex.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-osx-fmod-ex.a";
-			remoteRef = CD8F4811155E4736001A579F /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-tapjoy.a";
-			remoteRef = CDB9F122145937C1007DE94C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CDDD30A91574AE2100C410A0 /* liblibmoai-ios-fmod-designer.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "liblibmoai-ios-fmod-designer.a";
-			remoteRef = CDDD30A81574AE2100C410A0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		CDDD30AB1574AE2100C410A0 /* liblibmoai-osx-fmod-designer.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "liblibmoai-osx-fmod-designer.a";
-			remoteRef = CDDD30AA1574AE2100C410A0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E92D47E3153CA6FC00CB1E8A /* libmoai-ios-chartboost.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoai-ios-chartboost.a";
-			remoteRef = E92D47E2153CA6FC00CB1E8A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1D60588D0D05DD3D006BFB54 /* Resources */ = {
@@ -1251,119 +768,15 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		07E9F73713B50574006396F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone";
-			targetProxy = 07E9F73613B50574006396F3 /* PBXContainerItemProxy */;
-		};
-		07E9F73913B50574006396F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-3rdparty";
-			targetProxy = 07E9F73813B50574006396F3 /* PBXContainerItemProxy */;
-		};
-		07E9F73B13B50574006396F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-luaext";
-			targetProxy = 07E9F73A13B50574006396F3 /* PBXContainerItemProxy */;
-		};
-		07E9F73D13B50574006396F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-untz";
-			targetProxy = 07E9F73C13B50574006396F3 /* PBXContainerItemProxy */;
-		};
-		6630C510151005AB00F2F031 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-facebook";
-			targetProxy = 6630C50F151005AB00F2F031 /* PBXContainerItemProxy */;
-		};
-		CD508A08155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-facebook";
-			targetProxy = CD508A09155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508A0C155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-tapjoy";
-			targetProxy = CD508A0D155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508A0E155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-zipfs";
-			targetProxy = CD508A0F155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508A10155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone";
-			targetProxy = CD508A11155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508A12155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-3rdparty";
-			targetProxy = CD508A13155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508A14155E3AF90002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-luaext";
-			targetProxy = CD508A15155E3AF90002FC3B /* PBXContainerItemProxy */;
-		};
-		CD508AA9155E3B1A0002FC3B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-fmod";
-			targetProxy = CD508AA8155E3B1A0002FC3B /* PBXContainerItemProxy */;
-		};
-		CDDD2FE61574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone";
-			targetProxy = CDDD2FE71574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD2FE81574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-3rdparty";
-			targetProxy = CDDD2FE91574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD2FEA1574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-facebook";
-			targetProxy = CDDD2FEB1574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD2FEE1574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-iphone-luaext";
-			targetProxy = CDDD2FEF1574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD2FF01574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-tapjoy";
-			targetProxy = CDDD2FF11574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD2FF21574AC7300C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-zipfs";
-			targetProxy = CDDD2FF31574AC7300C410A0 /* PBXContainerItemProxy */;
-		};
-		CDDD30AD1574AEBB00C410A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-fmod-designer";
-			targetProxy = CDDD30AC1574AEBB00C410A0 /* PBXContainerItemProxy */;
-		};
-		E9AA1CC214D8C4750086E9DE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-tapjoy";
-			targetProxy = E9AA1CC114D8C4750086E9DE /* PBXContainerItemProxy */;
-		};
-		E9AA1CC414D8C4750086E9DE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "libmoai-ios-zipfs";
-			targetProxy = E9AA1CC314D8C4750086E9DE /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin XCBuildConfiguration section */
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = USE_UNTZ;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../../bin/ios\"",
+				);
 				PRODUCT_NAME = moai;
 			};
 			name = Debug;
@@ -1372,6 +785,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = USE_UNTZ;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../../bin/ios\"",
+				);
 				PRODUCT_NAME = moai;
 			};
 			name = Release;

--- a/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai-fmod-designer.xcscheme
+++ b/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai-fmod-designer.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -39,11 +40,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai-fmod-ex.xcscheme
+++ b/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai-fmod-ex.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -39,11 +40,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
+++ b/xcode/ios/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -39,11 +40,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -729,8 +729,6 @@
 		0324E6C413564BC8000ADC60 /* MOAICpSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52413564BC7000ADC60 /* MOAICpSpace.h */; };
 		0324E6C513564BC8000ADC60 /* MOAIDataBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52513564BC7000ADC60 /* MOAIDataBuffer.cpp */; };
 		0324E6C613564BC8000ADC60 /* MOAIDataBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52613564BC7000ADC60 /* MOAIDataBuffer.h */; };
-		0324E6C713564BC8000ADC60 /* MOAIDataIOAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52713564BC7000ADC60 /* MOAIDataIOAction.cpp */; };
-		0324E6C813564BC8000ADC60 /* MOAIDataIOAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52813564BC7000ADC60 /* MOAIDataIOAction.h */; };
 		0324E6C913564BC8000ADC60 /* MOAIDebugLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52913564BC7000ADC60 /* MOAIDebugLines.cpp */; };
 		0324E6CA13564BC8000ADC60 /* MOAIDebugLines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52A13564BC7000ADC60 /* MOAIDebugLines.h */; };
 		0324E6CB13564BC8000ADC60 /* MOAIDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52B13564BC7000ADC60 /* MOAIDeck.cpp */; };
@@ -922,8 +920,6 @@
 		0324E86213564BC8000ADC60 /* MOAICpSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52413564BC7000ADC60 /* MOAICpSpace.h */; };
 		0324E86313564BC8000ADC60 /* MOAIDataBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52513564BC7000ADC60 /* MOAIDataBuffer.cpp */; };
 		0324E86413564BC8000ADC60 /* MOAIDataBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52613564BC7000ADC60 /* MOAIDataBuffer.h */; };
-		0324E86513564BC8000ADC60 /* MOAIDataIOAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52713564BC7000ADC60 /* MOAIDataIOAction.cpp */; };
-		0324E86613564BC8000ADC60 /* MOAIDataIOAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52813564BC7000ADC60 /* MOAIDataIOAction.h */; };
 		0324E86713564BC8000ADC60 /* MOAIDebugLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52913564BC7000ADC60 /* MOAIDebugLines.cpp */; };
 		0324E86813564BC8000ADC60 /* MOAIDebugLines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0324E52A13564BC7000ADC60 /* MOAIDebugLines.h */; };
 		0324E86913564BC8000ADC60 /* MOAIDeck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0324E52B13564BC7000ADC60 /* MOAIDeck.cpp */; };
@@ -1706,10 +1702,6 @@
 		66C572701575703300A486AB /* MOAIMemStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5726B1575703300A486AB /* MOAIMemStream.cpp */; };
 		66C572711575703300A486AB /* MOAIMemStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726C1575703300A486AB /* MOAIMemStream.h */; };
 		66C572721575703300A486AB /* MOAIMemStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726C1575703300A486AB /* MOAIMemStream.h */; };
-		66C572731575703300A486AB /* MOAIStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5726D1575703300A486AB /* MOAIStream.cpp */; };
-		66C572741575703300A486AB /* MOAIStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5726D1575703300A486AB /* MOAIStream.cpp */; };
-		66C572751575703300A486AB /* MOAIStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726E1575703300A486AB /* MOAIStream.h */; };
-		66C572761575703300A486AB /* MOAIStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5726E1575703300A486AB /* MOAIStream.h */; };
 		66C572791575709400A486AB /* USDeflateReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572771575709400A486AB /* USDeflateReader.cpp */; };
 		66C5727A1575709400A486AB /* USDeflateReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572771575709400A486AB /* USDeflateReader.cpp */; };
 		66C5727B1575709400A486AB /* USDeflateReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572781575709400A486AB /* USDeflateReader.h */; };
@@ -1730,14 +1722,6 @@
 		66C572921575711000A486AB /* USBase64Writer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C5728B1575710F00A486AB /* USBase64Writer.cpp */; };
 		66C572931575711000A486AB /* USBase64Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5728C1575711000A486AB /* USBase64Writer.h */; };
 		66C572941575711000A486AB /* USBase64Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5728C1575711000A486AB /* USBase64Writer.h */; };
-		66C5729B1575713C00A486AB /* USBase64Reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572951575713C00A486AB /* USBase64Reader.cpp */; };
-		66C5729C1575713C00A486AB /* USBase64Reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572951575713C00A486AB /* USBase64Reader.cpp */; };
-		66C5729D1575713C00A486AB /* USBase64Reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572961575713C00A486AB /* USBase64Reader.h */; };
-		66C5729E1575713C00A486AB /* USBase64Reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572961575713C00A486AB /* USBase64Reader.h */; };
-		66C5729F1575713C00A486AB /* USBase64Writer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572971575713C00A486AB /* USBase64Writer.cpp */; };
-		66C572A01575713C00A486AB /* USBase64Writer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572971575713C00A486AB /* USBase64Writer.cpp */; };
-		66C572A11575713C00A486AB /* USBase64Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572981575713C00A486AB /* USBase64Writer.h */; };
-		66C572A21575713C00A486AB /* USBase64Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C572981575713C00A486AB /* USBase64Writer.h */; };
 		66C572A31575713C00A486AB /* USStreamReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572991575713C00A486AB /* USStreamReader.cpp */; };
 		66C572A41575713C00A486AB /* USStreamReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66C572991575713C00A486AB /* USStreamReader.cpp */; };
 		66C572A51575713C00A486AB /* USStreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C5729A1575713C00A486AB /* USStreamReader.h */; };
@@ -3388,13 +3372,9 @@
 		E9940DCF14B7A4A0006465CC /* USCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7C14B7A4A0006465CC /* USCurve.cpp */; };
 		E9940DD014B7A4A0006465CC /* USCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7D14B7A4A0006465CC /* USCurve.h */; };
 		E9940DD114B7A4A0006465CC /* USCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7D14B7A4A0006465CC /* USCurve.h */; };
-		E9940DD214B7A4A0006465CC /* USData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7E14B7A4A0006465CC /* USData.cpp */; };
 		E9940DD314B7A4A0006465CC /* USData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D7E14B7A4A0006465CC /* USData.cpp */; };
-		E9940DD414B7A4A0006465CC /* USData.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7F14B7A4A0006465CC /* USData.h */; };
 		E9940DD514B7A4A0006465CC /* USData.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D7F14B7A4A0006465CC /* USData.h */; };
-		E9940DD614B7A4A0006465CC /* USDataIOTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8014B7A4A0006465CC /* USDataIOTask.cpp */; };
 		E9940DD714B7A4A0006465CC /* USDataIOTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D8014B7A4A0006465CC /* USDataIOTask.cpp */; };
-		E9940DD814B7A4A0006465CC /* USDataIOTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8114B7A4A0006465CC /* USDataIOTask.h */; };
 		E9940DD914B7A4A0006465CC /* USDataIOTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8114B7A4A0006465CC /* USDataIOTask.h */; };
 		E9940DDA14B7A4A0006465CC /* USDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8214B7A4A0006465CC /* USDelegate.h */; };
 		E9940DDB14B7A4A0006465CC /* USDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D8214B7A4A0006465CC /* USDelegate.h */; };
@@ -3430,13 +3410,9 @@
 		E9940DFB14B7A4A0006465CC /* USMercator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9214B7A4A0006465CC /* USMercator.cpp */; };
 		E9940DFC14B7A4A0006465CC /* USMercator.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9314B7A4A0006465CC /* USMercator.h */; };
 		E9940DFD14B7A4A0006465CC /* USMercator.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9314B7A4A0006465CC /* USMercator.h */; };
-		E9940DFE14B7A4A0006465CC /* USMutex_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9414B7A4A0006465CC /* USMutex_posix.cpp */; };
 		E9940DFF14B7A4A0006465CC /* USMutex_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9414B7A4A0006465CC /* USMutex_posix.cpp */; };
-		E9940E0014B7A4A0006465CC /* USMutex_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9514B7A4A0006465CC /* USMutex_posix.h */; };
 		E9940E0114B7A4A0006465CC /* USMutex_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9514B7A4A0006465CC /* USMutex_posix.h */; };
-		E9940E0214B7A4A0006465CC /* USMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9614B7A4A0006465CC /* USMutex.cpp */; };
 		E9940E0314B7A4A0006465CC /* USMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9614B7A4A0006465CC /* USMutex.cpp */; };
-		E9940E0414B7A4A0006465CC /* USMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9714B7A4A0006465CC /* USMutex.h */; };
 		E9940E0514B7A4A0006465CC /* USMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940D9714B7A4A0006465CC /* USMutex.h */; };
 		E9940E0614B7A4A0006465CC /* USParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9814B7A4A0006465CC /* USParser.cpp */; };
 		E9940E0714B7A4A0006465CC /* USParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940D9814B7A4A0006465CC /* USParser.cpp */; };
@@ -3478,21 +3454,13 @@
 		E9940E2B14B7A4A0006465CC /* USSyntaxScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAA14B7A4A0006465CC /* USSyntaxScanner.cpp */; };
 		E9940E2C14B7A4A0006465CC /* USSyntaxScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAB14B7A4A0006465CC /* USSyntaxScanner.h */; };
 		E9940E2D14B7A4A0006465CC /* USSyntaxScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAB14B7A4A0006465CC /* USSyntaxScanner.h */; };
-		E9940E2E14B7A4A0006465CC /* USTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAC14B7A4A0006465CC /* USTask.cpp */; };
 		E9940E2F14B7A4A0006465CC /* USTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAC14B7A4A0006465CC /* USTask.cpp */; };
-		E9940E3014B7A4A0006465CC /* USTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAD14B7A4A0006465CC /* USTask.h */; };
 		E9940E3114B7A4A0006465CC /* USTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAD14B7A4A0006465CC /* USTask.h */; };
-		E9940E3214B7A4A0006465CC /* USTaskThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAE14B7A4A0006465CC /* USTaskThread.cpp */; };
 		E9940E3314B7A4A0006465CC /* USTaskThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DAE14B7A4A0006465CC /* USTaskThread.cpp */; };
-		E9940E3414B7A4A0006465CC /* USTaskThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAF14B7A4A0006465CC /* USTaskThread.h */; };
 		E9940E3514B7A4A0006465CC /* USTaskThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DAF14B7A4A0006465CC /* USTaskThread.h */; };
-		E9940E3614B7A4A0006465CC /* USThread_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB014B7A4A0006465CC /* USThread_posix.cpp */; };
 		E9940E3714B7A4A0006465CC /* USThread_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB014B7A4A0006465CC /* USThread_posix.cpp */; };
-		E9940E3814B7A4A0006465CC /* USThread_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB114B7A4A0006465CC /* USThread_posix.h */; };
 		E9940E3914B7A4A0006465CC /* USThread_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB114B7A4A0006465CC /* USThread_posix.h */; };
-		E9940E3A14B7A4A0006465CC /* USThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB214B7A4A0006465CC /* USThread.cpp */; };
 		E9940E3B14B7A4A0006465CC /* USThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB214B7A4A0006465CC /* USThread.cpp */; };
-		E9940E3C14B7A4A0006465CC /* USThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB314B7A4A0006465CC /* USThread.h */; };
 		E9940E3D14B7A4A0006465CC /* USThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E9940DB314B7A4A0006465CC /* USThread.h */; };
 		E9940E3E14B7A4A0006465CC /* USTrig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB414B7A4A0006465CC /* USTrig.cpp */; };
 		E9940E3F14B7A4A0006465CC /* USTrig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9940DB414B7A4A0006465CC /* USTrig.cpp */; };
@@ -3544,6 +3512,38 @@
 		E9CA1E5B151C8578005F39B7 /* MOAIWebViewIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */; };
 		E9DE4581157EA38800630A7D /* MOAIMoviePlayerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */; };
 		E9DE4582157EA38800630A7D /* MOAIMoviePlayerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */; };
+		FAA659EE16AD9178001C04DD /* MOAICamera2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659CE16AD9178001C04DD /* MOAICamera2D.cpp */; };
+		FAA659EF16AD9178001C04DD /* MOAICamera2D.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659CF16AD9178001C04DD /* MOAICamera2D.h */; };
+		FAA659F016AD9178001C04DD /* MOAIDataIOTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659D016AD9178001C04DD /* MOAIDataIOTask.cpp */; };
+		FAA659F116AD9178001C04DD /* MOAIDataIOTask.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659D116AD9178001C04DD /* MOAIDataIOTask.h */; };
+		FAA659F216AD9178001C04DD /* MOAILayer2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659D216AD9178001C04DD /* MOAILayer2D.cpp */; };
+		FAA659F316AD9178001C04DD /* MOAILayer2D.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659D316AD9178001C04DD /* MOAILayer2D.h */; };
+		FAA659F416AD9178001C04DD /* MOAIMutex_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659D416AD9178001C04DD /* MOAIMutex_posix.cpp */; };
+		FAA659F516AD9178001C04DD /* MOAIMutex_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659D516AD9178001C04DD /* MOAIMutex_posix.h */; };
+		FAA659F616AD9178001C04DD /* MOAIMutex_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659D616AD9178001C04DD /* MOAIMutex_win32.cpp */; };
+		FAA659F716AD9178001C04DD /* MOAIMutex_win32.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659D716AD9178001C04DD /* MOAIMutex_win32.h */; };
+		FAA659F816AD9178001C04DD /* MOAIMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659D816AD9178001C04DD /* MOAIMutex.cpp */; };
+		FAA659F916AD9178001C04DD /* MOAIMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659D916AD9178001C04DD /* MOAIMutex.h */; };
+		FAA659FA16AD9178001C04DD /* MOAIProp2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659DA16AD9178001C04DD /* MOAIProp2D.cpp */; };
+		FAA659FB16AD9178001C04DD /* MOAIProp2D.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659DB16AD9178001C04DD /* MOAIProp2D.h */; };
+		FAA659FC16AD9178001C04DD /* MOAITask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659DC16AD9178001C04DD /* MOAITask.cpp */; };
+		FAA659FD16AD9178001C04DD /* MOAITask.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659DD16AD9178001C04DD /* MOAITask.h */; };
+		FAA659FE16AD9178001C04DD /* MOAITaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659DE16AD9178001C04DD /* MOAITaskQueue.cpp */; };
+		FAA659FF16AD9178001C04DD /* MOAITaskQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659DF16AD9178001C04DD /* MOAITaskQueue.h */; };
+		FAA65A0016AD9178001C04DD /* MOAITaskSubscriber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659E016AD9178001C04DD /* MOAITaskSubscriber.cpp */; };
+		FAA65A0116AD9178001C04DD /* MOAITaskSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659E116AD9178001C04DD /* MOAITaskSubscriber.h */; };
+		FAA65A0216AD9178001C04DD /* MOAITaskThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659E216AD9178001C04DD /* MOAITaskThread.cpp */; };
+		FAA65A0316AD9178001C04DD /* MOAITaskThread.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659E316AD9178001C04DD /* MOAITaskThread.h */; };
+		FAA65A0416AD9178001C04DD /* MOAIThread_posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659E416AD9178001C04DD /* MOAIThread_posix.cpp */; };
+		FAA65A0516AD9178001C04DD /* MOAIThread_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659E516AD9178001C04DD /* MOAIThread_posix.h */; };
+		FAA65A0616AD9178001C04DD /* MOAIThread_win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659E616AD9178001C04DD /* MOAIThread_win32.cpp */; };
+		FAA65A0716AD9178001C04DD /* MOAIThread_win32.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659E716AD9178001C04DD /* MOAIThread_win32.h */; };
+		FAA65A0816AD9178001C04DD /* MOAIThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659E816AD9178001C04DD /* MOAIThread.cpp */; };
+		FAA65A0916AD9178001C04DD /* MOAIThread.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659E916AD9178001C04DD /* MOAIThread.h */; };
+		FAA65A0A16AD9178001C04DD /* MOAITransform2D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659EA16AD9178001C04DD /* MOAITransform2D.cpp */; };
+		FAA65A0B16AD9178001C04DD /* MOAITransform2D.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659EB16AD9178001C04DD /* MOAITransform2D.h */; };
+		FAA65A0C16AD9178001C04DD /* MOAIXmlWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAA659EC16AD9178001C04DD /* MOAIXmlWriter.cpp */; };
+		FAA65A0D16AD9178001C04DD /* MOAIXmlWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA659ED16AD9178001C04DD /* MOAIXmlWriter.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -3901,8 +3901,6 @@
 		0324E52413564BC7000ADC60 /* MOAICpSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAICpSpace.h; sourceTree = "<group>"; };
 		0324E52513564BC7000ADC60 /* MOAIDataBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIDataBuffer.cpp; sourceTree = "<group>"; };
 		0324E52613564BC7000ADC60 /* MOAIDataBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIDataBuffer.h; sourceTree = "<group>"; };
-		0324E52713564BC7000ADC60 /* MOAIDataIOAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIDataIOAction.cpp; sourceTree = "<group>"; };
-		0324E52813564BC7000ADC60 /* MOAIDataIOAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIDataIOAction.h; sourceTree = "<group>"; };
 		0324E52913564BC7000ADC60 /* MOAIDebugLines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIDebugLines.cpp; sourceTree = "<group>"; };
 		0324E52A13564BC7000ADC60 /* MOAIDebugLines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIDebugLines.h; sourceTree = "<group>"; };
 		0324E52B13564BC7000ADC60 /* MOAIDeck.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIDeck.cpp; sourceTree = "<group>"; };
@@ -5920,6 +5918,38 @@
 		E9CA1E59151C8578005F39B7 /* MOAIWebViewIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAIWebViewIOS.mm; path = "moaiext-iphone/MOAIWebViewIOS.mm"; sourceTree = "<group>"; };
 		E9DE457F157EA38800630A7D /* MOAIMoviePlayerIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MOAIMoviePlayerIOS.h; path = "moaiext-iphone/MOAIMoviePlayerIOS.h"; sourceTree = "<group>"; };
 		E9DE4580157EA38800630A7D /* MOAIMoviePlayerIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MOAIMoviePlayerIOS.mm; path = "moaiext-iphone/MOAIMoviePlayerIOS.mm"; sourceTree = "<group>"; };
+		FAA659CE16AD9178001C04DD /* MOAICamera2D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAICamera2D.cpp; sourceTree = "<group>"; };
+		FAA659CF16AD9178001C04DD /* MOAICamera2D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAICamera2D.h; sourceTree = "<group>"; };
+		FAA659D016AD9178001C04DD /* MOAIDataIOTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIDataIOTask.cpp; sourceTree = "<group>"; };
+		FAA659D116AD9178001C04DD /* MOAIDataIOTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIDataIOTask.h; sourceTree = "<group>"; };
+		FAA659D216AD9178001C04DD /* MOAILayer2D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAILayer2D.cpp; sourceTree = "<group>"; };
+		FAA659D316AD9178001C04DD /* MOAILayer2D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAILayer2D.h; sourceTree = "<group>"; };
+		FAA659D416AD9178001C04DD /* MOAIMutex_posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIMutex_posix.cpp; sourceTree = "<group>"; };
+		FAA659D516AD9178001C04DD /* MOAIMutex_posix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIMutex_posix.h; sourceTree = "<group>"; };
+		FAA659D616AD9178001C04DD /* MOAIMutex_win32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIMutex_win32.cpp; sourceTree = "<group>"; };
+		FAA659D716AD9178001C04DD /* MOAIMutex_win32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIMutex_win32.h; sourceTree = "<group>"; };
+		FAA659D816AD9178001C04DD /* MOAIMutex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIMutex.cpp; sourceTree = "<group>"; };
+		FAA659D916AD9178001C04DD /* MOAIMutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIMutex.h; sourceTree = "<group>"; };
+		FAA659DA16AD9178001C04DD /* MOAIProp2D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIProp2D.cpp; sourceTree = "<group>"; };
+		FAA659DB16AD9178001C04DD /* MOAIProp2D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIProp2D.h; sourceTree = "<group>"; };
+		FAA659DC16AD9178001C04DD /* MOAITask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAITask.cpp; sourceTree = "<group>"; };
+		FAA659DD16AD9178001C04DD /* MOAITask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAITask.h; sourceTree = "<group>"; };
+		FAA659DE16AD9178001C04DD /* MOAITaskQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAITaskQueue.cpp; sourceTree = "<group>"; };
+		FAA659DF16AD9178001C04DD /* MOAITaskQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAITaskQueue.h; sourceTree = "<group>"; };
+		FAA659E016AD9178001C04DD /* MOAITaskSubscriber.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAITaskSubscriber.cpp; sourceTree = "<group>"; };
+		FAA659E116AD9178001C04DD /* MOAITaskSubscriber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAITaskSubscriber.h; sourceTree = "<group>"; };
+		FAA659E216AD9178001C04DD /* MOAITaskThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAITaskThread.cpp; sourceTree = "<group>"; };
+		FAA659E316AD9178001C04DD /* MOAITaskThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAITaskThread.h; sourceTree = "<group>"; };
+		FAA659E416AD9178001C04DD /* MOAIThread_posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIThread_posix.cpp; sourceTree = "<group>"; };
+		FAA659E516AD9178001C04DD /* MOAIThread_posix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIThread_posix.h; sourceTree = "<group>"; };
+		FAA659E616AD9178001C04DD /* MOAIThread_win32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIThread_win32.cpp; sourceTree = "<group>"; };
+		FAA659E716AD9178001C04DD /* MOAIThread_win32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIThread_win32.h; sourceTree = "<group>"; };
+		FAA659E816AD9178001C04DD /* MOAIThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIThread.cpp; sourceTree = "<group>"; };
+		FAA659E916AD9178001C04DD /* MOAIThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIThread.h; sourceTree = "<group>"; };
+		FAA659EA16AD9178001C04DD /* MOAITransform2D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAITransform2D.cpp; sourceTree = "<group>"; };
+		FAA659EB16AD9178001C04DD /* MOAITransform2D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAITransform2D.h; sourceTree = "<group>"; };
+		FAA659EC16AD9178001C04DD /* MOAIXmlWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOAIXmlWriter.cpp; sourceTree = "<group>"; };
+		FAA659ED16AD9178001C04DD /* MOAIXmlWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIXmlWriter.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -7668,8 +7698,6 @@
 				0324E52613564BC7000ADC60 /* MOAIDataBuffer.h */,
 				66C57250157557FB00A486AB /* MOAIDataBufferStream.cpp */,
 				66C5724D157557F500A486AB /* MOAIDataBufferStream.h */,
-				0324E52713564BC7000ADC60 /* MOAIDataIOAction.cpp */,
-				0324E52813564BC7000ADC60 /* MOAIDataIOAction.h */,
 				031BBA5A13B17BD80005ECE0 /* MOAIEnvironment.cpp */,
 				031BBA5B13B17BD80005ECE0 /* MOAIEnvironment.h */,
 				66C5725F15756E4300A486AB /* MOAIFileStream.cpp */,
@@ -7690,6 +7718,38 @@
 				CDF0E6B6155C90920028E770 /* MOAITextBundle.h */,
 				0324E5A613564BC8000ADC60 /* MOAIXmlParser.cpp */,
 				0324E5A713564BC8000ADC60 /* MOAIXmlParser.h */,
+				FAA659CE16AD9178001C04DD /* MOAICamera2D.cpp */,
+				FAA659CF16AD9178001C04DD /* MOAICamera2D.h */,
+				FAA659D016AD9178001C04DD /* MOAIDataIOTask.cpp */,
+				FAA659D116AD9178001C04DD /* MOAIDataIOTask.h */,
+				FAA659D216AD9178001C04DD /* MOAILayer2D.cpp */,
+				FAA659D316AD9178001C04DD /* MOAILayer2D.h */,
+				FAA659D416AD9178001C04DD /* MOAIMutex_posix.cpp */,
+				FAA659D516AD9178001C04DD /* MOAIMutex_posix.h */,
+				FAA659D616AD9178001C04DD /* MOAIMutex_win32.cpp */,
+				FAA659D716AD9178001C04DD /* MOAIMutex_win32.h */,
+				FAA659D816AD9178001C04DD /* MOAIMutex.cpp */,
+				FAA659D916AD9178001C04DD /* MOAIMutex.h */,
+				FAA659DA16AD9178001C04DD /* MOAIProp2D.cpp */,
+				FAA659DB16AD9178001C04DD /* MOAIProp2D.h */,
+				FAA659DC16AD9178001C04DD /* MOAITask.cpp */,
+				FAA659DD16AD9178001C04DD /* MOAITask.h */,
+				FAA659DE16AD9178001C04DD /* MOAITaskQueue.cpp */,
+				FAA659DF16AD9178001C04DD /* MOAITaskQueue.h */,
+				FAA659E016AD9178001C04DD /* MOAITaskSubscriber.cpp */,
+				FAA659E116AD9178001C04DD /* MOAITaskSubscriber.h */,
+				FAA659E216AD9178001C04DD /* MOAITaskThread.cpp */,
+				FAA659E316AD9178001C04DD /* MOAITaskThread.h */,
+				FAA659E416AD9178001C04DD /* MOAIThread_posix.cpp */,
+				FAA659E516AD9178001C04DD /* MOAIThread_posix.h */,
+				FAA659E616AD9178001C04DD /* MOAIThread_win32.cpp */,
+				FAA659E716AD9178001C04DD /* MOAIThread_win32.h */,
+				FAA659E816AD9178001C04DD /* MOAIThread.cpp */,
+				FAA659E916AD9178001C04DD /* MOAIThread.h */,
+				FAA659EA16AD9178001C04DD /* MOAITransform2D.cpp */,
+				FAA659EB16AD9178001C04DD /* MOAITransform2D.h */,
+				FAA659EC16AD9178001C04DD /* MOAIXmlWriter.cpp */,
+				FAA659ED16AD9178001C04DD /* MOAIXmlWriter.h */,
 			);
 			name = util;
 			sourceTree = "<group>";
@@ -10259,7 +10319,6 @@
 				0324E86013564BC8000ADC60 /* MOAICpShape.h in Headers */,
 				0324E86213564BC8000ADC60 /* MOAICpSpace.h in Headers */,
 				0324E86413564BC8000ADC60 /* MOAIDataBuffer.h in Headers */,
-				0324E86613564BC8000ADC60 /* MOAIDataIOAction.h in Headers */,
 				0324E86813564BC8000ADC60 /* MOAIDebugLines.h in Headers */,
 				0324E86A13564BC8000ADC60 /* MOAIDeck.h in Headers */,
 				0324E86E13564BC8000ADC60 /* MOAIEaseDriver.h in Headers */,
@@ -10508,14 +10567,11 @@
 				66C5726415756E4300A486AB /* MOAIFileStream.h in Headers */,
 				66C5726A1575700A00A486AB /* MOAIStream.h in Headers */,
 				66C572721575703300A486AB /* MOAIMemStream.h in Headers */,
-				66C572761575703300A486AB /* MOAIStream.h in Headers */,
 				66C5727C1575709400A486AB /* USDeflateReader.h in Headers */,
 				66C57282157570A800A486AB /* USDeflateWriter.h in Headers */,
 				66C57288157570FF00A486AB /* USStreamWriter.h in Headers */,
 				66C572901575711000A486AB /* USBase64Reader.h in Headers */,
 				66C572941575711000A486AB /* USBase64Writer.h in Headers */,
-				66C5729E1575713C00A486AB /* USBase64Reader.h in Headers */,
-				66C572A21575713C00A486AB /* USBase64Writer.h in Headers */,
 				66C572A61575713C00A486AB /* USStreamReader.h in Headers */,
 				66C572AC1575714B00A486AB /* USBase64Encoder.h in Headers */,
 				66C572B21575717000A486AB /* MOAIGridDeck2D.h in Headers */,
@@ -11001,7 +11057,6 @@
 				0324E6C213564BC8000ADC60 /* MOAICpShape.h in Headers */,
 				0324E6C413564BC8000ADC60 /* MOAICpSpace.h in Headers */,
 				0324E6C613564BC8000ADC60 /* MOAIDataBuffer.h in Headers */,
-				0324E6C813564BC8000ADC60 /* MOAIDataIOAction.h in Headers */,
 				0324E6CA13564BC8000ADC60 /* MOAIDebugLines.h in Headers */,
 				0324E6CC13564BC8000ADC60 /* MOAIDeck.h in Headers */,
 				0324E6D013564BC8000ADC60 /* MOAIEaseDriver.h in Headers */,
@@ -11180,8 +11235,6 @@
 				E9940DC814B7A4A0006465CC /* USCgt.h in Headers */,
 				E9940DCC14B7A4A0006465CC /* USColor.h in Headers */,
 				E9940DD014B7A4A0006465CC /* USCurve.h in Headers */,
-				E9940DD414B7A4A0006465CC /* USData.h in Headers */,
-				E9940DD814B7A4A0006465CC /* USDataIOTask.h in Headers */,
 				E9940DDA14B7A4A0006465CC /* USDelegate.h in Headers */,
 				E9940DE014B7A4A0006465CC /* USDistance.h in Headers */,
 				E9940DE414B7A4A0006465CC /* USHexDump.h in Headers */,
@@ -11193,8 +11246,6 @@
 				E9940DF614B7A4A0006465CC /* USMatrix3x3.h in Headers */,
 				E9940DF814B7A4A0006465CC /* USMatrix4x4.h in Headers */,
 				E9940DFC14B7A4A0006465CC /* USMercator.h in Headers */,
-				E9940E0014B7A4A0006465CC /* USMutex_posix.h in Headers */,
-				E9940E0414B7A4A0006465CC /* USMutex.h in Headers */,
 				E9940E0814B7A4A0006465CC /* USParser.h in Headers */,
 				E9940E0C14B7A4A0006465CC /* USPlane.h in Headers */,
 				E9940E1014B7A4A0006465CC /* USPolar.h in Headers */,
@@ -11207,10 +11258,6 @@
 				E9940E2414B7A4A0006465CC /* USSurface2D.h in Headers */,
 				E9940E2814B7A4A0006465CC /* USSyntaxNode.h in Headers */,
 				E9940E2C14B7A4A0006465CC /* USSyntaxScanner.h in Headers */,
-				E9940E3014B7A4A0006465CC /* USTask.h in Headers */,
-				E9940E3414B7A4A0006465CC /* USTaskThread.h in Headers */,
-				E9940E3814B7A4A0006465CC /* USThread_posix.h in Headers */,
-				E9940E3C14B7A4A0006465CC /* USThread.h in Headers */,
 				E9940E4014B7A4A0006465CC /* USTrig.h in Headers */,
 				E9940E4414B7A4A0006465CC /* USTypedPtr.h in Headers */,
 				E9940E4814B7A4A0006465CC /* USXmlReader.h in Headers */,
@@ -11255,14 +11302,11 @@
 				66C5726315756E4300A486AB /* MOAIFileStream.h in Headers */,
 				66C572691575700A00A486AB /* MOAIStream.h in Headers */,
 				66C572711575703300A486AB /* MOAIMemStream.h in Headers */,
-				66C572751575703300A486AB /* MOAIStream.h in Headers */,
 				66C5727B1575709400A486AB /* USDeflateReader.h in Headers */,
 				66C57281157570A800A486AB /* USDeflateWriter.h in Headers */,
 				66C57287157570FF00A486AB /* USStreamWriter.h in Headers */,
 				66C5728F1575711000A486AB /* USBase64Reader.h in Headers */,
 				66C572931575711000A486AB /* USBase64Writer.h in Headers */,
-				66C5729D1575713C00A486AB /* USBase64Reader.h in Headers */,
-				66C572A11575713C00A486AB /* USBase64Writer.h in Headers */,
 				66C572A51575713C00A486AB /* USStreamReader.h in Headers */,
 				66C572AB1575714B00A486AB /* USBase64Encoder.h in Headers */,
 				66C572B11575717000A486AB /* MOAIGridDeck2D.h in Headers */,
@@ -11312,6 +11356,22 @@
 				6637040216128038002D0D27 /* USHashWriterWhirlpool.h in Headers */,
 				6637040616128038002D0D27 /* USHexReader.h in Headers */,
 				6637040E161280E1002D0D27 /* USHashWriter.h in Headers */,
+				FAA659EF16AD9178001C04DD /* MOAICamera2D.h in Headers */,
+				FAA659F116AD9178001C04DD /* MOAIDataIOTask.h in Headers */,
+				FAA659F316AD9178001C04DD /* MOAILayer2D.h in Headers */,
+				FAA659F516AD9178001C04DD /* MOAIMutex_posix.h in Headers */,
+				FAA659F716AD9178001C04DD /* MOAIMutex_win32.h in Headers */,
+				FAA659F916AD9178001C04DD /* MOAIMutex.h in Headers */,
+				FAA659FB16AD9178001C04DD /* MOAIProp2D.h in Headers */,
+				FAA659FD16AD9178001C04DD /* MOAITask.h in Headers */,
+				FAA659FF16AD9178001C04DD /* MOAITaskQueue.h in Headers */,
+				FAA65A0116AD9178001C04DD /* MOAITaskSubscriber.h in Headers */,
+				FAA65A0316AD9178001C04DD /* MOAITaskThread.h in Headers */,
+				FAA65A0516AD9178001C04DD /* MOAIThread_posix.h in Headers */,
+				FAA65A0716AD9178001C04DD /* MOAIThread_win32.h in Headers */,
+				FAA65A0916AD9178001C04DD /* MOAIThread.h in Headers */,
+				FAA65A0B16AD9178001C04DD /* MOAITransform2D.h in Headers */,
+				FAA65A0D16AD9178001C04DD /* MOAIXmlWriter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11967,7 +12027,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = NO;
-				LastUpgradeCheck = 0430;
+				LastUpgradeCheck = 0450;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "libmoai" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -12366,7 +12426,6 @@
 				0324E85F13564BC8000ADC60 /* MOAICpShape.cpp in Sources */,
 				0324E86113564BC8000ADC60 /* MOAICpSpace.cpp in Sources */,
 				0324E86313564BC8000ADC60 /* MOAIDataBuffer.cpp in Sources */,
-				0324E86513564BC8000ADC60 /* MOAIDataIOAction.cpp in Sources */,
 				0324E86713564BC8000ADC60 /* MOAIDebugLines.cpp in Sources */,
 				0324E86913564BC8000ADC60 /* MOAIDeck.cpp in Sources */,
 				0324E86D13564BC8000ADC60 /* MOAIEaseDriver.cpp in Sources */,
@@ -12568,14 +12627,11 @@
 				66C5726215756E4300A486AB /* MOAIFileStream.cpp in Sources */,
 				66C572681575700A00A486AB /* MOAIStream.cpp in Sources */,
 				66C572701575703300A486AB /* MOAIMemStream.cpp in Sources */,
-				66C572741575703300A486AB /* MOAIStream.cpp in Sources */,
 				66C5727A1575709400A486AB /* USDeflateReader.cpp in Sources */,
 				66C57280157570A800A486AB /* USDeflateWriter.cpp in Sources */,
 				66C57286157570FF00A486AB /* USStreamWriter.cpp in Sources */,
 				66C5728E1575711000A486AB /* USBase64Reader.cpp in Sources */,
 				66C572921575711000A486AB /* USBase64Writer.cpp in Sources */,
-				66C5729C1575713C00A486AB /* USBase64Reader.cpp in Sources */,
-				66C572A01575713C00A486AB /* USBase64Writer.cpp in Sources */,
 				66C572A41575713C00A486AB /* USStreamReader.cpp in Sources */,
 				66C572AA1575714B00A486AB /* USBase64Encoder.cpp in Sources */,
 				66C572B01575717000A486AB /* MOAIGridDeck2D.cpp in Sources */,
@@ -13580,9 +13636,9 @@
 				E9C4062F151861F200C7AB04 /* MOAITextStyle.cpp in Sources */,
 				E9C40630151861F200C7AB04 /* MOAITextStyler.cpp in Sources */,
 				E9C4062C151861A700C7AB04 /* MOAIGlyphCache.cpp in Sources */,
+				E9C4062B1518616F00C7AB04 /* MOAITextDesigner.cpp in Sources */,
 				E9C4062D151861A700C7AB04 /* MOAIGlyphCacheBase.cpp in Sources */,
 				E9C4062E151861A700C7AB04 /* MOAIGlyphCachePage.cpp in Sources */,
-				E9C4062B1518616F00C7AB04 /* MOAITextDesigner.cpp in Sources */,
 				E9C4062A1518615A00C7AB04 /* MOAIGlyphSet.cpp in Sources */,
 				E9C406281518614200C7AB04 /* MOAITextureBase.cpp in Sources */,
 				0324E69413564BC8000ADC60 /* AKU.cpp in Sources */,
@@ -13610,7 +13666,6 @@
 				0324E6C113564BC8000ADC60 /* MOAICpShape.cpp in Sources */,
 				0324E6C313564BC8000ADC60 /* MOAICpSpace.cpp in Sources */,
 				0324E6C513564BC8000ADC60 /* MOAIDataBuffer.cpp in Sources */,
-				0324E6C713564BC8000ADC60 /* MOAIDataIOAction.cpp in Sources */,
 				0324E6C913564BC8000ADC60 /* MOAIDebugLines.cpp in Sources */,
 				0324E6CB13564BC8000ADC60 /* MOAIDeck.cpp in Sources */,
 				0324E6CF13564BC8000ADC60 /* MOAIEaseDriver.cpp in Sources */,
@@ -13750,16 +13805,12 @@
 				E9940DC614B7A4A0006465CC /* USCgt.cpp in Sources */,
 				E9940DCA14B7A4A0006465CC /* USColor.cpp in Sources */,
 				E9940DCE14B7A4A0006465CC /* USCurve.cpp in Sources */,
-				E9940DD214B7A4A0006465CC /* USData.cpp in Sources */,
-				E9940DD614B7A4A0006465CC /* USDataIOTask.cpp in Sources */,
 				E9940DDE14B7A4A0006465CC /* USDistance.cpp in Sources */,
 				E9940DE214B7A4A0006465CC /* USHexDump.cpp in Sources */,
 				E9940DE614B7A4A0006465CC /* USInterpolate.cpp in Sources */,
 				E9940DEA14B7A4A0006465CC /* USIntersect.cpp in Sources */,
 				E9940DEE14B7A4A0006465CC /* USLexStream.cpp in Sources */,
 				E9940DFA14B7A4A0006465CC /* USMercator.cpp in Sources */,
-				E9940DFE14B7A4A0006465CC /* USMutex_posix.cpp in Sources */,
-				E9940E0214B7A4A0006465CC /* USMutex.cpp in Sources */,
 				E9940E0614B7A4A0006465CC /* USParser.cpp in Sources */,
 				E9940E0A14B7A4A0006465CC /* USPlane.cpp in Sources */,
 				E9940E0E14B7A4A0006465CC /* USPolar.cpp in Sources */,
@@ -13768,10 +13819,6 @@
 				E9940E2214B7A4A0006465CC /* USSurface2D.cpp in Sources */,
 				E9940E2614B7A4A0006465CC /* USSyntaxNode.cpp in Sources */,
 				E9940E2A14B7A4A0006465CC /* USSyntaxScanner.cpp in Sources */,
-				E9940E2E14B7A4A0006465CC /* USTask.cpp in Sources */,
-				E9940E3214B7A4A0006465CC /* USTaskThread.cpp in Sources */,
-				E9940E3614B7A4A0006465CC /* USThread_posix.cpp in Sources */,
-				E9940E3A14B7A4A0006465CC /* USThread.cpp in Sources */,
 				E9940E3E14B7A4A0006465CC /* USTrig.cpp in Sources */,
 				E9940E4214B7A4A0006465CC /* USTypedPtr.cpp in Sources */,
 				E9940E4614B7A4A0006465CC /* USXmlReader.cpp in Sources */,
@@ -13818,14 +13865,11 @@
 				66C5726115756E4300A486AB /* MOAIFileStream.cpp in Sources */,
 				66C572671575700A00A486AB /* MOAIStream.cpp in Sources */,
 				66C5726F1575703300A486AB /* MOAIMemStream.cpp in Sources */,
-				66C572731575703300A486AB /* MOAIStream.cpp in Sources */,
 				66C572791575709400A486AB /* USDeflateReader.cpp in Sources */,
 				66C5727F157570A800A486AB /* USDeflateWriter.cpp in Sources */,
 				66C57285157570FF00A486AB /* USStreamWriter.cpp in Sources */,
 				66C5728D1575711000A486AB /* USBase64Reader.cpp in Sources */,
 				66C572911575711000A486AB /* USBase64Writer.cpp in Sources */,
-				66C5729B1575713C00A486AB /* USBase64Reader.cpp in Sources */,
-				66C5729F1575713C00A486AB /* USBase64Writer.cpp in Sources */,
 				66C572A31575713C00A486AB /* USStreamReader.cpp in Sources */,
 				66C572A91575714B00A486AB /* USBase64Encoder.cpp in Sources */,
 				66C572AF1575717000A486AB /* MOAIGridDeck2D.cpp in Sources */,
@@ -13843,6 +13887,22 @@
 				6637040416128038002D0D27 /* USHexReader.cpp in Sources */,
 				6637040816128038002D0D27 /* USHexWriter.cpp in Sources */,
 				6637040C161280E1002D0D27 /* USHashWriter.cpp in Sources */,
+				FAA659EE16AD9178001C04DD /* MOAICamera2D.cpp in Sources */,
+				FAA659F016AD9178001C04DD /* MOAIDataIOTask.cpp in Sources */,
+				FAA659F216AD9178001C04DD /* MOAILayer2D.cpp in Sources */,
+				FAA659F416AD9178001C04DD /* MOAIMutex_posix.cpp in Sources */,
+				FAA659F616AD9178001C04DD /* MOAIMutex_win32.cpp in Sources */,
+				FAA659F816AD9178001C04DD /* MOAIMutex.cpp in Sources */,
+				FAA659FA16AD9178001C04DD /* MOAIProp2D.cpp in Sources */,
+				FAA659FC16AD9178001C04DD /* MOAITask.cpp in Sources */,
+				FAA659FE16AD9178001C04DD /* MOAITaskQueue.cpp in Sources */,
+				FAA65A0016AD9178001C04DD /* MOAITaskSubscriber.cpp in Sources */,
+				FAA65A0216AD9178001C04DD /* MOAITaskThread.cpp in Sources */,
+				FAA65A0416AD9178001C04DD /* MOAIThread_posix.cpp in Sources */,
+				FAA65A0616AD9178001C04DD /* MOAIThread_win32.cpp in Sources */,
+				FAA65A0816AD9178001C04DD /* MOAIThread.cpp in Sources */,
+				FAA65A0A16AD9178001C04DD /* MOAITransform2D.cpp in Sources */,
+				FAA65A0C16AD9178001C04DD /* MOAIXmlWriter.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14172,6 +14232,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREFIX_HEADER = "../../3rdparty/untz/src/native/ios/Untz-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
@@ -14209,6 +14270,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREFIX_HEADER = "../../3rdparty/untz/src/native/ios/Untz-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -14248,11 +14310,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
 				);
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "moai-osx";
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64 ppc970 ppc7400 ppc64 ppc";
@@ -14263,11 +14326,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
 				);
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "moai-osx";
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64 ppc970 ppc7400 ppc64 ppc";
@@ -14491,6 +14555,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
+				OTHER_LDFLAGS = "-v";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -15213,6 +15278,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
+				OTHER_LDFLAGS = "-v";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -15251,6 +15317,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15267,6 +15334,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15349,6 +15417,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15385,6 +15454,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15635,6 +15705,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15671,6 +15742,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15855,6 +15927,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15895,6 +15968,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15935,6 +16009,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -15975,6 +16050,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16015,6 +16091,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16055,6 +16132,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16095,6 +16173,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16135,6 +16214,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16269,6 +16349,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
+				OTHER_LDFLAGS = "-v";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -16483,6 +16564,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16491,7 +16573,7 @@
 					"${inherited}",
 					MACOSX,
 				);
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "moai-osx";
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64 ppc970 ppc7400 ppc64 ppc";
@@ -16502,6 +16584,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREFIX_HEADER = "../../3rdparty/untz/src/native/ios/Untz-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -16541,6 +16624,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16577,6 +16661,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16613,6 +16698,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -16855,6 +16941,7 @@
 					"-include",
 					"\"zlcore/zl_replace.h\"",
 				);
+				OTHER_LDFLAGS = "-v";
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -17135,11 +17222,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
 				);
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = "moai-osx";
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64 ppc970 ppc7400 ppc64 ppc";
@@ -17150,6 +17238,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREFIX_HEADER = "../../3rdparty/untz/src/native/ios/Untz-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -17189,6 +17278,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -17225,6 +17315,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,
@@ -17261,6 +17352,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"${inherited}",
 					MACOSX,

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-3rdparty.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-3rdparty.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-adcolony.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-adcolony.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-chartboost.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-chartboost.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-facebook.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-facebook.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-fmod-designer.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-fmod-designer.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-fmod-ex.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-fmod-ex.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-luaext.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-luaext.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-tapjoy.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-tapjoy.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-untz.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-untz.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-zlcore.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-zlcore.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-3rdparty.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-3rdparty.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-fmod-designer.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-fmod-designer.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-fmod-ex.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-fmod-ex.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-luaext.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-luaext.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-untz.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-untz.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-zlcore.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx-zlcore.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-osx.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>


### PR DESCRIPTION
MOAIEnvironment class has screenDpi property, but it is always nil for Android.
This fix populates screenDpi with data using DisplayMetrics in MoaiView. Changes were tested on HTC One X+ device.
