### PR TITLE
GL blend functions, build.sh tweaks

### DIFF
--- a/src/moaicore/MOAIBlendMode.cpp
+++ b/src/moaicore/MOAIBlendMode.cpp
@@ -12,6 +12,7 @@
 void MOAIBlendMode::Bind () {
 	
 	glEnable ( GL_BLEND );
+	glBlendEquation ( this->mEquation );
 	glBlendFunc ( this->mSourceFactor, this->mDestFactor );
 }
 
@@ -41,6 +42,7 @@ void MOAIBlendMode::GetBlendFactors ( u32 blend, int& srcFactor, int& dstFactor 
 void MOAIBlendMode::SetBlend ( u32 blend ) {
 	
 	MOAIBlendMode::GetBlendFactors ( blend, this->mSourceFactor, this->mDestFactor );
+	this->mEquation = GL_FUNC_ADD;
 }
 
 //----------------------------------------------------------------//
@@ -68,9 +70,18 @@ void MOAIBlendMode::SetBlend ( int srcFactor, int dstFactor ) {
 	this->mDestFactor = dstFactor;
 }
 
+void MOAIBlendMode::SetBlendEquation ( int equation ) {
+	// GL_FUNC_ADD
+	// GL_FUNC_SUBTRACT
+	// GL_FUNC_REVERSE_SUBTRACT
+	// (GL_MIN and GL_MAX don't exist on iOS)
+	this->mEquation = equation;
+}
+
 //----------------------------------------------------------------//
 MOAIBlendMode::MOAIBlendMode () :
 	mSourceFactor ( GL_ONE ),
+	mEquation ( GL_FUNC_ADD ),
 	mDestFactor ( GL_ONE_MINUS_SRC_ALPHA ) {
 }
 

--- a/src/moaicore/MOAIBlendMode.h
+++ b/src/moaicore/MOAIBlendMode.h
@@ -16,12 +16,14 @@ public:
 		BLEND_MULTIPLY,
 	};
 	
+	int				mEquation;
 	int				mSourceFactor;
 	int				mDestFactor;
 
 	//----------------------------------------------------------------//
 	void			Bind				();
 	static void		GetBlendFactors		( u32 blend, int& srcFactor, int& dstFactor );
+	void			SetBlendEquation		( int equation );
 	void			SetBlend			( u32 blend );
 	void			SetBlend			( int srcFactor, int dstFactor );
 					MOAIBlendMode			();
@@ -29,7 +31,9 @@ public:
 	
 	//----------------------------------------------------------------//
 	inline bool IsSame ( const MOAIBlendMode& blendMode ) {
-		return (( this->mSourceFactor == blendMode.mSourceFactor ) && ( this->mDestFactor == blendMode.mDestFactor ));
+		return (( this->mSourceFactor == blendMode.mSourceFactor ) &&
+		        ( this->mDestFactor == blendMode.mDestFactor ) &&
+			( this->mEquation == blendMode.mEquation ));
 	}
 };
 

