### PR TITLE
Initial Camera Support for iOS

### DIFF
--- a/src/moaiext-iphone/MOAIAppIOS.h
+++ b/src/moaiext-iphone/MOAIAppIOS.h
@@ -12,6 +12,7 @@
 #import <moaiext-iphone/ReachabilityListener.h>
 
 @class MoaiMailComposeDelegate;
+@class MOAITakeCameraListener;
 
 //================================================================//
 // MOAIAppIOS
@@ -39,6 +40,7 @@ private:
 	static int	_getUTCTime				( lua_State* L );
 	static int	_sendMail				( lua_State* L );
 	static int	_setListener			( lua_State* L );
+	static int  _takeCamera             ( lua_State* L );
 		
 public:
 	
@@ -62,13 +64,18 @@ public:
 	UIApplication*			mApplication;
 	MOAILuaRef				mListeners [ TOTAL ];
 	ReachabilityListener*	mReachabilityListener;
+	MOAILuaRef				mOnTakeCameraCallback;
+	MOAITakeCameraListener* mTakeCameraListener;
+	UIPopoverController*	mImagePickerPopover;
 
 			MOAIAppIOS			();
 			~MOAIAppIOS			();
+	
 	void	AppOpenedFromURL	( NSURL* url );
 	void	DidStartSession		( bool resumed );
 	void	RegisterLuaClass	( MOAILuaState& state );
 	void	WillEndSession		();
+	static void		callTakeCameraLuaCallback									(NSString* imagePath);
 };
 
 //================================================================//

--- a/src/moaiext-iphone/MOAIAppIOS.mm
+++ b/src/moaiext-iphone/MOAIAppIOS.mm
@@ -9,10 +9,69 @@
 #import <moaiext-iphone/NSDictionary+MOAILib.h>
 #import <moaiext-iphone/NSError+MOAILib.h>
 #import <moaiext-iphone/NSString+MOAILib.h>
+#import <moaiext-iphone/MOAITakeCameraListener.h>
 
 //================================================================//
 // lua
 //================================================================//
