### PR TITLE
Fix 3D Picking for Rays That Have a Zero Component

### DIFF
--- a/samples/input/input-picking3D/main.lua
+++ b/samples/input/input-picking3D/main.lua
@@ -10,8 +10,9 @@ dofile ( "cube.lua" )
 
 MOAISim.openWindow ( "test", SCREEN_WIDTH, SCREEN_HEIGHT )
 
-MOAIGfxDevice.setClearDepth ( true )
-MOAIGfxDevice.setClearColor ( 0, 0, 0, 1 )
+frameBuffer = MOAIGfxDevice.getFrameBuffer ()
+frameBuffer:setClearDepth ( true )
+frameBuffer:setClearColor ( 0, 0, 0, 1 )
 
 layer = MOAILayer.new ()
 MOAISim.pushRenderPass ( layer )

--- a/src/uslscore/USIntersect.cpp
+++ b/src/uslscore/USIntersect.cpp
@@ -19,13 +19,7 @@ bool _clipRayToBoxAxis ( float min, float max, float pos, float dir, float& t0, 
 bool _clipRayToBoxAxis ( float min, float max, float pos, float dir, float& t0, float& t1 ) {
 	
 	if ( fabs ( dir ) < EPSILON ) {
-		
-		if ( dir > 0.0f ) {
-			return !( pos > max );
-		}
-		else {
-			return !( pos < min );
-		}
+		return pos >= min && pos <= max;
 	}
 	
 	float u0, u1;


### PR DESCRIPTION
When using `MOAIPartition:propListForRay()` with a ray along the Z axis (i.e. (0, 0, -1)), there were false positives in the result buffer.

Fixed by checking against both `min` and `max` when the direction component is (almost) zero.

I also updated the 3d picking sample to check if it still works correctly.
