### PR TITLE
Fix Key Frame Search for Animation Curves

### DIFF
--- a/src/uslscore/USBinarySearch.h
+++ b/src/uslscore/USBinarySearch.h
@@ -57,22 +57,15 @@ u32 USBinarySearchNearest ( const TYPE* buffer, const TYPE& key, u32 total ) {
 	if ( key < buffer [ i ]) return NO_MATCH;
 	if ( buffer [ j ] < key ) return NO_MATCH;
 	
-	while ( s ) {
+	while ( s > 1 ) {
 		
 		u32 c = i + ( s >> 1 );
 		const TYPE& test = buffer [ c ];
 		
-		
 		if ( test < key ) {
-		
-			if ( i == c ) break;
-			
 			i = c;
 		}
 		else if ( key < test ) {
-			
-			if ( j == c ) break;
-			
 			j = c;
 		}
 		else {
@@ -81,11 +74,11 @@ u32 USBinarySearchNearest ( const TYPE* buffer, const TYPE& key, u32 total ) {
 		s = j - i;
 	}
 	
-	if ( key < buffer [ i ] ) {
-		return i - 1;
+	if ( key < buffer [ j ] ) {
+		return i;
 	}
 	else {
-		return i;
+		return j;
 	}
 }
 


### PR DESCRIPTION
The binary search used to determine the key frame id in an animation curve (USBinarySearchNearest) never returned the last key frame for curves with an even number of keys.

I replaced the break conditions with a stricter loop condition – this is merely a refactoring. The actual fix is to update the if condition in the end and return either the lower or the upper bound (i or j).

Unfortunately I only monkey-tested the code, even though it would lend itself perfectly to unit testing.
