### PR TITLE
Need to check for the proper error traceback when not in a coroutine.

### DIFF
--- a/src/moaicore/MOAILuaRuntime.cpp
+++ b/src/moaicore/MOAILuaRuntime.cpp
@@ -271,6 +271,11 @@ static int _traceback ( lua_State *L ) {
 		msg = lua_tostring ( L, 1 );
 	}
 	
+	AKUErrorTracebackFunc errorTraceback = AKUGetFunc_ErrorTraceback ();
+	if ( errorTraceback ) {
+		errorTraceback ( msg, L, 0 );
+	}
+	
 	if ( MOAILuaRuntime::Get ().GetCustomTraceback ()) {
 		
 		state.Push ( MOAILuaRuntime::Get ().GetCustomTraceback ());


### PR DESCRIPTION
When Moai crashes outside of a coroutine the custom AKU error function is not called. This fixes it by replicating the same functionality as in MOAICoroutine.
