### PR TITLE
Fixed MOAIEnvironment.screenDpi nil issue for Android

### DIFF
--- a/ant/host-source/source/project/src/app/MoaiView.java
+++ b/ant/host-source/source/project/src/app/MoaiView.java
@@ -14,6 +14,7 @@ import android.opengl.GLSurfaceView;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.MotionEvent;
+import android.util.DisplayMetrics;
 
 // Moai
 import com.ziplinegames.moai.*;
@@ -48,7 +49,9 @@ public class MoaiView extends GLSurfaceView {
 		
 		setScreenDimensions ( width, height );
 		Moai.setScreenSize ( mWidth, mHeight );
-		
+		DisplayMetrics metrics = getResources().getDisplayMetrics();
+		Moai.setScreenDpi(metrics.densityDpi);
+
 		if ( glesVersion >= 0x20000 ) {
 			
 			// NOTE: Must be set before the renderer is set.

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -172,6 +172,7 @@ public class Moai {
 	protected static native void 	AKUSetInputDeviceLocation 		( int deviceId, int sensorId, String name );
 	protected static native void	AKUSetInputDeviceTouch 			( int deviceId, int sensorId, String name );
 	protected static native void 	AKUSetScreenSize				( int width, int height );
+	protected static native void    AKUSetScreenDpi                         ( int dpi );
 	protected static native void 	AKUSetViewSize					( int width, int height );
 	protected static native void 	AKUSetWorkingDirectory 			( String path );
 	protected static native void 	AKUUntzInit			 			();
@@ -479,6 +480,14 @@ public class Moai {
 		
 		synchronized ( sAkuLock ) {
 			AKUSetScreenSize ( width, height );
+		}
+	}	
+
+	//----------------------------------------------------------------//
+	public static void setScreenDpi ( int dpi ) {
+		
+		synchronized ( sAkuLock ) {
+			AKUSetScreenDpi ( dpi );
 		}
 	}	
 


### PR DESCRIPTION
Currently default Android host doesn't set MOAIEnvironment.screenDpi parameter which is mentioned in MOAI 1.3 documentation.
That fix sets screenDpi parameter in MoaiView constructor in default Android host-source, density expressed as dots-per-inch.
