### PR TITLE
Fix input lag with the iOS host

### DIFF
--- a/src/aku/AKU-iphone.h
+++ b/src/aku/AKU-iphone.h
@@ -34,5 +34,6 @@ void			AKUNotifyRemoteNotificationRegistrationComplete	( NSData* deviceToken );
 void			AKUSetConnectionType							( long type );
 void			AKUViewDidRotateFromInterfaceOrientation		( UIInterfaceOrientation orientation );
 void			AKUSetFrameBuffer								( GLuint frameBuffer );
+void			AKUProcessKeyboardEventQueue							();
 
 #endif

--- a/src/aku/AKU-iphone.mm
+++ b/src/aku/AKU-iphone.mm
@@ -173,3 +173,8 @@ void AKUSetConnectionType ( long type ) {
 void AKUSetFrameBuffer ( GLuint frameBuffer ) {
 	MOAIGfxDevice::Get ().GetDefaultBuffer ()->SetGLFrameBufferID (frameBuffer);
 }
+
+//-----------------------------------------------------------------//
+void AKUProcessKeyboardEventQueue () {
+	MOAIKeyboardIOS::Get ().ProcessEventQueue();
+}

--- a/src/moaiext-iphone/MOAIKeyboardIOS.h
+++ b/src/moaiext-iphone/MOAIKeyboardIOS.h
@@ -107,6 +107,14 @@ private:
 		RETURN_KEY_SEND			= UIReturnKeySend,
 	};
 
+	struct EventQueueItem {
+		u32 eventID;
+		NSRange range;
+		STLString string;
+	};
+
+	STLList < EventQueueItem > mEventQueue;
+
 	UITextField*	mTextField;
 
 	//----------------------------------------------------------------//
@@ -115,6 +123,10 @@ private:
 
 	//----------------------------------------------------------------//
 	void			ShowKeyboard			( cc8* text, int type, int returnKey, bool secure, int autocap, int appearance );
+
+	//----------------------------------------------------------------//
+	void			HandleInputEvent		( const EventQueueItem& item );
+	void			HandleEnterEvent		( const EventQueueItem& item );
 
 public:
 	
@@ -131,6 +143,8 @@ public:
 					~MOAIKeyboardIOS		();
 	void			PushText				( MOAILuaState& state );
 	void			RegisterLuaClass		( MOAILuaState& state );
+	void			QueueEventItem			( u32 eventID, const NSRange& range, const STLString& string );
+	void			ProcessEventQueue		();
 	
 };
 

--- a/xcode/ios/Classes/MoaiView.h
+++ b/xcode/ios/Classes/MoaiView.h
@@ -25,6 +25,9 @@
 	NSTimeInterval					mAnimInterval;
     RefPtr < CADisplayLink >		mDisplayLink;
 	RefPtr < LocationObserver >		mLocationObserver;
+
+	dispatch_queue_t mOpenGLESContextQueue;
+	dispatch_semaphore_t mFrameRenderingSemaphore;
 }
 
 	//----------------------------------------------------------------//
@@ -36,5 +39,6 @@
 
     PROPERTY_READONLY ( GLint, width );
     PROPERTY_READONLY ( GLint, height );
+	PROPERTY_READONLY ( dispatch_queue_t, openGLESContextQueue );
 	
 @end

--- a/xcode/ios/Classes/MoaiView.mm
+++ b/xcode/ios/Classes/MoaiView.mm
@@ -246,6 +246,7 @@ namespace MoaiInputDeviceSensorID {
 		
 		[ self openContext ];
 		AKUSetContext ( mAku );
+		AKUProcessKeyboardEventQueue ();
 		AKUUpdate ();
 		#ifdef USE_FMOD_EX
 			AKUFmodExUpdate ();


### PR DESCRIPTION
iOS host has severe input lag if the frame rate dips below the target and accelerometer is enabled. This can result in a lag of seconds.

This pull request does a bit of an ambitious change, and puts the renderer on its own thread so that the input can get through unblocked. A semaphore blocks the update loop so it won't run if the renderer is drawing.

Another input source, that was previously blocked, is the MOAIKeyboardIOS which can send events to Lua regardless of the semaphore, and can result in a crash if the Lua code changes renderable stuff, such as text. The other commit in this pull request queues input from the keyboard, and pushes them to the listeners at the proper place to prevent crashes.

There probably are other places which might crash the renderer with out of sync changes; which makes this change a bit dangerous, but I still feel it is a necessary one as the input lag can be really severe.
