### PR TITLE
fix: MOAIImageTexture not override OnInvalidate

### DIFF
--- a/src/moaicore/MOAIImageTexture.cpp
+++ b/src/moaicore/MOAIImageTexture.cpp
@@ -127,6 +127,11 @@ void MOAIImageTexture::OnLoad () {
 }
 
 //----------------------------------------------------------------//
+void MOAIImageTexture::OnInvalidate(){
+
+}
+
+//----------------------------------------------------------------//
 void MOAIImageTexture::RegisterLuaClass ( MOAILuaState& state ) {
 	
 	MOAITextureBase::RegisterLuaClass ( state );

--- a/src/moaicore/MOAIImageTexture.h
+++ b/src/moaicore/MOAIImageTexture.h
@@ -39,6 +39,7 @@ private:
 	void			OnClear					();
 	void			OnCreate				();
 	void			OnLoad					();
+	void			OnInvalidate			();
 
 public:
 	


### PR DESCRIPTION
MOAIImageTexture doesn't override MOAITextureBase::OnInvalidate(), which causes it remove its GLTexID and recreate the texture every time on MOAIImageTexture::Invalidate() is called.
