### PR TITLE
Fixed MOAIEnvironment.verticalResolution (and .horizontalResolution) overriding

### DIFF
--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -124,8 +124,6 @@ void AKUIphoneInit ( UIApplication* application ) {
 	environment.SetValue ( MOAI_ENV_osVersion,			[[ UIDevice currentDevice ].systemVersion UTF8String ]);
 	environment.SetValue ( MOAI_ENV_resourceDirectory,	[[[ NSBundle mainBundle ] resourcePath ] UTF8String ]);
 	environment.SetValue ( MOAI_ENV_openUdid,			[[ MOAIOpenUDID value] UTF8String ]);
-	environment.SetValue ( MOAI_ENV_horizontalResolution, [[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ] );
-	environment.SetValue ( MOAI_ENV_verticalResolution, [[ UIScreen mainScreen ] bounds ].size.height * [[ UIScreen mainScreen ] scale ] );
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
moaiInit already sets verticalResolution and horizontalResolution params by implicit AKUSetScreenSize call.
But additional call in AKUIphoneInit `environment.SetValue ( MOAI_ENV_horizontalResolution, [[ UIScreen mainScreen ] bounds ].size.width * [[ UIScreen mainScreen ] scale ] );` will override them.
It is wrong behavior since it will hide custom setup, for example - for landscape screen orientation.
