### PR TITLE
Fixed MOAIEnvironment.screenDpi nil issue for iOS host

### DIFF
--- a/xcode/ios/Classes/MoaiView.mm
+++ b/xcode/ios/Classes/MoaiView.mm
@@ -200,6 +200,7 @@ namespace MoaiInputDeviceSensorID {
 		CGFloat screenHeight = screenRect.size.height * scale;
 		
 		AKUSetScreenSize ( screenWidth, screenHeight );
+		AKUSetScreenDpi([ self guessScreenDpi ]);
 		AKUSetViewSize ( mWidth, mHeight );
 		
 		AKUSetDefaultFrameBuffer ( mFramebuffer );
@@ -225,6 +226,22 @@ namespace MoaiInputDeviceSensorID {
 	}
 	
 	//----------------------------------------------------------------//
+	-( int ) guessScreenDpi {
+		float dpi;
+		float scale = 1;
+		if ([[ UIScreen mainScreen ] respondsToSelector:@selector(scale) ]) {
+			scale = [[ UIScreen mainScreen ] scale];
+		}
+		if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+			//Not working for iPad Mini, but appropriate solution doesn't exist yet
+			dpi = 132 * scale;
+		}else{
+			dpi = 163 * scale;
+		}
+		return dpi;
+	}
+
+    //----------------------------------------------------------------//
 	-( void ) onUpdateAnim {
 		
 		[ self openContext ];


### PR DESCRIPTION
That fix sets MOAIEnvironment.screenDpi parameter in MoaiView maoiInit method for iOS host.
That solution is not ideal - there are two hardcoded dpi values (for iPhone and iPad) and the resulting dpi is being calculated using interface idiom macros and current scale factor (retina/non retina display).
Also it will report lower than real dpi value for iPad Mini, but it seems to be no appropriate workaround yet .
