### PR TITLE
Fix for paid apps released on Google Play

### DIFF
--- a/ant/host-source/source/project/src/app/MoaiActivity.java
+++ b/ant/host-source/source/project/src/app/MoaiActivity.java
@@ -94,7 +94,7 @@ public class MoaiActivity extends Activity {
 			
 			ApplicationInfo myApp = getPackageManager ().getApplicationInfo ( getPackageName (), 0 );
 
-			Moai.mount ( "bundle", myApp.publicSourceDir );
+			Moai.mount ( "bundle", myApp.sourceDir );
 			Moai.setWorkingDirectory ( "bundle/assets/@WORKING_DIR@" );				
 		} catch ( NameNotFoundException e ) {
 


### PR DESCRIPTION
Change the variable used to find the path of the APK to mount it. This one works also for forward-locked apps (used by Google Play on Jelly Bean)
