### PR TITLE
Fix IOS sendMail argument and allocation/crash

### DIFF
--- a/src/moaiext-iphone/MOAIAppIOS.mm
+++ b/src/moaiext-iphone/MOAIAppIOS.mm
@@ -147,13 +147,13 @@ int MOAIAppIOS::_sendMail ( lua_State* L ) {
 	MOAILuaState state ( L );
 	
 	cc8* recipient = state.GetValue < cc8* >( 1, "" );
-	cc8* subject = state.GetValue < cc8* >( 1, "" );
-	cc8* message = state.GetValue < cc8* >( 1, "" );
+	cc8* subject = state.GetValue < cc8* >( 2, "" );
+	cc8* message = state.GetValue < cc8* >( 3, "" );
 	
 	MFMailComposeViewController* controller = [[ MFMailComposeViewController alloc ] init ];
 	controller.mailComposeDelegate = MOAIAppIOS::Get ().mMailDelegate;
 	
-	NSArray* to = [[ NSArray alloc ] arrayByAddingObject:[[ NSString alloc ] initWithUTF8String:recipient ]];
+	NSArray* to = [ NSArray arrayWithObject:[[ NSString alloc ] initWithUTF8String:recipient ]];
 	
 	[ controller setToRecipients:to ];
 	[ controller setSubject:[[ NSString alloc ] initWithUTF8String:subject ]];

--- a/src/moaiext-iphone/MOAIAppIOS.mm
+++ b/src/moaiext-iphone/MOAIAppIOS.mm
@@ -153,11 +153,11 @@ int MOAIAppIOS::_sendMail ( lua_State* L ) {
 	MFMailComposeViewController* controller = [[ MFMailComposeViewController alloc ] init ];
 	controller.mailComposeDelegate = MOAIAppIOS::Get ().mMailDelegate;
 	
-	NSArray* to = [ NSArray arrayWithObject:[[ NSString alloc ] initWithUTF8String:recipient ]];
+	NSArray* to = [ NSArray arrayWithObject:[ NSString  stringWithUTF8String:recipient ]];
 	
 	[ controller setToRecipients:to ];
-	[ controller setSubject:[[ NSString alloc ] initWithUTF8String:subject ]];
-	[ controller setMessageBody:[[ NSString alloc ] initWithUTF8String:message ] isHTML:NO ]; 
+	[ controller setSubject:[ NSString stringWithUTF8String:subject ]];
+	[ controller setMessageBody:[ NSString stringWithUTF8String:message ] isHTML:NO ]; 
 	
 	if (controller) {
 				


### PR DESCRIPTION
The ios sendMail function was using the first Lua argument for
recipient, message and subject.  Updated this to use the correct
arguments.

Also in sendMail, a crash was occuring for me.  This seemed to be due
to an array being alloc'ed but constructed with an autorelease method.
I removed the alloc and just created the array using the autorelease
method and this fixed the crash.