+
+/** @name _takeCamera
+	@text Allows to pick a photo from the CameraRoll or from the Camera
+	@in function	callback
+	@in NSUInteger	input camera source
+	@in int			if device is an ipad x coordinate of Popover
+	@in int			if device is an ipad y coordinate of Popover
+	@in int			if device is an ipad width coordinate of Popover
+	@in int			if device is an ipad height coordinate of Popover
+
+ */
+ 
+int MOAIAppIOS::_takeCamera( lua_State* L ) {
+	
+	int x, y, width, height = 0;
+	NSUInteger sourceType;
+	
+	MOAILuaState state ( L );
+	if ( state.IsType ( 1, LUA_TFUNCTION )) {
+		MOAIAppIOS::Get ().mOnTakeCameraCallback.SetStrongRef ( state, 1 );
+	}
+	
+	sourceType = state.GetValue < NSUInteger >( 2, 0 );
+	x = state.GetValue < int >( 3, 0 );
+	y = state.GetValue < int >( 4, 0 );
+	width = state.GetValue < int >( 5, 0 );
+	height = state.GetValue < int >( 6, 0 );
+	
+	UIImagePickerController *ipc = [[UIImagePickerController alloc]
+									init]; 
+	UIWindow* window = [[ UIApplication sharedApplication ] keyWindow ];
+	UIViewController* rootVC = [ window rootViewController ];
+
+	ipc.delegate = MOAIAppIOS::Get ().mTakeCameraListener;
+	ipc.sourceType = sourceType;
+	
+	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+		MOAIAppIOS::Get().mImagePickerPopover = [[UIPopoverController alloc] 
+												   initWithContentViewController: ipc];
+		[MOAIAppIOS::Get ().mTakeCameraListener setPopover:MOAIAppIOS::Get().mImagePickerPopover];
+		MOAIAppIOS::Get().mImagePickerPopover.delegate = MOAIAppIOS::Get ().mTakeCameraListener;
+		CGRect rect = CGRectMake(x,y,10,10);
+		[MOAIAppIOS::Get().mImagePickerPopover presentPopoverFromRect:rect inView:[rootVC view] 
+						  permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+
+	} else {
+		[rootVC presentModalViewController:ipc animated:YES];
+	}
+	
+	return 0;
+}
+
+void MOAIAppIOS::callTakeCameraLuaCallback (NSString *imagePath) {
+	MOAILuaRef& callback = MOAIAppIOS::Get ().mOnTakeCameraCallback;
+	MOAILuaStateHandle state = callback.GetSelf ();
+	state.Push ([imagePath UTF8String]);
+	state.DebugCall ( 1, 0 );
+}
 
 //----------------------------------------------------------------//
 /**	@name	getDirectoryInDomain
@@ -137,12 +196,14 @@ MOAIAppIOS::MOAIAppIOS () {
 	[ this->mReachabilityListener startListener ];	
 	
 	mMailDelegate = [ MoaiMailComposeDelegate alloc ];
+	this->mTakeCameraListener = [MOAITakeCameraListener alloc];
 }
 
 //----------------------------------------------------------------//
 MOAIAppIOS::~MOAIAppIOS () {
 
 	[ mMailDelegate release ];
+	[ this->mTakeCameraListener release];
 }
 
 //----------------------------------------------------------------//
@@ -161,6 +222,7 @@ void MOAIAppIOS::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "getUTCTime",				_getUTCTime },
 		{ "sendMail",				_sendMail },
 		{ "setListener",			_setListener },
+		{ "takeCamera",             _takeCamera },
 		{ NULL, NULL }
 	};
 
@@ -234,4 +296,5 @@ void MOAIAppIOS::WillEndSession ( ) {
 		[ rootVC dismissModalViewControllerAnimated:YES ];
 	}
 }
+
 @end

--- a/src/moaiext-iphone/MOAITakeCameraListener.h
+++ b/src/moaiext-iphone/MOAITakeCameraListener.h
@@ -1,0 +1,21 @@
+//
+//  MOAITakeCameraListener.h
+//  libmoai
+//
+//  Created by Antonio Pascual Alonso on 13/11/11.
+//  Copyright 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+#import <UIKit/UIKit.h>
+
+
+@interface MOAITakeCameraListener : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UIPopoverControllerDelegate> {
+@private
+	UIPopoverController *popover;
+}
+
+@property ( readwrite, assign ) UIPopoverController*	popover;
+
+@end

--- a/src/moaiext-iphone/MOAITakeCameraListener.mm
+++ b/src/moaiext-iphone/MOAITakeCameraListener.mm
@@ -1,0 +1,51 @@
+//
+//  MOAITakeCameraListener.m
+//  libmoai
+//
+//  Created by Antonio Pascual Alonso on 13/11/11.
+//  Copyright 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import <moaiext-iphone/MOAIAppIOS.h>
+#import <moaiext-iphone/MOAITakeCameraListener.h>
+
+@implementation MOAITakeCameraListener
+
+@synthesize popover;
+
+- (void)imagePickerController:(UIImagePickerController *)picker 
+	didFinishPickingMediaWithInfo:(NSDictionary *)info
+{
+	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) { 
+		// If on the phone, the image picker is presented modally. Dismiss it.
+		[[picker parentViewController] dismissModalViewControllerAnimated:YES]; 
+	} else {
+		// If on the pad, the image picker is in the popover. Dismiss the popover. 
+		[popover dismissPopoverAnimated:YES];
+	}
+	
+	UIImage *image = [info objectForKey:UIImagePickerControllerOriginalImage];
+
+	// Create a CFUUID object - it knows how to create unique identifier strings 
+    CFUUIDRef newUniqueID = CFUUIDCreate(kCFAllocatorDefault);
+    CFStringRef newUniqueIDString =
+	CFUUIDCreateString (kCFAllocatorDefault, newUniqueID);
+    
+	NSString *path;
+	path = [NSString stringWithFormat:
+			@"%@/Documents/%@.PNG", 
+			NSHomeDirectory(), 
+			(__bridge NSString *)newUniqueIDString];
+	
+	NSData *data1 = [NSData dataWithData:UIImagePNGRepresentation(image)];
+	[data1 writeToFile:path atomically:YES];	
+	
+	// call the lua callback
+	MOAIAppIOS::callTakeCameraLuaCallback(path);
+
+	CFRelease(newUniqueIDString); 
+    CFRelease(newUniqueID);
+	[picker release];	
+}
+
+@end

--- a/src/moaiext-iphone/MOAITakeCameraListener.mm
+++ b/src/moaiext-iphone/MOAITakeCameraListener.mm
@@ -18,7 +18,7 @@
 {
 	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) { 
 		// If on the phone, the image picker is presented modally. Dismiss it.
-		[[picker parentViewController] dismissModalViewControllerAnimated:YES]; 
+		[picker dismissModalViewControllerAnimated:YES]; 
 	} else {
 		// If on the pad, the image picker is in the popover. Dismiss the popover. 
 		[popover dismissPopoverAnimated:YES];


### PR DESCRIPTION
Allows to take a picture with the camera or pick up from the camera roll.

```
MOAIApp.takeCamera(
    function_callback(image_path),
    source,
    x,
    y,
    width,
    height
)
```

**function_callback(image_path)**: It is the function that will be called at the end. The image is copied to the "Documents" directory of the application folder. The function receives the image path as parameter.
**source**: The source use when picking the image. 
The values are
0=UIImagePickerControllerSourceTypePhotoLibrary
1=UIImagePickerControllerSourceTypeCamera
2=UIImagePickerControllerSourceTypeSavedPhotosAlbum

**x**: On iPAD a popover must be used to present the UIPickerController. These are the coordinates and the size of the popover
**y**: y coordinate
**width**: width of popover
**height**: height of popover

Example of use:

```
local img = RNFactory.createImage(Resource:getVignette(0))

img.scaleX = 0.8
img.scaleY = 0.8
img:setOnTouchUp(takePhoto)

function takePhoto(event)
    if (MOAIApp) then
        MOAIApp.takeCamera(function(image_path)
            print ("takeCamera moai function called")
            local i = RNFactory.createImage(image_path)
            sceneGroup:insert(i)
        end,
        1,
        500,
        600,
        10,
        10)
    end
end
```
