### PR TITLE
Added EVENT_PAUSE, EVENT_RESUME events to MOAISim

### DIFF
--- a/src/moaicore/MOAISim.cpp
+++ b/src/moaicore/MOAISim.cpp
@@ -738,6 +738,7 @@ void MOAISim::OnGlobalsRetire () {
 //----------------------------------------------------------------//
 void MOAISim::PauseMOAI () {
 
+	this->SendPauseEvent();
 	this->mLoopState = PAUSED;
 }
 
@@ -746,6 +747,8 @@ void MOAISim::RegisterLuaClass ( MOAILuaState& state ) {
 	MOAIGlobalEventSource::RegisterLuaClass ( state );
 
 	state.SetField ( -1, "EVENT_FINALIZE", ( u32 )EVENT_FINALIZE );
+	state.SetField ( -1, "EVENT_PAUSE", ( u32 )EVENT_PAUSE );
+	state.SetField ( -1, "EVENT_RESUME", ( u32 )EVENT_RESUME );
 
 	state.SetField ( -1, "SIM_LOOP_FORCE_STEP", ( u32 )SIM_LOOP_FORCE_STEP );
 	state.SetField ( -1, "SIM_LOOP_ALLOW_BOOST", ( u32 )SIM_LOOP_ALLOW_BOOST );
@@ -815,6 +818,7 @@ void MOAISim::RegisterLuaFuncs ( MOAILuaState& state ) {
 void MOAISim::ResumeMOAI() {
 
 	if ( this->mLoopState == PAUSED ) {
+		this->SendResumeEvent();
 		this->mLoopState = START;
 	}
 }
@@ -824,6 +828,24 @@ void MOAISim::SendFinalizeEvent () {
 
 	MOAILuaStateHandle state = MOAILuaRuntime::Get ().State ();
 	if ( this->PushListener ( EVENT_FINALIZE, state )) {
+		state.DebugCall ( 0, 0 );
+	}
+}
+
+//----------------------------------------------------------------//
+void MOAISim::SendPauseEvent () {
+
+	MOAILuaStateHandle state = MOAILuaRuntime::Get ().State ();
+	if ( this->PushListener ( EVENT_PAUSE, state )) {
+		state.DebugCall ( 0, 0 );
+	}
+}
+
+//----------------------------------------------------------------//
+void MOAISim::SendResumeEvent () {
+
+	MOAILuaStateHandle state = MOAILuaRuntime::Get ().State ();
+	if ( this->PushListener ( EVENT_RESUME, state )) {
 		state.DebugCall ( 0, 0 );
 	}
 }

--- a/src/moaicore/MOAISim.h
+++ b/src/moaicore/MOAISim.h
@@ -18,6 +18,8 @@ class MOAIProp;
 	@text	Sim timing and settings class.
 	
 	@const	EVENT_FINALIZE
+	@const	EVENT_PAUSE
+	@const	EVENT_RESUME
 	
 	@const SIM_LOOP_FORCE_STEP
 	@const SIM_LOOP_ALLOW_BOOST
@@ -52,6 +54,8 @@ private:
 	// events
 	enum {
 		EVENT_FINALIZE,
+		EVENT_PAUSE,
+		EVENT_RESUME,
 	};
 
 	u32				mLoopState;
@@ -162,6 +166,8 @@ public:
 	void			RegisterLuaFuncs			( MOAILuaState& state );
 	void			ResumeMOAI					();
 	void			SendFinalizeEvent			();
+	void			SendPauseEvent				();
+	void			SendResumeEvent				();
 	void			SetStep						( double step );
 	void			Update						();
 };


### PR DESCRIPTION
Added EVENT_PAUSE, EVENT_RESUME event to MOAISim according to issue https://github.com/moai/moai-dev/issues/599
These events are extremely important for any online game due to valid connection opening and closing.

Now MOAI pause (resume) event can be caught using snippets:
`MOAISim.setListener(MOAISim.EVENT_PAUSE, function() print('pause') end)`
