### PR TITLE
MOAIJsonParser int/real fix

### DIFF
--- a/src/moaicore/MOAIJsonParser.cpp
+++ b/src/moaicore/MOAIJsonParser.cpp
@@ -2,6 +2,7 @@
 // http://getmoai.com
 
 #include "pch.h"
+#include <math.h>
 #include <moaicore/MOAILogMessages.h>
 #include <moaicore/MOAIJsonParser.h>
 #include <jansson.h>
@@ -118,7 +119,12 @@ json_t* _luaToJSON ( lua_State* L, int idx ) {
 		case LUA_TNUMBER: {
 		
 			double real = lua_tonumber ( L, idx );
-			return json_real ( real );
+			double intpart;
+			if(modf(real, &intpart) == 0.0) {
+				return json_integer( intpart);
+			}else{
+				return json_real ( real );
+			}
 		}
 		
 		case LUA_TLIGHTUSERDATA: {


### PR DESCRIPTION
MOAIJsonParser used to format all the lua numbers as real. It can be a big deal in many cases. So, an additional check was added. If check shows the current number is an integer, it will be formatted using json_integer.
