### PR TITLE
Fix for error messages when setting bounds to nil

### DIFF
--- a/src/moaicore/MOAIProp.cpp
+++ b/src/moaicore/MOAIProp.cpp
@@ -284,7 +284,7 @@ int MOAIProp::_setBlendMode ( lua_State* L ) {
 int MOAIProp::_setBounds ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIProp, "U" )
 
-	if ( state.CheckParams ( 2, "NNNNNN" )) {
+	if ( state.CheckParams ( 2, "NNNNNN", false )) {
 
 		self->mBoundsOverride = state.GetBox ( 2 );
 		self->mFlags |= FLAGS_OVERRIDE_BOUNDS;


### PR DESCRIPTION
According to the docs, settings bounds to nil is supported: http://getmoai.com/docs/class_m_o_a_i_prop.html#ac4e79263e7888512d117368142a499d7

This works fine, however it gives a stack trace as if an error has just occurred. This patch removes that stack trace printout.
