### PR TITLE
Fix Clang 4.2 (Xcode 4.6) Compiler Warnings

### DIFF
--- a/src/moaicore/MOAIParticleForce.cpp
+++ b/src/moaicore/MOAIParticleForce.cpp
@@ -188,8 +188,7 @@ void MOAIParticleForce::Eval ( const USVec3D& loc, float mass, USVec3D& accelera
 //----------------------------------------------------------------//
 MOAIParticleForce::MOAIParticleForce () :
 	mShape ( LINEAR ),
-	mType ( GRAVITY ),
-	mUseMass ( false ) {
+	mType ( GRAVITY ) {
 	
 	RTTI_BEGIN
 		RTTI_EXTEND ( MOAITransform )

--- a/src/moaicore/MOAIParticleForce.h
+++ b/src/moaicore/MOAIParticleForce.h
@@ -31,8 +31,6 @@ private:
 	USVec3D		mWorldLoc;	
 	USVec3D		mWorldVec;
 
-	bool		mUseMass;
-
 	// attractor coefficients
 	float		mRadius;
 	float		mPull;

--- a/src/moaicore/MOAIPartitionResultBuffer.cpp
+++ b/src/moaicore/MOAIPartitionResultBuffer.cpp
@@ -248,8 +248,6 @@ u32 MOAIPartitionResultBuffer::Sort ( u32 mode ) {
 //----------------------------------------------------------------//
 u32 MOAIPartitionResultBuffer::SortResultsIso () {
 
-	this->mTotalResults = this->mTotalResults;
-
 	IsoSortItem* sortBuffer = ( IsoSortItem* )alloca ( this->mTotalResults * sizeof ( IsoSortItem ));
 	
 	IsoSortList frontList;

--- a/src/moaicore/MOAITask.cpp
+++ b/src/moaicore/MOAITask.cpp
@@ -11,9 +11,9 @@
 
 //----------------------------------------------------------------//
 MOAITask::MOAITask () :
+	mPriority ( PRIORITY_HIGH ),
 	mQueue ( 0 ),
-	mSubscriber ( 0 ),
-	mPriority ( PRIORITY_HIGH ) {
+	mSubscriber ( 0 ) {
 	
 	this->mLink.Data ( this );
 }

--- a/src/moaicore/MOAITouchSensor.h
+++ b/src/moaicore/MOAITouchSensor.h
@@ -76,8 +76,6 @@ private:
 		
 	MOAILuaRef		mCallback;
 		
-	MOAITouch		mLastTouch;
-		
 	u32				mLingerTop;
 	MOAITouchLinger	mLingerTouches [ MAX_TOUCHES ];
 		

--- a/src/uslscore/USLexStream.cpp
+++ b/src/uslscore/USLexStream.cpp
@@ -99,8 +99,7 @@ u8 USLexStream::UnreadByte () {
 
 //----------------------------------------------------------------//
 USLexStream::USLexStream () :
-	mLine ( DEFAULT_LINE_NO ),
-	mLinePad ( DEFAULT_LINE_PAD ) {
+	mLine ( DEFAULT_LINE_NO ) {
 }
 
 //----------------------------------------------------------------//

--- a/src/uslscore/USLexStream.h
+++ b/src/uslscore/USLexStream.h
@@ -20,7 +20,6 @@ private:
 	static const u32 DEFAULT_LINE_PAD	= 1;
 	
 	size_t mLine;
-	size_t mLinePad;
 	
 	//----------------------------------------------------------------//
 	u8			ReadByte			();


### PR DESCRIPTION
Fixes a few compiler warnings that showed up in my iOS Xcode project concerning unused members, member initialization order and assignment to itself.

There are a few more warnings (e.g. about using `->isa` being deprecated and a `__bridge` cast without effect) but I wasn't sure how to fix them correctly and safely.
