### PR TITLE
Android Host Improvements

### DIFF
--- a/ant/host-source/d.run-host.sh
+++ b/ant/host-source/d.run-host.sh
@@ -209,6 +209,19 @@
 		popd > /dev/null
 	done
 
+    # Copy Assets
+    for (( i=0; i<${#assets_dirs[@]}; i++ )); do
+		asset_dir=${assets_dirs[$i]}
+		if [ x"$asset_dir" != x ] && [ x"$local_root" != x ] && [[ ! $asset_dir == /* ]]; then
+			source_dir=$local_root/$asset_dir
+		fi
+		pushd $asset_dir > /dev/null
+			find -L . -name ".?*" -type d -prune -o -name "*.sh" -prune -o -name "*.lua" -type f \
+            -prune -o  -name "*.bat" -type f -prune -o -type f -print0 | cpio -pmd0 --quiet $out_dir/project/assets/
+		popd > /dev/null
+	done
+
+
 	if [ "$debug" == "true" ]; then
 		install_cmd="ant debug install"
 	else

--- a/ant/host-source/d.run-host.sh
+++ b/ant/host-source/d.run-host.sh
@@ -205,7 +205,7 @@
 			source_dir=$local_root/$source_dir
 		fi
 		pushd $source_dir > /dev/null
-			find . -name ".?*" -type d -prune -o -name "*.sh" -type f -prune -o -name "*.bat" -type f -prune -o -type f -print0 | cpio -pmd0 --quiet $out_dir/project/assets/${dest_dirs[$i]}
+			find -L . -name ".?*" -type d -prune -o -name "*.sh" -type f -prune -o -name "*.bat" -type f -prune -o -type f -print0 | cpio -pmd0 --quiet $out_dir/project/assets/${dest_dirs[$i]}
 		popd > /dev/null
 	done
 

--- a/ant/host-source/d.run-host.sh
+++ b/ant/host-source/d.run-host.sh
@@ -210,17 +210,13 @@
 	done
 
     # Copy Assets
-    for (( i=0; i<${#assets_dirs[@]}; i++ )); do
-		asset_dir=${assets_dirs[$i]}
+    for (( i=0; i<${#asset_dirs[@]}; i++ )); do
+		asset_dir=${asset_dirs[$i]}
 		if [ x"$asset_dir" != x ] && [ x"$local_root" != x ] && [[ ! $asset_dir == /* ]]; then
-			source_dir=$local_root/$asset_dir
+			asset_dir=$local_root/$asset_dir
 		fi
-		pushd $asset_dir > /dev/null
-			find -L . -name ".?*" -type d -prune -o -name "*.sh" -prune -o -name "*.lua" -type f \
-            -prune -o  -name "*.bat" -type f -prune -o -type f -print0 | cpio -pmd0 --quiet $out_dir/project/assets/
-		popd > /dev/null
+        cp -R $asset_dir $out_dir/project/assets/
 	done
-
 
 	if [ "$debug" == "true" ]; then
 		install_cmd="ant debug install"

--- a/ant/host-source/d.settings-local.sh
+++ b/ant/host-source/d.settings-local.sh
@@ -27,7 +27,7 @@
 # application bundle in the assets directory 
 #----------------------------------------------------------------#
 
-	asset_dirs=( "" )
+	asset_dirs=( )
 
 #----------------------------------------------------------------#
 # debug & release settings

--- a/ant/host-source/d.settings-local.sh
+++ b/ant/host-source/d.settings-local.sh
@@ -23,6 +23,13 @@
 	dest_dirs=(	"lua" )
 
 #----------------------------------------------------------------#
+# space-delimited list of asset directories to add to the 
+# application bundle in the assets directory 
+#----------------------------------------------------------------#
+
+	asset_dirs=( "" )
+
+#----------------------------------------------------------------#
 # debug & release settings
 # you must define key store data in order to build for release
 #----------------------------------------------------------------#

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -631,6 +631,18 @@ public class Moai {
 		sActivity.startActivity ( new Intent ( Intent.ACTION_VIEW, Uri.parse ( url )));
 	}
 		
+    //----------------------------------------------------------------//
+	public static void sendMail ( String recipient, String subject, String message ) {
+
+		Intent intent = new Intent ( Intent.ACTION_SEND ).setType ( "message/rfc822" );
+		
+		if ( recipient != null ) intent.putExtra ( Intent.EXTRA_EMAIL, new String[] {recipient} );
+		if ( subject != null ) intent.putExtra ( Intent.EXTRA_SUBJECT, subject );
+		if ( message != null ) intent.putExtra ( Intent.EXTRA_TEXT, message );
+	
+		sActivity.startActivity ( Intent.createChooser ( intent, "Send E-mail" ));
+	}
+
 	//----------------------------------------------------------------//
 	public static void share ( String prompt, String subject, String text ) {
 

--- a/src/moaiext-android/MOAIAppAndroid.cpp
+++ b/src/moaiext-android/MOAIAppAndroid.cpp
@@ -114,7 +114,48 @@ int MOAIAppAndroid::_openURL ( lua_State* L ) {
 			env->CallStaticVoidMethod ( moai, openURL, jurl );	
 		}
 	}
-	
+
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/**	@name	sendMail
+    @text Send a mail with the passed in default values
+
+    @in	string recipient
+    @in	string subject
+    @in	string message
+    @out	nil
+*/
+int	MOAIAppAndroid::_sendMail ( lua_State* L ) {
+    MOAILuaState state ( L );
+
+	cc8* recipient = state.GetValue < cc8* >( 1, "" );
+	cc8* subject = state.GetValue < cc8* >( 2, "" );
+	cc8* message = state.GetValue < cc8* >( 3, "" );
+
+    JNI_GET_ENV ( jvm, env );
+
+	JNI_GET_JSTRING ( recipient, jrecipient );
+	JNI_GET_JSTRING ( subject, jsubject );
+	JNI_GET_JSTRING ( message, jmessage );
+
+    jclass moai = env->FindClass ( "com/ziplinegames/moai/Moai" );
+    if ( moai == NULL ) {
+
+		USLog::Print ( "MOAIAppAndroid: Unable to find java class %s", "com/ziplinegames/moai/Moai" );
+    } else {
+
+    	jmethodID sendMail = env->GetStaticMethodID ( moai, "sendMail", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V" );
+    	if ( sendMail == NULL ) {
+
+			USLog::Print ( "MOAIAppAndroid: Unable to find static java method %s", "sendMail" );
+    	} else {
+
+			env->CallStaticVoidMethod ( moai, sendMail, jrecipient, jsubject, jmessage );
+		}
+	}
+
 	return 0;
 }
 
@@ -202,6 +243,7 @@ void MOAIAppAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "getUTCTime",				_getUTCTime },
 		{ "getStatusBarHeight",		_getStatusBarHeight },
 		{ "openURL",				_openURL },
+		{ "sendMail",				_sendMail },
 		{ "setListener",			_setListener },
 		{ "share",					_share },
 		{ NULL, NULL }

--- a/src/moaiext-android/MOAIAppAndroid.h
+++ b/src/moaiext-android/MOAIAppAndroid.h
@@ -34,6 +34,7 @@ private:
 	static int	_getUTCTime			( lua_State* L );
 	static int 	_getStatusBarHeight ( lua_State* L );
 	static int	_openURL			( lua_State* L );
+	static int	_sendMail			( lua_State* L );
 	static int	_setListener		( lua_State* L );
 	static int	_share				( lua_State* L );
 


### PR DESCRIPTION
Copy symlinked files during android run-host build.  Adding -L option
to the find command that copies sources to the assets directory so that
symlinked sources are included.

Adding configurable assets in the run-host build.

Adding sendMail functionality to Android that mirrors the functionality provided by iOS host.

My apologies for the multiple features in a single pull request.