--- a/src/moaicore/MOAIProp.cpp
+++ b/src/moaicore/MOAIProp.cpp
@@ -214,15 +214,48 @@ int MOAIProp::_setBillboard ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
-/** @name	setBlendMode
-	@text	Set the blend mode.
+/** @name	setBlendEquation
+	@text	Set the blend equation. This determines how the srcFactor and dstFactor values set with setBlendMode are interpreted.
 
-	@overload	Reset the blend mode to MOAIProp.BLEND_NORMAL (equivalent to src = GL_ONE, dst = GL_ONE_MINUS_SRC_ALPHA)
+	@overload	Reset the blend function to GL_FUNC_ADD.
 
 		@in		MOAIProp self
 		@out	nil
 
-	@overload	Set blend mode using one of the Moai presets.
+	@overload	Set the blend equation.
+
+		@in		MOAIProp self
+		@in		number equation					One of GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT.
+		@out	nil
+	
+*/
+
+int MOAIProp::_setBlendEquation ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIProp, "U" )
+
+	if ( state.IsType ( 2, LUA_TNUMBER )) {
+		u32 equation = state.GetValue < u32 >( 2, GL_FUNC_ADD );
+		self->mBlendMode.SetBlendEquation ( equation );
+	}
+	else {
+		self->mBlendMode.SetBlendEquation ( GL_FUNC_ADD );
+	}
+	
+	self->ScheduleUpdate ();
+	
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/** @name	setBlendMode
+	@text	Set the blend mode.
+
+	@overload	Reset the blend mode to MOAIProp.BLEND_NORMAL (equivalent to src = GL_ONE, dst = GL_ONE_MINUS_SRC_ALPHA). This will reset the blend function to GL_FUNC_ADD.
+
+		@in		MOAIProp self
+		@out	nil
+
+	@overload	Set blend mode using one of the Moai presets. This will reset the blend function to GL_FUNC_ADD.
 
 		@in		MOAIProp self
 		@in		number mode					One of MOAIProp.BLEND_NORMAL, MOAIProp.BLEND_ADD, MOAIProp.BLEND_MULTIPLY.
@@ -1078,18 +1111,23 @@ void MOAIProp::RegisterLuaClass ( MOAILuaState& state ) {
 	state.SetField ( -1, "BLEND_ADD", ( u32 )MOAIBlendMode::BLEND_ADD );
 	state.SetField ( -1, "BLEND_MULTIPLY", ( u32 )MOAIBlendMode::BLEND_MULTIPLY );
 	state.SetField ( -1, "BLEND_NORMAL", ( u32 )MOAIBlendMode::BLEND_NORMAL );
-	
-	state.SetField ( -1, "GL_ONE", ( u32 )GL_ONE );
-	state.SetField ( -1, "GL_ZERO", ( u32 )GL_ZERO );
-	state.SetField ( -1, "GL_DST_ALPHA", ( u32 )GL_DST_ALPHA );
-	state.SetField ( -1, "GL_DST_COLOR", ( u32 )GL_DST_COLOR );
-	state.SetField ( -1, "GL_SRC_COLOR", ( u32 )GL_SRC_COLOR );
-	state.SetField ( -1, "GL_ONE_MINUS_DST_ALPHA", ( u32 )GL_ONE_MINUS_DST_ALPHA );
-	state.SetField ( -1, "GL_ONE_MINUS_DST_COLOR", ( u32 )GL_ONE_MINUS_DST_COLOR );
-	state.SetField ( -1, "GL_ONE_MINUS_SRC_ALPHA", ( u32 )GL_ONE_MINUS_SRC_ALPHA );
-	state.SetField ( -1, "GL_ONE_MINUS_SRC_COLOR", ( u32 )GL_ONE_MINUS_SRC_COLOR );
-	state.SetField ( -1, "GL_SRC_ALPHA", ( u32 )GL_SRC_ALPHA );
-	state.SetField ( -1, "GL_SRC_ALPHA_SATURATE", ( u32 )GL_SRC_ALPHA_SATURATE );
+
+#define SIMPLE_FIELD_MAP(x) state.SetField ( -1, #x, ( u32 ) x )
+	SIMPLE_FIELD_MAP(GL_FUNC_ADD);
+	SIMPLE_FIELD_MAP(GL_FUNC_SUBTRACT);
+	SIMPLE_FIELD_MAP(GL_FUNC_REVERSE_SUBTRACT);
+
+	SIMPLE_FIELD_MAP(GL_ONE);
+	SIMPLE_FIELD_MAP(GL_ZERO);
+	SIMPLE_FIELD_MAP(GL_DST_ALPHA);
+	SIMPLE_FIELD_MAP(GL_DST_COLOR);
+	SIMPLE_FIELD_MAP(GL_SRC_COLOR);
+	SIMPLE_FIELD_MAP(GL_ONE_MINUS_DST_ALPHA);
+	SIMPLE_FIELD_MAP(GL_ONE_MINUS_DST_COLOR);
+	SIMPLE_FIELD_MAP(GL_ONE_MINUS_SRC_ALPHA);
+	SIMPLE_FIELD_MAP(GL_ONE_MINUS_SRC_COLOR);
+	SIMPLE_FIELD_MAP(GL_SRC_ALPHA);
+	SIMPLE_FIELD_MAP(GL_SRC_ALPHA_SATURATE);
 	
 	state.SetField ( -1, "DEPTH_TEST_DISABLE", ( u32 )0 );
 	state.SetField ( -1, "DEPTH_TEST_NEVER", ( u32 )GL_NEVER );
@@ -1122,6 +1160,7 @@ void MOAIProp::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "getWorldBounds",		_getWorldBounds },
 		{ "inside",				_inside },
 		{ "setBillboard",		_setBillboard },
+		{ "setBlendEquation",		_setBlendEquation },
 		{ "setBlendMode",		_setBlendMode },
 		{ "setBounds",			_setBounds },
 		{ "setCullMode",		_setCullMode },

--- a/src/moaicore/MOAIProp.h
+++ b/src/moaicore/MOAIProp.h
@@ -43,6 +43,10 @@ class MOAITextureBase;
 	@const	BLEND_NORMAL
 	@const	BLEND_ADD
 	@const	BLEND_MULTIPLY
+
+	@const  GL_FUNC_ADD
+	@const  GL_FUNC_SUBTRACT
+	@const  GL_FUNC_REVERSE_SUBTRACT
 	
 	@const	GL_ONE
 	@const	GL_ZERO
@@ -103,6 +107,7 @@ private:
 	static int		_getWorldBounds		( lua_State* L );
 	static int		_inside				( lua_State* L );
 	static int		_setBillboard		( lua_State* L );
+	static int		_setBlendEquation	( lua_State* L );
 	static int		_setBlendMode		( lua_State* L );
 	static int		_setBounds			( lua_State* L );
 	static int		_setCullMode		( lua_State* L );

--- a/xcode/libmoai/build.sh
+++ b/xcode/libmoai/build.sh
@@ -6,36 +6,40 @@
 # http://getmoai.com
 #----------------------------------------------------------------#
 
-set -e
+# osx_schemes="libmoai-osx libmoai-osx-3rdparty libmoai-osx-fmod-ex libmoai-osx-luaext libmoai-osx-untz libmoai-osx-zlcore"
+osx_schemes="libmoai-osx libmoai-osx-3rdparty libmoai-osx-luaext libmoai-osx-untz libmoai-osx-zlcore"
+osx_sdks="macosx"
+osx_architectures_macosx="i386"
 
-# osx_schemes=( "libmoai-osx" "libmoai-osx-3rdparty" "libmoai-osx-fmod-ex" "libmoai-osx-luaext" "libmoai-osx-untz" "libmoai-osx-zlcore" )
-osx_schemes=( "libmoai-osx" "libmoai-osx-3rdparty" "libmoai-osx-luaext" "libmoai-osx-untz" "libmoai-osx-zlcore" )
-osx_sdks=( "macosx" )
-osx_architectures=( "i386")
+# ios_schemes="libmoai-ios libmoai-ios-3rdparty libmoai-ios-facebook libmoai-ios-fmod-ex libmoai-ios-luaext libmoai-ios-tapjoy libmoai-ios-untz libmoai-ios-zlcore"
+ios_schemes="libmoai-ios libmoai-ios-3rdparty libmoai-ios-facebook libmoai-ios-luaext libmoai-ios-tapjoy libmoai-ios-untz libmoai-ios-zlcore"
+ios_sdks="iphoneos iphonesimulator"
+ios_architectures_iphonesimulator="i386"
+ios_architectures_iphoneos="armv7 armv7s"
 
-# ios_schemes=( "libmoai-ios" "libmoai-ios-3rdparty" "libmoai-ios-facebook" "libmoai-ios-fmod-ex" "libmoai-ios-luaext" "libmoai-ios-tapjoy" "libmoai-ios-untz" "libmoai-ios-zlcore" )
-ios_schemes=( "libmoai-ios" "libmoai-ios-3rdparty" "libmoai-ios-facebook" "libmoai-ios-luaext" "libmoai-ios-tapjoy" "libmoai-ios-untz" "libmoai-ios-zlcore" )
-ios_sdks=( "iphoneos" "iphonesimulator" )
-ios_architectures=( "i386" "armv7" "armv7s" )
-
-usage="usage: $0 [-j <jobName>] [-c Debug|Release|all] [-p osx|ios|all]"
+usage() {
+	echo >&2 "usage: $0 [-v] [-j <jobName>] [-c Debug|Release|all] [-p osx|ios|all]"
+	exit 1
+}
 job="moai"
 configurations="all"
 platforms="all"
+verbose=false
 
-while [ $# -gt 0 ];	do
-    case "$1" in
-		-j)  job="$2"; shift;;
-		-c)  configurations="$2"; shift;;
-		-p)  platforms="$2"; shift;;
-		-*)
-	    	echo >&2 \
-	    		$usage
-	    	exit 1;;
-		*)  break;;
-    esac
-    shift
+while getopts c:j:p: o; do
+	case $o in
+	c)	configurations=$OPTARG;;
+	j)	job=$OPTARG;;
+	p)	platforms=$OPTARG;;
+	v)	verbose=true;;
+	\?)	usage;;
+	esac
 done
+shift `expr $OPTIND - 1`
+
+if [ $# -gt 0 ]; then
+	usage
+fi
 
 if ! [[ $job =~ ^[a-zA-Z0-9_\-]+$ ]]; then
 	echo -e "*** Illegal job name specified: $job..."
@@ -58,49 +62,80 @@ elif [ x"$platforms" = xall ]; then
 	platforms="osx ios"
 fi
 
+basedir=${TMPDIR:-/tmp}/$job
+
+build() {
+	dir=${basedir}/${platform}/${scheme}/${sdk}/${config}
+	mkdir -p $dir
+	cmd="xcodebuild -configuration $config -workspace libmoai.xcodeproj/project.xcworkspace -scheme $scheme -sdk $sdk build CONFIGURATION_BUILD_DIR=$dir"
+	msg="Building libmoai/$scheme/$sdk for $platform $config..."
+
+	if $verbose; then
+		printf "%s\n" "$msg"
+		if $cmd; then
+			echo "Build OK."
+		else
+			echo "Build failed, aborting."
+			exit 1
+		fi
+	else
+		printf "%s" "$msg"
+		log=$dir/xcodebuild.log
+		if $cmd > $log; then
+			echo "Done."
+		else
+			echo "Failed."
+			echo >&2 "Logs in $dir/xcodebuild.log. Last few lines of failure:"
+			tail >&2 $dir/xcodebuild.log
+			exit 1
+		fi
+	fi
+}
+
 for platform in $platforms; do
 
 	schemes=
 	sdks=
 	architectures=
-	if [ x"$platform" = xosx ]; then
-		schemes="${osx_schemes[@]}"
-		sdks="${osx_sdks[@]}"
-		architectures="${osx_architectures[@]}"
-	elif [ x"$platform" = xios ]; then
-		schemes="${ios_schemes[@]}"
-		sdks="${ios_sdks[@]}"
-		architectures="${ios_architectures[@]}"
-	fi
+	eval schemes=\$${platform}_schemes
+	eval sdks=\$${platform}_sdks
 
 	for config in $configurations; do
 		for sdk in $sdks; do		
+			eval architectures=\$${platform}_architectures_$sdk
 			for scheme in $schemes; do
-				echo "Building libmoai/$scheme/$sdk for $platform $config"
-				xcodebuild -configuration $config -workspace libmoai.xcodeproj/project.xcworkspace -scheme $scheme -sdk $sdk build CONFIGURATION_BUILD_DIR=/tmp/$job/$platform/$scheme/$sdk/$config
-				echo "Done. Binaries available in /tmp/$job/$platform/$scheme/$sdk/$config"
+				build
 			done
 		done
 	done
 
 	for config in $configurations; do
-		rm -rf "/tmp/$job/$platform/$config/universal"
-		mkdir -p "/tmp/$job/$platform/$config/universal"
+		rm -rf "$basedir/$platform/$config/universal"
+		mkdir -p "$basedir/$platform/$config/universal"
 		for scheme in $schemes; do
 			libs=
 			for sdk in $sdks; do
-				libs="$libs /tmp/$job/$platform/$scheme/$sdk/$config/$scheme.a"
+				libs="$libs $basedir/$platform/$scheme/$sdk/$config/$scheme.a"
 			done
-			lipo -create -output "/tmp/$job/$platform/$config/universal/$scheme.a" $libs						
+			if ! xcrun -sdk $sdk lipo -create -output "$basedir/$platform/$config/universal/$scheme.a" $libs; then
+				echo >&2 "lipo failed, giving up."
+				exit 1
+			fi
 		done
 	done
 
 	for config in $configurations; do
-		for arch in $architectures; do
-			rm -rf "/tmp/$job/$platform/$config/$arch"
-			mkdir -p "/tmp/$job/$platform/$config/$arch"
-			for scheme in $schemes; do
-				lipo -thin $arch -output "/tmp/$job/$platform/$config/$arch/$scheme.a" "/tmp/$job/$platform/$config/universal/$scheme.a"
+		for sdk in $sdks; do
+			eval architectures=\$${platform}_architectures_$sdk
+			for arch in $architectures; do
+				rm -rf "$basedir/$platform/$config/$arch"
+				mkdir -p "$basedir/$platform/$config/$arch"
+				for scheme in $schemes; do
+					if !  xcrun -sdk $sdk lipo -thin $arch -output "$basedir/$platform/$config/$arch/$scheme.a" "$basedir/$platform/$config/universal/$scheme.a"; then
+						echo >&2 "lipo failed, giving up."
+						exit 1
+					fi
+				done
 			done
 		done
 	done


### PR DESCRIPTION
The GL function stuff is untested but at least builds. Open issues:
- It'd be nice to support GL_MIN and GL_MAX, but apparently those are extensions and may not be available for iOS.
- I wanted to also support glBlendFuncSeparate and glBlendModeSeparate, but those, too, are apparently extensions and some Android devices won't support them.

The build.sh stuff fixes the lipo errors by only running it for each SDK against the architectures that SDK supports, and also makes the output a little more manageable.
