### PR TITLE
Add Lua argv global to Glut host, run 'main.lua' if host given no args

### DIFF
--- a/src/aku/AKU.cpp
+++ b/src/aku/AKU.cpp
@@ -510,3 +510,31 @@ void AKUUpdate () {
 
 	MOAISim::Get ().Update ();
 }
+
+//----------------------------------------------------------------//
+void AKUSetArgv ( char **argv ) {
+
+	int i;
+	int argc = 0;
+
+	lua_State* L = AKUGetLuaState ();
+
+	// count argv
+	while ( argv[argc] ) argc++;
+
+	lua_createtable ( L, argc, 0 );
+	int newTable = lua_gettop ( L );
+
+	// arg[-1] => host binary (lua, luajit, moai-untz, ...)
+	// arg[0]  => first arg (script name as passed to host binary)
+	// arg[1]  => next arg/option/script
+	// arg[2]  => next arg/option/script
+	// ...
+	for ( i=0; i < argc; i++ ) {
+		lua_pushstring ( L, argv[i] );
+		lua_rawseti ( L, newTable, i - 1 );
+	}
+
+	// same as lua global 'arg'
+	lua_setglobal ( L, "arg" );
+}

--- a/src/aku/AKU.h
+++ b/src/aku/AKU.h
@@ -83,6 +83,7 @@ AKU_API void			AKUSetViewSize					( int width, int height );
 AKU_API void			AKUSoftReleaseGfxResources		( int age );
 AKU_API int				AKUSetWorkingDirectory			( char const* path );
 AKU_API void			AKUUpdate						();
+AKU_API void			AKUSetArgv						( char **argv );
 
 // input device api
 AKU_API void			AKUReserveInputDevices			( int total );

--- a/src/hosts/GlutHost.cpp
+++ b/src/hosts/GlutHost.cpp
@@ -349,9 +349,12 @@ int GlutHost ( int argc, char** argv ) {
 	char* lastScript = NULL;
 
 	if ( argc < 2 ) {
-		AKURunScript( "main.lua" );
+		AKURunScript ( "main.lua" );
 	}
 	else {
+
+		AKUSetArgv ( argv );
+
 		for ( int i = 1; i < argc; ++i ) {
 			char* arg = argv [ i ];
 			if ( strcmp( arg, "-e" ) == 0 ) {

--- a/src/hosts/GlutHost.cpp
+++ b/src/hosts/GlutHost.cpp
@@ -348,18 +348,23 @@ int GlutHost ( int argc, char** argv ) {
 
 	char* lastScript = NULL;
 
-	for ( int i = 1; i < argc; ++i ) {
-		char* arg = argv [ i ];
-		if ( strcmp( arg, "-e" ) == 0 ) {
-			sDynamicallyReevaluateLuaFiles = true;
-		}
-		else if ( strcmp( arg, "-s" ) == 0 && ++i < argc ) {
-			char* script = argv [ i ];
-			AKURunString ( script );
-		}
-		else {
-			AKURunScript ( arg );
-			lastScript = arg;
+	if ( argc < 2 ) {
+		AKURunScript( "main.lua" );
+	}
+	else {
+		for ( int i = 1; i < argc; ++i ) {
+			char* arg = argv [ i ];
+			if ( strcmp( arg, "-e" ) == 0 ) {
+				sDynamicallyReevaluateLuaFiles = true;
+			}
+			else if ( strcmp( arg, "-s" ) == 0 && ++i < argc ) {
+				char* script = argv [ i ];
+				AKURunString ( script );
+			}
+			else {
+				AKURunScript ( arg );
+				lastScript = arg;
+			}
 		}
 	}
 	


### PR DESCRIPTION
If the host is given no arguments, run 'main.lua' by default.

The host's argv is converted to the lua global 'arg'.  See AKUSetArgv() for arg array order.

This allows the Moai binary to be a drop-in replacement for lua or luajit in the Busted (like Rspec) test framework.  See https://github.com/Olivine-Labs/busted

Example Busted Usage: Run all the specs in ../spec/modules

```
busted -l /home/robert/workspace/myproject/hosts/cmake/build/hosts/moai-untz -m '../spec/?.lua' ../spec/modules
```
