### PR TITLE
Fixed a problem when you move the Layer.

### DIFF
--- a/src/moaicore/MOAILayer.cpp
+++ b/src/moaicore/MOAILayer.cpp
@@ -483,11 +483,11 @@ void MOAILayer::Draw ( int subPrimID ) {
 	USRect viewportRect = viewport;
 
 	// TODO:
-	//USMatrix4x4 mtx;
-	//mtx.Init ( this->mLocalToWorldMtx );
-	//// TODO:
-	////mtx.Append ( gfxDevice.GetWorldToWndMtx ( 1.0f, 1.0f ));
-	//mtx.Transform ( viewportRect );
+	USMatrix4x4 mtx;
+	mtx.Init ( this->mLocalToWorldMtx );
+	// TODO:
+	//mtx.Append ( gfxDevice.GetWorldToWndMtx ( 1.0f, 1.0f ));
+	mtx.Transform ( viewportRect );
 
 	gfxDevice.SetViewRect ( viewportRect );
 	gfxDevice.SetScissorRect ( viewportRect );


### PR DESCRIPTION
In V1.3, when you move the Layer, was also moved Viewport.
In V1.4, you can move the Layer, Viewport does not move.
I have modified to the same behavior as before.
