### PR TITLE
Fixing iOS build after reorganization

### DIFF
--- a/src/host-glut/GlutHost.cpp
+++ b/src/host-glut/GlutHost.cpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <moai_config.h>
+#include <lua.h>
 #include <lua-headers/moai_lua.h>
 #include <host-glut/GlutHost.h>
 #include <string.h>

--- a/xcode/ios/Classes/MoaiAppDelegate.mm
+++ b/xcode/ios/Classes/MoaiAppDelegate.mm
@@ -4,8 +4,8 @@
 // http://getmoai.com
 //----------------------------------------------------------------//
 
-#import <moaicore/AKU.h>
-#import <moaiext-iphone/AKU-iphone.h>
+#import <moai-core/host.h>
+#import <moai-iphone/AKU-iphone.h>
 
 #import "MoaiAppDelegate.h"
 #import "LocationObserver.h"

--- a/xcode/ios/Classes/MoaiVC.mm
+++ b/xcode/ios/Classes/MoaiVC.mm
@@ -4,7 +4,8 @@
 // http://getmoai.com
 //----------------------------------------------------------------//
 
-#import <moaicore/AKU.h>
+#import <moai-core/headers.h>
+#import <moai-sim/host.h>
 #import "MoaiVC.h"
 #import "MoaiView.h"
 

--- a/xcode/ios/Classes/MoaiView.h
+++ b/xcode/ios/Classes/MoaiView.h
@@ -8,7 +8,7 @@
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
-#import <moaicore/AKU.h>
+#import <moai-core/host.h>
 
 #import "OpenGLView.h"
 #import "RefPtr.h"

--- a/xcode/ios/Classes/MoaiView.mm
+++ b/xcode/ios/Classes/MoaiView.mm
@@ -13,13 +13,15 @@
 //	#include <lualib.h>
 //}
 
-#import <moaiext-iphone/AKU-iphone.h>
-#import <moaiext-luaext/AKU-luaext.h>
-#import <moaiext-audiosampler/AKU-audiosampler.h>
+#import <moai-iphone/AKU-iphone.h>
+#import <moai-luaext/host.h>
+#import <moai-sim/host.h>
+#import <moai-audiosampler/MOAIAudioSampler.h>
+#import <moai-audiosampler/AKU-audiosampler.h>
 #import <lua-headers/moai_lua.h>
 
 #ifdef USE_UNTZ
-#import <moaiext-untz/AKU-untz.h>
+#import <moai-untz/host.h>
 #endif
 
 #ifdef USE_FMOD_EX
@@ -174,7 +176,7 @@ namespace MoaiInputDeviceSensorID {
 		AKUExtLoadLuasocket ();
 		
 		#ifdef USE_UNTZ
-			AKUUntzInit ();
+			AKUInitializeUntz();
 		#endif
         
 		#ifdef USE_FMOD_EX

--- a/xcode/ios/Classes/OpenGLView.mm
+++ b/xcode/ios/Classes/OpenGLView.mm
@@ -6,7 +6,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGLES/EAGLDrawable.h>
-#import <moaicore/AKU.h>
+#import <moai-core/host.h>
 
 #import "OpenGLView.h"
 

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -50,6 +50,13 @@
 		665383F3160A798F003D5529 /* FacebookSDKResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 665383F2160A798F003D5529 /* FacebookSDKResources.bundle */; };
 		665383F5160A7B65003D5529 /* libfacebook_ios_sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */; };
 		665383F7160A8466003D5529 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 665383F6160A8466003D5529 /* MessageUI.framework */; };
+		89ADB9E1174302E900E8058B /* libmoai-ios-sim.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8919565A1742C47A00A6BC5B /* libmoai-ios-sim.a */; };
+		89ADB9E21743034600E8058B /* libmoai-ios-box2d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8919564C1742C47A00A6BC5B /* libmoai-ios-box2d.a */; };
+		89ADB9E71743039C00E8058B /* libmoai-ios-chipmunk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8919564E1742C47A00A6BC5B /* libmoai-ios-chipmunk.a */; };
+		89ADB9E8174303A000E8058B /* libmoai-ios-crittercism.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 891956501742C47A00A6BC5B /* libmoai-ios-crittercism.a */; };
+		89ADB9EF174303D200E8058B /* libmoai-ios-http-client.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 891956541742C47A00A6BC5B /* libmoai-ios-http-client.a */; };
+		89ADB9F01743042A00E8058B /* liblibmoai-ios-facebook copy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8919565C1742C47A00A6BC5B /* liblibmoai-ios-facebook copy.a */; };
+		89ADB9F2174304B200E8058B /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89ADB9F1174304B200E8058B /* ParticlePresets.cpp */; };
 		CD464CE0147259EA00501E4E /* libmoai-ios-zlcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */; };
 		CD508A1A155E3AF90002FC3B /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC904F13B3C1B700B2724C /* Icon-72.png */; };
 		CD508A1B155E3AF90002FC3B /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905013B3C1B700B2724C /* Icon-Small-50.png */; };
@@ -399,6 +406,48 @@
 			remoteGlobalIDString = 89BE6F18173AD07100DFE837;
 			remoteInfo = "libmoai-osx-sim";
 		};
+		89ADB9DF174302E400E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE6EF5173AD06700DFE837;
+			remoteInfo = "libmoai-ios-sim";
+		};
+		89ADB9E31743034900E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE737C173AD2B600DFE837;
+			remoteInfo = "libmoai-ios-box2d";
+		};
+		89ADB9E51743039600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE7519173C116400DFE837;
+			remoteInfo = "libmoai-ios-chipmunk";
+		};
+		89ADB9E9174303A300E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE76C4173C6C8800DFE837;
+			remoteInfo = "libmoai-ios-crittercism";
+		};
+		89ADB9EB174303AC00E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE76E0173C6DB500DFE837;
+			remoteInfo = "libmoai-ios-twitter";
+		};
+		89ADB9ED174303CE00E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 89BE75DB173C126100DFE837;
+			remoteInfo = "libmoai-ios-http-client";
+		};
 		CD04AF1114725736009C20E5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
@@ -614,6 +663,7 @@
 		665383F2160A798F003D5529 /* FacebookSDKResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = FacebookSDKResources.bundle; path = "../../3rdparty/facebookiOS-3.0.6.b/FacebookSDKResources.bundle"; sourceTree = "<group>"; };
 		665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfacebook_ios_sdk.a; path = "../../3rdparty/facebookiOS-3.0.6.b/libfacebook_ios_sdk.a"; sourceTree = "<group>"; };
 		665383F6160A8466003D5529 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
+		89ADB9F1174304B200E8058B /* ParticlePresets.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParticlePresets.cpp; path = "../../src/host-glut/ParticlePresets.cpp"; sourceTree = "<group>"; };
 		CD508AA2155E3AF90002FC3B /* moai-fmod-ex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "moai-fmod-ex.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDDD307E1574AC7300C410A0 /* moai-fmod-designer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "moai-fmod-designer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E92D47E5153CA75B00CB1E8A /* close_button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = close_button.png; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCCore/Views/close_button.png"; sourceTree = "<group>"; };
@@ -642,6 +692,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89ADB9F01743042A00E8058B /* liblibmoai-ios-facebook copy.a in Frameworks */,
+				89ADB9EF174303D200E8058B /* libmoai-ios-http-client.a in Frameworks */,
+				89ADB9E8174303A000E8058B /* libmoai-ios-crittercism.a in Frameworks */,
+				89ADB9E71743039C00E8058B /* libmoai-ios-chipmunk.a in Frameworks */,
+				89ADB9E21743034600E8058B /* libmoai-ios-box2d.a in Frameworks */,
+				89ADB9E1174302E900E8058B /* libmoai-ios-sim.a in Frameworks */,
 				665383F5160A7B65003D5529 /* libfacebook_ios_sdk.a in Frameworks */,
 				665383F1160A76E2003D5529 /* libCrittercismCrashOnly_v3_3_3.a in Frameworks */,
 				07E9F73E13B50582006396F3 /* libmoai-ios.a in Frameworks */,
@@ -832,6 +888,7 @@
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
+				89ADB9F1174304B200E8058B /* ParticlePresets.cpp */,
 				32CA4F630368D1EE00C91783 /* MoaiSample_Prefix.pch */,
 				03CC90A813B3C37C00B2724C /* main.mm */,
 			);
@@ -934,6 +991,12 @@
 			buildRules = (
 			);
 			dependencies = (
+				89ADB9EE174303CE00E8058B /* PBXTargetDependency */,
+				89ADB9EC174303AC00E8058B /* PBXTargetDependency */,
+				89ADB9EA174303A300E8058B /* PBXTargetDependency */,
+				89ADB9E61743039600E8058B /* PBXTargetDependency */,
+				89ADB9E41743034900E8058B /* PBXTargetDependency */,
+				89ADB9E0174302E400E8058B /* PBXTargetDependency */,
 				07E9F73713B50574006396F3 /* PBXTargetDependency */,
 				07E9F73913B50574006396F3 /* PBXTargetDependency */,
 				6630C510151005AB00F2F031 /* PBXTargetDependency */,
@@ -1435,6 +1498,7 @@
 				03CC90A713B3C37200B2724C /* OpenGLView.mm in Sources */,
 				03CC90A913B3C37C00B2724C /* main.mm in Sources */,
 				078D630113BA9EA30072F273 /* MoaiVC.mm in Sources */,
+				89ADB9F2174304B200E8058B /* ParticlePresets.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1491,6 +1555,36 @@
 			isa = PBXTargetDependency;
 			name = "libmoai-ios-facebook";
 			targetProxy = 6630C50F151005AB00F2F031 /* PBXContainerItemProxy */;
+		};
+		89ADB9E0174302E400E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-sim";
+			targetProxy = 89ADB9DF174302E400E8058B /* PBXContainerItemProxy */;
+		};
+		89ADB9E41743034900E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-box2d";
+			targetProxy = 89ADB9E31743034900E8058B /* PBXContainerItemProxy */;
+		};
+		89ADB9E61743039600E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-chipmunk";
+			targetProxy = 89ADB9E51743039600E8058B /* PBXContainerItemProxy */;
+		};
+		89ADB9EA174303A300E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-crittercism";
+			targetProxy = 89ADB9E9174303A300E8058B /* PBXContainerItemProxy */;
+		};
+		89ADB9EC174303AC00E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-twitter";
+			targetProxy = 89ADB9EB174303AC00E8058B /* PBXContainerItemProxy */;
+		};
+		89ADB9EE174303CE00E8058B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libmoai-ios-http-client";
+			targetProxy = 89ADB9ED174303CE00E8058B /* PBXContainerItemProxy */;
 		};
 		CD508A08155E3AF90002FC3B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/ios/MoaiSample.xcodeproj/project.pbxproj
@@ -84,7 +84,6 @@
 		CD508A83155E3AF90002FC3B /* OpenGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A213B3C37200B2724C /* OpenGLView.mm */; };
 		CD508A84155E3AF90002FC3B /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A813B3C37C00B2724C /* main.mm */; };
 		CD508A85155E3AF90002FC3B /* MoaiVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 078D630013BA9EA30072F273 /* MoaiVC.mm */; };
-		CD508A86155E3AF90002FC3B /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
 		CD508A8A155E3AF90002FC3B /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BD13B3C39D00B2724C /* libmoai-ios.a */; };
 		CD508A8B155E3AF90002FC3B /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */; };
 		CD508A8C155E3AF90002FC3B /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6676D5D115100458004EA27A /* libmoai-ios-facebook.a */; };
@@ -105,7 +104,6 @@
 		CD508A9C155E3AF90002FC3B /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07E6C6A0140C5EBD004D1227 /* GameKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		CD508A9D155E3AF90002FC3B /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 079530CD1447A0FF00143A72 /* MediaPlayer.framework */; };
 		CD508A9E155E3AF90002FC3B /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07EF3E43147BAAA5006CFDCE /* Twitter.framework */; };
-		CD7C73AE13B95516006CFA19 /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
 		CDB9F12414593A66007DE94C /* libmoai-ios-tapjoy.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */; };
 		CDDD2FF61574AC7300C410A0 /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC904F13B3C1B700B2724C /* Icon-72.png */; };
 		CDDD2FF71574AC7300C410A0 /* Icon-Small-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 03CC905013B3C1B700B2724C /* Icon-Small-50.png */; };
@@ -140,7 +138,6 @@
 		CDDD305F1574AC7300C410A0 /* OpenGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A213B3C37200B2724C /* OpenGLView.mm */; };
 		CDDD30601574AC7300C410A0 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03CC90A813B3C37C00B2724C /* main.mm */; };
 		CDDD30611574AC7300C410A0 /* MoaiVC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 078D630013BA9EA30072F273 /* MoaiVC.mm */; };
-		CDDD30621574AC7300C410A0 /* ParticlePresets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */; };
 		CDDD30661574AC7300C410A0 /* libmoai-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BD13B3C39D00B2724C /* libmoai-ios.a */; };
 		CDDD30671574AC7300C410A0 /* libmoai-ios-3rdparty.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */; };
 		CDDD30681574AC7300C410A0 /* libmoai-ios-facebook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6676D5D115100458004EA27A /* libmoai-ios-facebook.a */; };
@@ -296,6 +293,111 @@
 			proxyType = 2;
 			remoteGlobalIDString = 07F4C7B014FC440500FB78BA;
 			remoteInfo = "libmoai-ios-facebook";
+		};
+		8919564B1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE74A1173AD2B600DFE837;
+			remoteInfo = "libmoai-ios-box2d";
+		};
+		8919564D1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7547173C116400DFE837;
+			remoteInfo = "libmoai-ios-chipmunk";
+		};
+		8919564F1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE76D3173C6C8800DFE837;
+			remoteInfo = "libmoai-ios-crittercism";
+		};
+		891956511742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7647173C138100DFE837;
+			remoteInfo = "libmoai-ios-harness";
+		};
+		891956531742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE75F7173C126100DFE837;
+			remoteInfo = "libmoai-ios-http-client";
+		};
+		891956551742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7686173C15F100DFE837;
+			remoteInfo = "libmoai-ios-http-server";
+		};
+		891956571742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 07175BD41656E03400F3DF6B;
+			remoteInfo = "libmoai-ios-mat";
+		};
+		891956591742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE6F06173AD06700DFE837;
+			remoteInfo = "libmoai-ios-sim";
+		};
+		8919565B1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE771A173C6DB500DFE837;
+			remoteInfo = "libmoai-ios-twitter";
+		};
+		8919565D1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE737B173AD29200DFE837;
+			remoteInfo = "libmoai-osx-box2d";
+		};
+		8919565F1742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7576173C119600DFE837;
+			remoteInfo = "libmoai-osx-chipmunk";
+		};
+		891956611742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7660173C13EB00DFE837;
+			remoteInfo = "libmoai-osx-harness";
+		};
+		891956631742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE75DA173C121800DFE837;
+			remoteInfo = "libmoai-osx-http-client";
+		};
+		891956651742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE769F173C160E00DFE837;
+			remoteInfo = "libmoai-osx-http-server";
+		};
+		891956671742C47A00A6BC5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03CC90AE13B3C39D00B2724C /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE6F18173AD07100DFE837;
+			remoteInfo = "libmoai-osx-sim";
 		};
 		CD04AF1114725736009C20E5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -513,8 +615,6 @@
 		665383F4160A7B65003D5529 /* libfacebook_ios_sdk.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfacebook_ios_sdk.a; path = "../../3rdparty/facebookiOS-3.0.6.b/libfacebook_ios_sdk.a"; sourceTree = "<group>"; };
 		665383F6160A8466003D5529 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		CD508AA2155E3AF90002FC3B /* moai-fmod-ex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "moai-fmod-ex.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParticlePresets.cpp; path = ../../src/hosts/ParticlePresets.cpp; sourceTree = SOURCE_ROOT; };
-		CD7C73AD13B95516006CFA19 /* ParticlePresets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ParticlePresets.h; path = ../../src/hosts/ParticlePresets.h; sourceTree = SOURCE_ROOT; };
 		CDDD307E1574AC7300C410A0 /* moai-fmod-designer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "moai-fmod-designer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E92D47E5153CA75B00CB1E8A /* close_button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = close_button.png; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCCore/Views/close_button.png"; sourceTree = "<group>"; };
 		E92D47E6153CA75B00CB1E8A /* TJCLoadingView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TJCLoadingView.xib; path = "../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect/Components/TJCCore/Views/TJCLoadingView.xib"; sourceTree = "<group>"; };
@@ -640,20 +740,35 @@
 				03CC90BD13B3C39D00B2724C /* libmoai-ios.a */,
 				03CC90BF13B3C39D00B2724C /* libmoai-ios-3rdparty.a */,
 				6676D5CF15100458004EA27A /* libmoai-ios-adcolony.a */,
+				8919564C1742C47A00A6BC5B /* libmoai-ios-box2d.a */,
 				E92D47E3153CA6FC00CB1E8A /* libmoai-ios-chartboost.a */,
+				8919564E1742C47A00A6BC5B /* libmoai-ios-chipmunk.a */,
+				891956501742C47A00A6BC5B /* libmoai-ios-crittercism.a */,
 				6676D5D115100458004EA27A /* libmoai-ios-facebook.a */,
-				CDDD30A91574AE2100C410A0 /* liblibmoai-ios-fmod-designer.a */,
+				CDDD30A91574AE2100C410A0 /* libmoai-ios-fmod-designer.a */,
 				CD508AA7155E3AF90002FC3B /* libmoai-ios-fmod-ex.a */,
+				891956521742C47A00A6BC5B /* libmoai-ios-harness.a */,
+				891956541742C47A00A6BC5B /* libmoai-ios-http-client.a */,
+				891956561742C47A00A6BC5B /* libmoai-ios-http-server.a */,
 				03CC90C113B3C39D00B2724C /* libmoai-ios-luaext.a */,
+				891956581742C47A00A6BC5B /* libmoai-ios-mat.a */,
+				8919565A1742C47A00A6BC5B /* libmoai-ios-sim.a */,
 				CDB9F123145937C1007DE94C /* libmoai-ios-tapjoy.a */,
+				8919565C1742C47A00A6BC5B /* liblibmoai-ios-facebook copy.a */,
 				03CC90C313B3C39D00B2724C /* libmoai-ios-untz.a */,
 				0730448E15AD00130046422F /* libmoai-ios-vungle.a */,
 				CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */,
 				03CC90C513B3C39D00B2724C /* libmoai-osx.a */,
 				03CC90C713B3C39D00B2724C /* libmoai-osx-3rdparty.a */,
-				CDDD30AB1574AE2100C410A0 /* liblibmoai-osx-fmod-designer.a */,
+				8919565E1742C47A00A6BC5B /* libmoai-osx-box2d.a */,
+				891956601742C47A00A6BC5B /* libmoai-osx-chipmunk.a */,
+				CDDD30AB1574AE2100C410A0 /* libmoai-osx-fmod-designer.a */,
 				CD8F4812155E4736001A579F /* libmoai-osx-fmod-ex.a */,
+				891956621742C47A00A6BC5B /* libmoai-osx-harness.a */,
+				891956641742C47A00A6BC5B /* libmoai-osx-http-client.a */,
+				891956661742C47A00A6BC5B /* libmoai-osx-http-server.a */,
 				03CC90C913B3C39D00B2724C /* libmoai-osx-luaext.a */,
+				891956681742C47A00A6BC5B /* libmoai-osx-sim.a */,
 				03CC90CB13B3C39D00B2724C /* libmoai-osx-untz.a */,
 				CD04AF1414725736009C20E5 /* libmoai-osx-zlcore.a */,
 			);
@@ -683,8 +798,6 @@
 				03CC90A013B3C37200B2724C /* MoaiView.mm */,
 				03CC90A113B3C37200B2724C /* OpenGLView.h */,
 				03CC90A213B3C37200B2724C /* OpenGLView.mm */,
-				CD7C73AC13B95516006CFA19 /* ParticlePresets.cpp */,
-				CD7C73AD13B95516006CFA19 /* ParticlePresets.h */,
 				03CC90A313B3C37200B2724C /* RefPtr.h */,
 			);
 			path = Classes;
@@ -997,6 +1110,111 @@
 			remoteRef = 6676D5D015100458004EA27A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		8919564C1742C47A00A6BC5B /* libmoai-ios-box2d.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-box2d.a";
+			remoteRef = 8919564B1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8919564E1742C47A00A6BC5B /* libmoai-ios-chipmunk.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-chipmunk.a";
+			remoteRef = 8919564D1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956501742C47A00A6BC5B /* libmoai-ios-crittercism.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-crittercism.a";
+			remoteRef = 8919564F1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956521742C47A00A6BC5B /* libmoai-ios-harness.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-harness.a";
+			remoteRef = 891956511742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956541742C47A00A6BC5B /* libmoai-ios-http-client.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-http-client.a";
+			remoteRef = 891956531742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956561742C47A00A6BC5B /* libmoai-ios-http-server.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-http-server.a";
+			remoteRef = 891956551742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956581742C47A00A6BC5B /* libmoai-ios-mat.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-mat.a";
+			remoteRef = 891956571742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8919565A1742C47A00A6BC5B /* libmoai-ios-sim.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-sim.a";
+			remoteRef = 891956591742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8919565C1742C47A00A6BC5B /* liblibmoai-ios-facebook copy.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "liblibmoai-ios-facebook copy.a";
+			remoteRef = 8919565B1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8919565E1742C47A00A6BC5B /* libmoai-osx-box2d.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-box2d.a";
+			remoteRef = 8919565D1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956601742C47A00A6BC5B /* libmoai-osx-chipmunk.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-chipmunk.a";
+			remoteRef = 8919565F1742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956621742C47A00A6BC5B /* libmoai-osx-harness.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-harness.a";
+			remoteRef = 891956611742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956641742C47A00A6BC5B /* libmoai-osx-http-client.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-http-client.a";
+			remoteRef = 891956631742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956661742C47A00A6BC5B /* libmoai-osx-http-server.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-http-server.a";
+			remoteRef = 891956651742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		891956681742C47A00A6BC5B /* libmoai-osx-sim.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-sim.a";
+			remoteRef = 891956671742C47A00A6BC5B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		CD04AF1214725736009C20E5 /* libmoai-ios-zlcore.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1032,17 +1250,17 @@
 			remoteRef = CDB9F122145937C1007DE94C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CDDD30A91574AE2100C410A0 /* liblibmoai-ios-fmod-designer.a */ = {
+		CDDD30A91574AE2100C410A0 /* libmoai-ios-fmod-designer.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "liblibmoai-ios-fmod-designer.a";
+			path = "libmoai-ios-fmod-designer.a";
 			remoteRef = CDDD30A81574AE2100C410A0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CDDD30AB1574AE2100C410A0 /* liblibmoai-osx-fmod-designer.a */ = {
+		CDDD30AB1574AE2100C410A0 /* libmoai-osx-fmod-designer.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "liblibmoai-osx-fmod-designer.a";
+			path = "libmoai-osx-fmod-designer.a";
 			remoteRef = CDDD30AA1574AE2100C410A0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1217,7 +1435,6 @@
 				03CC90A713B3C37200B2724C /* OpenGLView.mm in Sources */,
 				03CC90A913B3C37C00B2724C /* main.mm in Sources */,
 				078D630113BA9EA30072F273 /* MoaiVC.mm in Sources */,
-				CD7C73AE13B95516006CFA19 /* ParticlePresets.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1231,7 +1448,6 @@
 				CD508A83155E3AF90002FC3B /* OpenGLView.mm in Sources */,
 				CD508A84155E3AF90002FC3B /* main.mm in Sources */,
 				CD508A85155E3AF90002FC3B /* MoaiVC.mm in Sources */,
-				CD508A86155E3AF90002FC3B /* ParticlePresets.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1245,7 +1461,6 @@
 				CDDD305F1574AC7300C410A0 /* OpenGLView.mm in Sources */,
 				CDDD30601574AC7300C410A0 /* main.mm in Sources */,
 				CDDD30611574AC7300C410A0 /* MoaiVC.mm in Sources */,
-				CDDD30621574AC7300C410A0 /* ParticlePresets.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1364,6 +1579,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = USE_UNTZ;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "";
 				PRODUCT_NAME = moai;
 			};
 			name = Debug;
@@ -1372,6 +1589,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = USE_UNTZ;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "";
 				PRODUCT_NAME = moai;
 			};
 			name = Release;
@@ -1383,7 +1602,46 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../src\"/**";
+				HEADER_SEARCH_PATHS = (
+					"\"../../src/hosts\"",
+					"\"../../src/config-default\"",
+					"\"../../src\"/**",
+					"\"../../3rdparty\"",
+					"\"../../3rdparty/lua-5.1.3/src\"",
+					"\"../../3rdparty/contrib\"",
+					"\"../../3rdparty/tinyxml\"",
+					"\"../../3rdparty/lpng140\"",
+					"\"../../3rdparty/c-ares-1.7.5\"",
+					"\"../../3rdparty/openssl-1.0.0d/include-iphone\"",
+					"\"../../3rdparty/curl-7.19.7/include-iphone\"",
+					"\"../../3rdparty/curl-7.19.7/lib\"",
+					"\"../../3rdparty/expat-2.0.1/lib\"",
+					"\"../../3rdparty/freetype-2.4.4/include\"",
+					"\"../../3rdparty/box2d-2.2.1\"",
+					"\"../../3rdparty/chipmunk-5.3.4/include\"",
+					"\"../../3rdparty/chipmunk-5.3.4/include/chipmunk\"",
+					"\"../../3rdparty/luacrypto-0.2.0/src\"",
+					"\"../../3rdparty/luacurl-1.2.1/src\"",
+					"\"../../3rdparty/luasocket-2.0.2/src\"",
+					"\"../../3rdparty/luasql-2.2.0/src\"",
+					"\"../../3rdparty/libogg-1.2.2/include\"",
+					"\"../../3rdparty/jansson-2.1/src\"",
+					"\"../../3rdparty/jpeg-8c\"",
+					"\"../../3rdparty/untz/include\"",
+					"\"../../3rdparty/untz/src\"",
+					"\"../../3rdparty/libvorbis-1.3.2/lib\"",
+					"\"../../3rdparty/libvorbis-1.3.2/include\"",
+					"\"../../3rdparty/tlsf-2.0\"",
+					"\"../../3rdparty/zlib-1.2.3\"",
+					"\"../../3rdparty/ooid-0.99\"",
+					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
+					"\"../../3rdparty/chartboostiOS-3.0.7\"",
+					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
+					"\"../../3rdparty/vungle116/lib\"",
+					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
+					"\"../../3rdparty/mongoose\"",
+				);
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				LIBRARY_SEARCH_PATHS = (
@@ -1413,7 +1671,46 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../src\"/**";
+				HEADER_SEARCH_PATHS = (
+					"\"../../src/hosts\"",
+					"\"../../src/config-default\"",
+					"\"../../src\"/**",
+					"\"../../3rdparty\"",
+					"\"../../3rdparty/lua-5.1.3/src\"",
+					"\"../../3rdparty/contrib\"",
+					"\"../../3rdparty/tinyxml\"",
+					"\"../../3rdparty/lpng140\"",
+					"\"../../3rdparty/c-ares-1.7.5\"",
+					"\"../../3rdparty/openssl-1.0.0d/include-iphone\"",
+					"\"../../3rdparty/curl-7.19.7/include-iphone\"",
+					"\"../../3rdparty/curl-7.19.7/lib\"",
+					"\"../../3rdparty/expat-2.0.1/lib\"",
+					"\"../../3rdparty/freetype-2.4.4/include\"",
+					"\"../../3rdparty/box2d-2.2.1\"",
+					"\"../../3rdparty/chipmunk-5.3.4/include\"",
+					"\"../../3rdparty/chipmunk-5.3.4/include/chipmunk\"",
+					"\"../../3rdparty/luacrypto-0.2.0/src\"",
+					"\"../../3rdparty/luacurl-1.2.1/src\"",
+					"\"../../3rdparty/luasocket-2.0.2/src\"",
+					"\"../../3rdparty/luasql-2.2.0/src\"",
+					"\"../../3rdparty/libogg-1.2.2/include\"",
+					"\"../../3rdparty/jansson-2.1/src\"",
+					"\"../../3rdparty/jpeg-8c\"",
+					"\"../../3rdparty/untz/include\"",
+					"\"../../3rdparty/untz/src\"",
+					"\"../../3rdparty/libvorbis-1.3.2/lib\"",
+					"\"../../3rdparty/libvorbis-1.3.2/include\"",
+					"\"../../3rdparty/tlsf-2.0\"",
+					"\"../../3rdparty/zlib-1.2.3\"",
+					"\"../../3rdparty/ooid-0.99\"",
+					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
+					"\"../../3rdparty/chartboostiOS-3.0.7\"",
+					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
+					"\"../../3rdparty/vungle116/lib\"",
+					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
+					"\"../../3rdparty/mongoose\"",
+				);
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				LIBRARY_SEARCH_PATHS = (

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -5314,7 +5314,7 @@
 		89BE76A6173C168400DFE837 /* pch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pch.cpp; sourceTree = "<group>"; };
 		89BE76A7173C168400DFE837 /* pch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pch.h; sourceTree = "<group>"; };
 		89BE76D3173C6C8800DFE837 /* libmoai-ios-crittercism.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libmoai-ios-crittercism.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-ios-facebook copy.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		89BE771A173C6DB500DFE837 /* libmoai-ios-twitter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libmoai-ios-twitter.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C359A148143A81BA005E7829 /* RAudioBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RAudioBuffer.h; path = ../../3rdparty/untz/src/RAudioBuffer.h; sourceTree = "<group>"; };
 		C37D421D13B1692F009600BB /* BufferedAudioSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BufferedAudioSource.cpp; path = ../../3rdparty/untz/src/BufferedAudioSource.cpp; sourceTree = "<group>"; };
 		C37D421E13B1692F009600BB /* BufferedAudioSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BufferedAudioSource.h; path = ../../3rdparty/untz/src/BufferedAudioSource.h; sourceTree = "<group>"; };
@@ -7253,7 +7253,7 @@
 				89BE7686173C15F100DFE837 /* libmoai-ios-http-server.a */,
 				89BE769F173C160E00DFE837 /* libmoai-osx-http-server.a */,
 				89BE76D3173C6C8800DFE837 /* libmoai-ios-crittercism.a */,
-				89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */,
+				89BE771A173C6DB500DFE837 /* libmoai-ios-twitter.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -12708,7 +12708,7 @@
 			);
 			name = "libmoai-ios-twitter";
 			productName = OpenUSLS;
-			productReference = 89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */;
+			productReference = 89BE771A173C6DB500DFE837 /* libmoai-ios-twitter.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CD04AABB14725568009C20E5 /* libmoai-ios-zlcore */ = {
@@ -18165,7 +18165,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				PRODUCT_NAME = "moai-ios-twitter";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
 				WARNING_CFLAGS = "-w";
@@ -18199,7 +18199,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				PRODUCT_NAME = "moai-ios-twitter";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
 				WARNING_CFLAGS = "-w";
@@ -18233,7 +18233,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				PRODUCT_NAME = "moai-ios-twitter";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
 				WARNING_CFLAGS = "-w";
@@ -18267,7 +18267,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				PRODUCT_NAME = "moai-ios-twitter";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
 				WARNING_CFLAGS = "-w";

--- a/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
+++ b/xcode/libmoai/libmoai.xcodeproj/project.pbxproj
@@ -1639,37 +1639,19 @@
 		89BE6B7517399FEB00DFE837 /* MOAIUntzSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B6617399FEB00DFE837 /* MOAIUntzSystem.cpp */; };
 		89BE6B7617399FEB00DFE837 /* MOAIUntzSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B6717399FEB00DFE837 /* MOAIUntzSystem.h */; };
 		89BE6B7717399FEB00DFE837 /* MOAIUntzSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B6717399FEB00DFE837 /* MOAIUntzSystem.h */; };
-		89BE6BDB1739A05600DFE837 /* AKU-adcolony.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B921739A05600DFE837 /* AKU-adcolony.h */; };
-		89BE6BDC1739A05600DFE837 /* AKU-adcolony.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B931739A05600DFE837 /* AKU-adcolony.mm */; };
-		89BE6BDD1739A05600DFE837 /* AKU-chartboost.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B941739A05600DFE837 /* AKU-chartboost.h */; };
-		89BE6BDE1739A05600DFE837 /* AKU-chartboost.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B951739A05600DFE837 /* AKU-chartboost.mm */; };
 		89BE6BDF1739A05600DFE837 /* AKU-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B961739A05600DFE837 /* AKU-iphone.h */; };
 		89BE6BE01739A05600DFE837 /* AKU-iphone.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B971739A05600DFE837 /* AKU-iphone.mm */; };
-		89BE6BE11739A05600DFE837 /* AKU-vungle.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B981739A05600DFE837 /* AKU-vungle.h */; };
-		89BE6BE21739A05600DFE837 /* AKU-vungle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B991739A05600DFE837 /* AKU-vungle.mm */; };
-		89BE6BE31739A05600DFE837 /* MOAIAdColonyIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B9A1739A05600DFE837 /* MOAIAdColonyIOS.h */; };
-		89BE6BE41739A05600DFE837 /* MOAIAdColonyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B9B1739A05600DFE837 /* MOAIAdColonyIOS.mm */; };
 		89BE6BE51739A05600DFE837 /* MOAIAppIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B9C1739A05600DFE837 /* MOAIAppIOS.h */; };
 		89BE6BE61739A05600DFE837 /* MOAIAppIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B9D1739A05600DFE837 /* MOAIAppIOS.mm */; };
 		89BE6BE71739A05600DFE837 /* MOAIBillingIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B9E1739A05600DFE837 /* MOAIBillingIOS.h */; };
 		89BE6BE81739A05600DFE837 /* MOAIBillingIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B9F1739A05600DFE837 /* MOAIBillingIOS.mm */; };
-		89BE6BE91739A05600DFE837 /* MOAIChartBoostIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA01739A05600DFE837 /* MOAIChartBoostIOS.h */; };
-		89BE6BEA1739A05600DFE837 /* MOAIChartBoostIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA11739A05600DFE837 /* MOAIChartBoostIOS.mm */; };
-		89BE6BEB1739A05600DFE837 /* MOAICrittercismIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA21739A05600DFE837 /* MOAICrittercismIOS.h */; };
-		89BE6BEC1739A05600DFE837 /* MOAICrittercismIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA31739A05600DFE837 /* MOAICrittercismIOS.mm */; };
 		89BE6BED1739A05600DFE837 /* MOAIDialogIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA41739A05600DFE837 /* MOAIDialogIOS.h */; };
 		89BE6BEE1739A05600DFE837 /* MOAIDialogIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA51739A05600DFE837 /* MOAIDialogIOS.mm */; };
 		89BE6BEF1739A05600DFE837 /* moaiext-iphone.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA61739A05600DFE837 /* moaiext-iphone.h */; };
-		89BE6BF01739A05600DFE837 /* MOAIFacebookIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA71739A05600DFE837 /* MOAIFacebookIOS.h */; };
-		89BE6BF11739A05600DFE837 /* MOAIFacebookIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA81739A05600DFE837 /* MOAIFacebookIOS.mm */; };
 		89BE6BF21739A05600DFE837 /* MOAIGameCenterIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA91739A05600DFE837 /* MOAIGameCenterIOS.h */; };
 		89BE6BF31739A05600DFE837 /* MOAIGameCenterIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BAA1739A05600DFE837 /* MOAIGameCenterIOS.mm */; };
-		89BE6BF41739A05600DFE837 /* MOAIHttpTaskNSURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BAB1739A05600DFE837 /* MOAIHttpTaskNSURL.h */; };
-		89BE6BF51739A05600DFE837 /* MOAIHttpTaskNSURL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BAC1739A05600DFE837 /* MOAIHttpTaskNSURL.mm */; };
 		89BE6BF61739A05600DFE837 /* MOAIKeyboardIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BAD1739A05600DFE837 /* MOAIKeyboardIOS.h */; };
 		89BE6BF71739A05600DFE837 /* MOAIKeyboardIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BAE1739A05600DFE837 /* MOAIKeyboardIOS.mm */; };
-		89BE6BF81739A05600DFE837 /* MOAIMobileAppTrackerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BAF1739A05600DFE837 /* MOAIMobileAppTrackerIOS.h */; };
-		89BE6BF91739A05600DFE837 /* MOAIMobileAppTrackerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BB01739A05600DFE837 /* MOAIMobileAppTrackerIOS.mm */; };
 		89BE6BFA1739A05600DFE837 /* MOAIMoviePlayerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BB11739A05600DFE837 /* MOAIMoviePlayerIOS.h */; };
 		89BE6BFB1739A05600DFE837 /* MOAIMoviePlayerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BB21739A05600DFE837 /* MOAIMoviePlayerIOS.mm */; };
 		89BE6BFC1739A05600DFE837 /* MOAINotificationsIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BB31739A05600DFE837 /* MOAINotificationsIOS.h */; };
@@ -1680,14 +1662,6 @@
 		89BE6C011739A05600DFE837 /* MOAIStoreKitListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BB81739A05600DFE837 /* MOAIStoreKitListener.mm */; };
 		89BE6C021739A05600DFE837 /* MOAITakeCameraListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BB91739A05600DFE837 /* MOAITakeCameraListener.h */; };
 		89BE6C031739A05600DFE837 /* MOAITakeCameraListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BBA1739A05600DFE837 /* MOAITakeCameraListener.mm */; };
-		89BE6C041739A05600DFE837 /* MOAITapjoyIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBB1739A05600DFE837 /* MOAITapjoyIOS.h */; };
-		89BE6C051739A05600DFE837 /* MOAITapjoyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BBC1739A05600DFE837 /* MOAITapjoyIOS.mm */; };
-		89BE6C061739A05600DFE837 /* MOAITwitterIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBD1739A05600DFE837 /* MOAITwitterIOS.h */; };
-		89BE6C071739A05600DFE837 /* MOAITwitterIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BBE1739A05600DFE837 /* MOAITwitterIOS.mm */; };
-		89BE6C081739A05600DFE837 /* MOAIUrlMgrNSURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBF1739A05600DFE837 /* MOAIUrlMgrNSURL.h */; };
-		89BE6C091739A05600DFE837 /* MOAIUrlMgrNSURL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BC01739A05600DFE837 /* MOAIUrlMgrNSURL.mm */; };
-		89BE6C0A1739A05600DFE837 /* MOAIVungleIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BC11739A05600DFE837 /* MOAIVungleIOS.h */; };
-		89BE6C0B1739A05600DFE837 /* MOAIVungleIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BC21739A05600DFE837 /* MOAIVungleIOS.mm */; };
 		89BE6C0C1739A05600DFE837 /* MOAIWebViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BC31739A05600DFE837 /* MOAIWebViewDelegate.h */; };
 		89BE6C0D1739A05600DFE837 /* MOAIWebViewDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BC41739A05600DFE837 /* MOAIWebViewDelegate.mm */; };
 		89BE6C0E1739A05600DFE837 /* MOAIWebViewIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BC51739A05600DFE837 /* MOAIWebViewIOS.h */; };
@@ -2608,6 +2582,32 @@
 		89BE76B3173C168400DFE837 /* pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89BE76A6173C168400DFE837 /* pch.cpp */; };
 		89BE76B4173C168400DFE837 /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE76A7173C168400DFE837 /* pch.h */; };
 		89BE76B5173C168400DFE837 /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE76A7173C168400DFE837 /* pch.h */; };
+		89BE76B8173C659900DFE837 /* MOAIFacebookIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA71739A05600DFE837 /* MOAIFacebookIOS.h */; };
+		89BE76B9173C659900DFE837 /* MOAIFacebookIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA81739A05600DFE837 /* MOAIFacebookIOS.mm */; };
+		89BE76BA173C6C2200DFE837 /* AKU-adcolony.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B921739A05600DFE837 /* AKU-adcolony.h */; };
+		89BE76BB173C6C2200DFE837 /* AKU-adcolony.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B931739A05600DFE837 /* AKU-adcolony.mm */; };
+		89BE76BC173C6C2900DFE837 /* AKU-chartboost.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B941739A05600DFE837 /* AKU-chartboost.h */; };
+		89BE76BD173C6C2900DFE837 /* AKU-chartboost.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B951739A05600DFE837 /* AKU-chartboost.mm */; };
+		89BE76BE173C6C3500DFE837 /* AKU-vungle.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B981739A05600DFE837 /* AKU-vungle.h */; };
+		89BE76BF173C6C3500DFE837 /* AKU-vungle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B991739A05600DFE837 /* AKU-vungle.mm */; };
+		89BE76C0173C6C4100DFE837 /* MOAIAdColonyIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6B9A1739A05600DFE837 /* MOAIAdColonyIOS.h */; };
+		89BE76C1173C6C4100DFE837 /* MOAIAdColonyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6B9B1739A05600DFE837 /* MOAIAdColonyIOS.mm */; };
+		89BE76C2173C6C5D00DFE837 /* MOAIChartBoostIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA01739A05600DFE837 /* MOAIChartBoostIOS.h */; };
+		89BE76C3173C6C5D00DFE837 /* MOAIChartBoostIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA11739A05600DFE837 /* MOAIChartBoostIOS.mm */; };
+		89BE76D4173C6CE800DFE837 /* MOAICrittercismIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BA21739A05600DFE837 /* MOAICrittercismIOS.h */; };
+		89BE76D5173C6CE800DFE837 /* MOAICrittercismIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BA31739A05600DFE837 /* MOAICrittercismIOS.mm */; };
+		89BE76D6173C6D4900DFE837 /* MOAIHttpTaskNSURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BAB1739A05600DFE837 /* MOAIHttpTaskNSURL.h */; };
+		89BE76D7173C6D4900DFE837 /* MOAIHttpTaskNSURL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BAC1739A05600DFE837 /* MOAIHttpTaskNSURL.mm */; };
+		89BE76D8173C6D5500DFE837 /* MOAIMobileAppTrackerIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BAF1739A05600DFE837 /* MOAIMobileAppTrackerIOS.h */; };
+		89BE76D9173C6D5500DFE837 /* MOAIMobileAppTrackerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BB01739A05600DFE837 /* MOAIMobileAppTrackerIOS.mm */; };
+		89BE76DA173C6D7100DFE837 /* MOAITapjoyIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBB1739A05600DFE837 /* MOAITapjoyIOS.h */; };
+		89BE76DB173C6D7100DFE837 /* MOAITapjoyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BBC1739A05600DFE837 /* MOAITapjoyIOS.mm */; };
+		89BE76DC173C6D8E00DFE837 /* MOAIUrlMgrNSURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBF1739A05600DFE837 /* MOAIUrlMgrNSURL.h */; };
+		89BE76DD173C6D8E00DFE837 /* MOAIUrlMgrNSURL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BC01739A05600DFE837 /* MOAIUrlMgrNSURL.mm */; };
+		89BE76DE173C6D9600DFE837 /* MOAIVungleIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BC11739A05600DFE837 /* MOAIVungleIOS.h */; };
+		89BE76DF173C6D9600DFE837 /* MOAIVungleIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BC21739A05600DFE837 /* MOAIVungleIOS.mm */; };
+		89BE771B173C6DD200DFE837 /* MOAITwitterIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 89BE6BBD1739A05600DFE837 /* MOAITwitterIOS.h */; };
+		89BE771C173C6DD200DFE837 /* MOAITwitterIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 89BE6BBE1739A05600DFE837 /* MOAITwitterIOS.mm */; };
 		C359A149143A81BA005E7829 /* RAudioBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = C359A148143A81BA005E7829 /* RAudioBuffer.h */; };
 		C37D422213B16930009600BB /* BufferedAudioSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C37D421E13B1692F009600BB /* BufferedAudioSource.h */; };
 		C37D422413B16930009600BB /* BufferedAudioSourceThread.h in Headers */ = {isa = PBXBuildFile; fileRef = C37D422013B16930009600BB /* BufferedAudioSourceThread.h */; };
@@ -5313,6 +5313,8 @@
 		89BE76A5173C168400DFE837 /* MOAIHttpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOAIHttpServer.h; sourceTree = "<group>"; };
 		89BE76A6173C168400DFE837 /* pch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pch.cpp; sourceTree = "<group>"; };
 		89BE76A7173C168400DFE837 /* pch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pch.h; sourceTree = "<group>"; };
+		89BE76D3173C6C8800DFE837 /* libmoai-ios-crittercism.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libmoai-ios-crittercism.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibmoai-ios-facebook copy.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C359A148143A81BA005E7829 /* RAudioBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RAudioBuffer.h; path = ../../3rdparty/untz/src/RAudioBuffer.h; sourceTree = "<group>"; };
 		C37D421D13B1692F009600BB /* BufferedAudioSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BufferedAudioSource.cpp; path = ../../3rdparty/untz/src/BufferedAudioSource.cpp; sourceTree = "<group>"; };
 		C37D421E13B1692F009600BB /* BufferedAudioSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BufferedAudioSource.h; path = ../../3rdparty/untz/src/BufferedAudioSource.h; sourceTree = "<group>"; };
@@ -6504,6 +6506,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		89BE76CD173C6C8800DFE837 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89BE7714173C6DB500DFE837 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CD04ACB014725568009C20E5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -7236,6 +7252,8 @@
 				89BE7660173C13EB00DFE837 /* libmoai-osx-harness.a */,
 				89BE7686173C15F100DFE837 /* libmoai-ios-http-server.a */,
 				89BE769F173C160E00DFE837 /* libmoai-osx-http-server.a */,
+				89BE76D3173C6C8800DFE837 /* libmoai-ios-crittercism.a */,
+				89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -11215,31 +11233,18 @@
 				89BE6B50173975E500DFE837 /* pch.h in Headers */,
 				89BE6B591739760900DFE837 /* AKU-audiosampler.h in Headers */,
 				89BE6B5D1739760900DFE837 /* MOAIAudioSampler.h in Headers */,
-				89BE6BDB1739A05600DFE837 /* AKU-adcolony.h in Headers */,
-				89BE6BDD1739A05600DFE837 /* AKU-chartboost.h in Headers */,
 				89BE6BDF1739A05600DFE837 /* AKU-iphone.h in Headers */,
-				89BE6BE11739A05600DFE837 /* AKU-vungle.h in Headers */,
-				89BE6BE31739A05600DFE837 /* MOAIAdColonyIOS.h in Headers */,
 				89BE6BE51739A05600DFE837 /* MOAIAppIOS.h in Headers */,
 				89BE6BE71739A05600DFE837 /* MOAIBillingIOS.h in Headers */,
-				89BE6BE91739A05600DFE837 /* MOAIChartBoostIOS.h in Headers */,
-				89BE6BEB1739A05600DFE837 /* MOAICrittercismIOS.h in Headers */,
 				89BE6BED1739A05600DFE837 /* MOAIDialogIOS.h in Headers */,
 				89BE6BEF1739A05600DFE837 /* moaiext-iphone.h in Headers */,
-				89BE6BF01739A05600DFE837 /* MOAIFacebookIOS.h in Headers */,
 				89BE6BF21739A05600DFE837 /* MOAIGameCenterIOS.h in Headers */,
-				89BE6BF41739A05600DFE837 /* MOAIHttpTaskNSURL.h in Headers */,
 				89BE6BF61739A05600DFE837 /* MOAIKeyboardIOS.h in Headers */,
-				89BE6BF81739A05600DFE837 /* MOAIMobileAppTrackerIOS.h in Headers */,
 				89BE6BFA1739A05600DFE837 /* MOAIMoviePlayerIOS.h in Headers */,
 				89BE6BFC1739A05600DFE837 /* MOAINotificationsIOS.h in Headers */,
 				89BE6BFE1739A05600DFE837 /* MOAISafariIOS.h in Headers */,
 				89BE6C001739A05600DFE837 /* MOAIStoreKitListener.h in Headers */,
 				89BE6C021739A05600DFE837 /* MOAITakeCameraListener.h in Headers */,
-				89BE6C041739A05600DFE837 /* MOAITapjoyIOS.h in Headers */,
-				89BE6C061739A05600DFE837 /* MOAITwitterIOS.h in Headers */,
-				89BE6C081739A05600DFE837 /* MOAIUrlMgrNSURL.h in Headers */,
-				89BE6C0A1739A05600DFE837 /* MOAIVungleIOS.h in Headers */,
 				89BE6C0C1739A05600DFE837 /* MOAIWebViewDelegate.h in Headers */,
 				89BE6C0E1739A05600DFE837 /* MOAIWebViewIOS.h in Headers */,
 				89BE6C101739A05600DFE837 /* NSArray+MOAILib.h in Headers */,
@@ -11288,6 +11293,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				895850831731C5FE00C9F577 /* AdColonyPublic.h in Headers */,
+				89BE76BA173C6C2200DFE837 /* AKU-adcolony.h in Headers */,
+				89BE76C0173C6C4100DFE837 /* MOAIAdColonyIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11295,6 +11302,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76D8173C6D5500DFE837 /* MOAIMobileAppTrackerIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11367,6 +11375,7 @@
 				07F11A7C15391291004EAA24 /* TapjoyConnect.h in Headers */,
 				07F11A7E15391291004EAA24 /* TapjoyConnectConstants.h in Headers */,
 				07F11A7F15391291004EAA24 /* TJCConfig.h in Headers */,
+				89BE76DA173C6D7100DFE837 /* MOAITapjoyIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11421,6 +11430,7 @@
 				07CBE8FD15E5BE7600C8DFDF /* FBUtility.h in Headers */,
 				07CBE8FE15E5BE7600C8DFDF /* FBViewController.h in Headers */,
 				07CBE8FF15E5BE7600C8DFDF /* FBViewController+Internal.h in Headers */,
+				89BE76B8173C659900DFE837 /* MOAIFacebookIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11429,6 +11439,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				663BA378159D09F800F80FE9 /* vunglepub.h in Headers */,
+				89BE76BE173C6C3500DFE837 /* AKU-vungle.h in Headers */,
+				89BE76DE173C6D9600DFE837 /* MOAIVungleIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11847,6 +11859,8 @@
 				89BE761C173C12CE00DFE837 /* MOAIUrlMgrCurl.h in Headers */,
 				89BE7620173C12CE00DFE837 /* MOAIUrlMgrNaCl.h in Headers */,
 				89BE7624173C12CE00DFE837 /* pch.h in Headers */,
+				89BE76D6173C6D4900DFE837 /* MOAIHttpTaskNSURL.h in Headers */,
+				89BE76DC173C6D8E00DFE837 /* MOAIUrlMgrNSURL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11887,6 +11901,22 @@
 				89BE76AD173C168400DFE837 /* host.h in Headers */,
 				89BE76B1173C168400DFE837 /* MOAIHttpServer.h in Headers */,
 				89BE76B5173C168400DFE837 /* pch.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89BE76C5173C6C8800DFE837 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89BE76D4173C6CE800DFE837 /* MOAICrittercismIOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89BE76E1173C6DB500DFE837 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89BE771B173C6DD200DFE837 /* MOAITwitterIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12282,6 +12312,8 @@
 			files = (
 				07F3902B1626446E00673C6F /* CBAnalytics.h in Headers */,
 				07F3902C1626446E00673C6F /* Chartboost.h in Headers */,
+				89BE76BC173C6C2900DFE837 /* AKU-chartboost.h in Headers */,
+				89BE76C2173C6C5D00DFE837 /* MOAIChartBoostIOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12645,6 +12677,40 @@
 			productReference = 89BE769F173C160E00DFE837 /* libmoai-osx-http-server.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		89BE76C4173C6C8800DFE837 /* libmoai-ios-crittercism */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89BE76CE173C6C8800DFE837 /* Build configuration list for PBXNativeTarget "libmoai-ios-crittercism" */;
+			buildPhases = (
+				89BE76C5173C6C8800DFE837 /* Headers */,
+				89BE76CA173C6C8800DFE837 /* Sources */,
+				89BE76CD173C6C8800DFE837 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-ios-crittercism";
+			productName = OpenUSLS;
+			productReference = 89BE76D3173C6C8800DFE837 /* libmoai-ios-crittercism.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		89BE76E0173C6DB500DFE837 /* libmoai-ios-twitter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89BE7715173C6DB500DFE837 /* Build configuration list for PBXNativeTarget "libmoai-ios-twitter" */;
+			buildPhases = (
+				89BE76E1173C6DB500DFE837 /* Headers */,
+				89BE7712173C6DB500DFE837 /* Sources */,
+				89BE7714173C6DB500DFE837 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libmoai-ios-twitter";
+			productName = OpenUSLS;
+			productReference = 89BE771A173C6DB500DFE837 /* liblibmoai-ios-facebook copy.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		CD04AABB14725568009C20E5 /* libmoai-ios-zlcore */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CD04ACB114725568009C20E5 /* Build configuration list for PBXNativeTarget "libmoai-ios-zlcore" */;
@@ -12871,6 +12937,7 @@
 				89BE737C173AD2B600DFE837 /* libmoai-ios-box2d */,
 				E98DBD4B1537A1C500514387 /* libmoai-ios-chartboost */,
 				89BE7519173C116400DFE837 /* libmoai-ios-chipmunk */,
+				89BE76C4173C6C8800DFE837 /* libmoai-ios-crittercism */,
 				07F4C7A514FC440500FB78BA /* libmoai-ios-facebook */,
 				CDDD30811574AE0000C410A0 /* libmoai-ios-fmod-designer */,
 				CD5089C6155E3A1B0002FC3B /* libmoai-ios-fmod-ex */,
@@ -12881,6 +12948,7 @@
 				07175BC61656E03400F3DF6B /* libmoai-ios-mat */,
 				89BE6EF5173AD06700DFE837 /* libmoai-ios-sim */,
 				073D52EC1459269600289D5C /* libmoai-ios-tapjoy */,
+				89BE76E0173C6DB500DFE837 /* libmoai-ios-twitter */,
 				CD07C3A313A182AA00C9386C /* libmoai-ios-untz */,
 				663BA366159D041D00F80FE9 /* libmoai-ios-vungle */,
 				CD04AABB14725568009C20E5 /* libmoai-ios-zlcore */,
@@ -14275,30 +14343,17 @@
 				89BE6B4E173975E500DFE837 /* pch.cpp in Sources */,
 				89BE6B571739760900DFE837 /* AKU-audiosampler.cpp in Sources */,
 				89BE6B5B1739760900DFE837 /* MOAIAudioSampler.cpp in Sources */,
-				89BE6BDC1739A05600DFE837 /* AKU-adcolony.mm in Sources */,
-				89BE6BDE1739A05600DFE837 /* AKU-chartboost.mm in Sources */,
 				89BE6BE01739A05600DFE837 /* AKU-iphone.mm in Sources */,
-				89BE6BE21739A05600DFE837 /* AKU-vungle.mm in Sources */,
-				89BE6BE41739A05600DFE837 /* MOAIAdColonyIOS.mm in Sources */,
 				89BE6BE61739A05600DFE837 /* MOAIAppIOS.mm in Sources */,
 				89BE6BE81739A05600DFE837 /* MOAIBillingIOS.mm in Sources */,
-				89BE6BEA1739A05600DFE837 /* MOAIChartBoostIOS.mm in Sources */,
-				89BE6BEC1739A05600DFE837 /* MOAICrittercismIOS.mm in Sources */,
 				89BE6BEE1739A05600DFE837 /* MOAIDialogIOS.mm in Sources */,
-				89BE6BF11739A05600DFE837 /* MOAIFacebookIOS.mm in Sources */,
 				89BE6BF31739A05600DFE837 /* MOAIGameCenterIOS.mm in Sources */,
-				89BE6BF51739A05600DFE837 /* MOAIHttpTaskNSURL.mm in Sources */,
 				89BE6BF71739A05600DFE837 /* MOAIKeyboardIOS.mm in Sources */,
-				89BE6BF91739A05600DFE837 /* MOAIMobileAppTrackerIOS.mm in Sources */,
 				89BE6BFB1739A05600DFE837 /* MOAIMoviePlayerIOS.mm in Sources */,
 				89BE6BFD1739A05600DFE837 /* MOAINotificationsIOS.mm in Sources */,
 				89BE6BFF1739A05600DFE837 /* MOAISafariIOS.mm in Sources */,
 				89BE6C011739A05600DFE837 /* MOAIStoreKitListener.mm in Sources */,
 				89BE6C031739A05600DFE837 /* MOAITakeCameraListener.mm in Sources */,
-				89BE6C051739A05600DFE837 /* MOAITapjoyIOS.mm in Sources */,
-				89BE6C071739A05600DFE837 /* MOAITwitterIOS.mm in Sources */,
-				89BE6C091739A05600DFE837 /* MOAIUrlMgrNSURL.mm in Sources */,
-				89BE6C0B1739A05600DFE837 /* MOAIVungleIOS.mm in Sources */,
 				89BE6C0D1739A05600DFE837 /* MOAIWebViewDelegate.mm in Sources */,
 				89BE6C0F1739A05600DFE837 /* MOAIWebViewIOS.mm in Sources */,
 				89BE6C111739A05600DFE837 /* NSArray+MOAILib.mm in Sources */,
@@ -14345,6 +14400,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76BB173C6C2200DFE837 /* AKU-adcolony.mm in Sources */,
+				89BE76C1173C6C4100DFE837 /* MOAIAdColonyIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14352,6 +14409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76D9173C6D5500DFE837 /* MOAIMobileAppTrackerIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14414,6 +14472,7 @@
 				07F11A7915391291004EAA24 /* TJCVGUtil.m in Sources */,
 				07F11A7B15391291004EAA24 /* TJCVGViewHandler.m in Sources */,
 				07F11A7D15391291004EAA24 /* TapjoyConnect.m in Sources */,
+				89BE76DB173C6D7100DFE837 /* MOAITapjoyIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14421,6 +14480,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76B9173C659900DFE837 /* MOAIFacebookIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14428,6 +14488,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76BF173C6C3500DFE837 /* AKU-vungle.mm in Sources */,
+				89BE76DF173C6D9600DFE837 /* MOAIVungleIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14816,6 +14878,8 @@
 				89BE761A173C12CE00DFE837 /* MOAIUrlMgrCurl.cpp in Sources */,
 				89BE761E173C12CE00DFE837 /* MOAIUrlMgrNaCl.cpp in Sources */,
 				89BE7622173C12CE00DFE837 /* pch.cpp in Sources */,
+				89BE76D7173C6D4900DFE837 /* MOAIHttpTaskNSURL.mm in Sources */,
+				89BE76DD173C6D8E00DFE837 /* MOAIUrlMgrNSURL.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14854,6 +14918,22 @@
 				89BE76AB173C168400DFE837 /* host.cpp in Sources */,
 				89BE76AF173C168400DFE837 /* MOAIHttpServer.cpp in Sources */,
 				89BE76B3173C168400DFE837 /* pch.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89BE76CA173C6C8800DFE837 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89BE76D5173C6CE800DFE837 /* MOAICrittercismIOS.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89BE7712173C6DB500DFE837 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89BE771C173C6DD200DFE837 /* MOAITwitterIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15239,6 +15319,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89BE76BD173C6C2900DFE837 /* AKU-chartboost.mm in Sources */,
+				89BE76C3173C6C5D00DFE837 /* MOAIChartBoostIOS.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15559,12 +15641,12 @@
 					"\"../../3rdparty/zlib-1.2.3\"",
 					"\"../../3rdparty/ooid-0.99\"",
 					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
-					"\"../../3rdparty/crittercismiOS-3.1.5/CrittercismSDK\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"../../3rdparty/chartboostiOS-3.0.7\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"\"../../3rdparty/vungle116/lib\"",
 					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
-					"\"$(SLOTS_SRC)/src\"",
+					"\"../../3rdparty/mongoose\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PROVISIONING_PROFILE = "";
@@ -15611,6 +15693,7 @@
 					OPENSSL_NO_RFC3779,
 					OPENSSL_NO_STORE,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15648,6 +15731,7 @@
 					OPENSSL_NO_RFC3779,
 					OPENSSL_NO_STORE,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15680,6 +15764,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-adcolony";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15713,6 +15798,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-adcolony";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15746,6 +15832,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-adcolony";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15783,6 +15870,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-mat";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15820,6 +15908,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-mat";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15857,6 +15946,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-mat";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15894,6 +15984,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-mat";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15927,6 +16018,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-tapjoy";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15960,6 +16052,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-tapjoy";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -15993,6 +16086,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-facebook";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16026,6 +16120,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-facebook";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16059,6 +16154,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-facebook";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16092,6 +16188,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-vungle";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16125,6 +16222,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-vungle";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16158,6 +16256,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-vungle";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -16191,6 +16290,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-vungle";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -17902,6 +18002,278 @@
 			};
 			name = Distribution;
 		};
+		89BE76CF173C6C8800DFE837 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "moai-ios-crittercism";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Debug;
+		};
+		89BE76D0173C6C8800DFE837 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "moai-ios-crittercism";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Release;
+		};
+		89BE76D1173C6C8800DFE837 /* AdHoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "moai-ios-crittercism";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = AdHoc;
+		};
+		89BE76D2173C6C8800DFE837 /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "moai-ios-crittercism";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Distribution;
+		};
+		89BE7716173C6DB500DFE837 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Debug;
+		};
+		89BE7717173C6DB500DFE837 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Release;
+		};
+		89BE7718173C6DB500DFE837 /* AdHoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = AdHoc;
+		};
+		89BE7719173C6DB500DFE837 /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_ABOUT_POINTER_SIGNEDNESS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
+				GCC_WARN_PROTOTYPE_CONVERSION = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_SIGN_COMPARE = NO;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
+				GCC_WARN_UNKNOWN_PRAGMAS = NO;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_LABEL = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_NAME = "libmoai-ios-facebook copy";
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "i386 armv7 armv7s";
+				WARNING_CFLAGS = "-w";
+			};
+			name = Distribution;
+		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -17996,12 +18368,12 @@
 					"\"../../3rdparty/zlib-1.2.3\"",
 					"\"../../3rdparty/ooid-0.99\"",
 					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
-					"\"../../3rdparty/crittercismiOS-3.1.5/CrittercismSDK\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"../../3rdparty/chartboostiOS-3.0.7\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"\"../../3rdparty/vungle116/lib\"",
 					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
-					"\"$(SLOTS_SRC)/src\"",
+					"\"../../3rdparty/mongoose\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PROVISIONING_PROFILE = "";
@@ -18017,6 +18389,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "moai-ios-zlcore";
 				SDKROOT = iphoneos;
@@ -18030,6 +18403,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "moai-ios-zlcore";
 				SDKROOT = iphoneos;
@@ -18096,6 +18470,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-untz";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -18129,6 +18504,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-untz";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -18382,6 +18758,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-luaext";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -18415,6 +18792,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-luaext";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19051,12 +19429,12 @@
 					"\"../../3rdparty/zlib-1.2.3\"",
 					"\"../../3rdparty/ooid-0.99\"",
 					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
-					"\"../../3rdparty/crittercismiOS-3.1.5/CrittercismSDK\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"../../3rdparty/chartboostiOS-3.0.7\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"\"../../3rdparty/vungle116/lib\"",
 					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
-					"\"$(SLOTS_SRC)/src\"",
+					"\"../../3rdparty/mongoose\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PROVISIONING_PROFILE = "";
@@ -19098,6 +19476,7 @@
 					OPENSSL_NO_RFC3779,
 					OPENSSL_NO_STORE,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19187,6 +19566,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-luaext";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19220,6 +19600,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-tapjoy";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19253,6 +19634,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-untz";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19265,6 +19647,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "moai-ios-zlcore";
 				SDKROOT = iphoneos;
@@ -19445,6 +19828,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-chartboost";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19478,6 +19862,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-chartboost";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19511,6 +19896,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-chartboost";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19544,6 +19930,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-chartboost";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19640,12 +20027,12 @@
 					"\"../../3rdparty/zlib-1.2.3\"",
 					"\"../../3rdparty/ooid-0.99\"",
 					"\"../../3rdparty/tapjoyiOS-8.1.9/TapjoyConnect\"",
-					"\"../../3rdparty/crittercismiOS-3.1.5/CrittercismSDK\"",
+					"\"../../3rdparty/crittercismiOS-3.3.3/CrittercismSDK-crashonly\"",
 					"\"../../3rdparty/chartboostiOS-3.0.7\"",
 					"\"../../3rdparty/facebookiOS-3.0.6.b/src\"",
 					"\"../../3rdparty/vungle116/lib\"",
 					"\"../../3rdparty/adcolonyiOS-1911/Library\"",
-					"\"$(SLOTS_SRC)/src\"",
+					"\"../../3rdparty/mongoose\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PROVISIONING_PROFILE = "";
@@ -19687,6 +20074,7 @@
 					OPENSSL_NO_RFC3779,
 					OPENSSL_NO_STORE,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19776,6 +20164,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-adcolony";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19809,6 +20198,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-facebook";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19842,6 +20232,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-luaext";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19875,6 +20266,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-tapjoy";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19908,6 +20300,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "moai-ios-untz";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "i386 armv7 armv7s";
@@ -19920,6 +20313,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD_32_BIT)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "moai-ios-zlcore";
 				SDKROOT = iphoneos;
@@ -20300,6 +20694,28 @@
 				89BE769C173C160E00DFE837 /* Release */,
 				89BE769D173C160E00DFE837 /* AdHoc */,
 				89BE769E173C160E00DFE837 /* Distribution */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		89BE76CE173C6C8800DFE837 /* Build configuration list for PBXNativeTarget "libmoai-ios-crittercism" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89BE76CF173C6C8800DFE837 /* Debug */,
+				89BE76D0173C6C8800DFE837 /* Release */,
+				89BE76D1173C6C8800DFE837 /* AdHoc */,
+				89BE76D2173C6C8800DFE837 /* Distribution */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		89BE7715173C6DB500DFE837 /* Build configuration list for PBXNativeTarget "libmoai-ios-twitter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89BE7716173C6DB500DFE837 /* Debug */,
+				89BE7717173C6DB500DFE837 /* Release */,
+				89BE7718173C6DB500DFE837 /* AdHoc */,
+				89BE7719173C6DB500DFE837 /* Distribution */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-crittercism.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-crittercism.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89BE76C4173C6C8800DFE837"
+               BuildableName = "libmoai-ios-crittercism.a"
+               BlueprintName = "libmoai-ios-crittercism"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-twitter.xcscheme
+++ b/xcode/libmoai/libmoai.xcodeproj/xcshareddata/xcschemes/libmoai-ios-twitter.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89BE76E0173C6DB500DFE837"
+               BuildableName = "liblibmoai-ios-facebook copy.a"
+               BlueprintName = "libmoai-ios-twitter"
+               ReferencedContainer = "container:libmoai.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/osx/MoaiSample.xcodeproj/project.pbxproj
+++ b/xcode/osx/MoaiSample.xcodeproj/project.pbxproj
@@ -142,20 +142,6 @@
 			remoteGlobalIDString = 07175BD41656E03400F3DF6B;
 			remoteInfo = "libmoai-ios-mat";
 		};
-		0720DD8016F3D3E70096A3E3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 07ABD7DA167185030088D59D;
-			remoteInfo = "libmoaiext-osx-slots";
-		};
-		0720DD8216F3D3E70096A3E3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 076541FA1694B84F00F4179E;
-			remoteInfo = "libmoaiext-ios-slots";
-		};
 		07D91D1715CC367C00ACC811 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
@@ -190,6 +176,48 @@
 			proxyType = 1;
 			remoteGlobalIDString = CD04ACB51472557F009C20E5;
 			remoteInfo = "libmoai-osx-zlcore";
+		};
+		89ADB9BA1742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE76D3173C6C8800DFE837;
+			remoteInfo = "libmoai-ios-crittercism";
+		};
+		89ADB9BC1742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7647173C138100DFE837;
+			remoteInfo = "libmoai-ios-harness";
+		};
+		89ADB9BE1742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7686173C15F100DFE837;
+			remoteInfo = "libmoai-ios-http-server";
+		};
+		89ADB9C01742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE771A173C6DB500DFE837;
+			remoteInfo = "libmoai-ios-twitter";
+		};
+		89ADB9C21742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE7660173C13EB00DFE837;
+			remoteInfo = "libmoai-osx-harness";
+		};
+		89ADB9C41742FE0600E8058B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0324CC6913564429000ADC60 /* libmoai.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 89BE769F173C160E00DFE837;
+			remoteInfo = "libmoai-osx-http-server";
 		};
 		89BE7259173AD20E00DFE837 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -581,14 +609,18 @@
 				89BE7515173AD32100DFE837 /* libmoai-ios-box2d.a */,
 				E92D4ACC153CCBC400CB1E8A /* libmoai-ios-chartboost.a */,
 				89BE75B4173C11E100DFE837 /* libmoai-ios-chipmunk.a */,
+				89ADB9BB1742FE0600E8058B /* libmoai-ios-crittercism.a */,
 				E91A4C2C15181BB80008F1A5 /* libmoai-ios-facebook.a */,
-				CD6DC25A1574B334008C3996 /* liblibmoai-ios-fmod-designer.a */,
+				CD6DC25A1574B334008C3996 /* libmoai-ios-fmod-designer.a */,
 				CDE8A7CE155E42DD00C2DFF5 /* libmoai-ios-fmod-ex.a */,
+				89ADB9BD1742FE0600E8058B /* libmoai-ios-harness.a */,
 				89BE762B173C12DB00DFE837 /* libmoai-ios-http-client.a */,
+				89ADB9BF1742FE0600E8058B /* libmoai-ios-http-server.a */,
 				CD07C41313A185E200C9386C /* libmoai-ios-luaext.a */,
 				0720DD7F16F3D3E70096A3E3 /* libmoai-ios-mat.a */,
 				89BE725A173AD20E00DFE837 /* libmoai-ios-sim.a */,
 				1B70C4CE1475F198009C6869 /* libmoai-ios-tapjoy.a */,
+				89ADB9C11742FE0600E8058B /* liblibmoai-ios-facebook copy.a */,
 				CD07C41513A185E200C9386C /* libmoai-ios-untz.a */,
 				07D91D1815CC367C00ACC811 /* libmoai-ios-vungle.a */,
 				1B70C4D01475F198009C6869 /* libmoai-ios-zlcore.a */,
@@ -596,15 +628,15 @@
 				0324E2C01356485F000ADC60 /* libmoai-osx-3rdparty.a */,
 				89BE7517173AD32100DFE837 /* libmoai-osx-box2d.a */,
 				89BE75B6173C11E100DFE837 /* libmoai-osx-chipmunk.a */,
-				CD6DC25C1574B334008C3996 /* liblibmoai-osx-fmod-designer.a */,
+				CD6DC25C1574B334008C3996 /* libmoai-osx-fmod-designer.a */,
 				CDE8A82E155E435800C2DFF5 /* libmoai-osx-fmod-ex.a */,
+				89ADB9C31742FE0600E8058B /* libmoai-osx-harness.a */,
 				89BE762D173C12DB00DFE837 /* libmoai-osx-http-client.a */,
+				89ADB9C51742FE0600E8058B /* libmoai-osx-http-server.a */,
 				CD07C41713A185E200C9386C /* libmoai-osx-luaext.a */,
 				89BE725C173AD20E00DFE837 /* libmoai-osx-sim.a */,
 				CDBDAEBF13A2F6C700FD5641 /* libmoai-osx-untz.a */,
 				1B70C4D21475F198009C6869 /* libmoai-osx-zlcore.a */,
-				0720DD8116F3D3E70096A3E3 /* libmoaiext-osx-slots.a */,
-				0720DD8316F3D3E70096A3E3 /* libmoaiext-ios-slots.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -857,20 +889,6 @@
 			remoteRef = 0720DD7E16F3D3E70096A3E3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		0720DD8116F3D3E70096A3E3 /* libmoaiext-osx-slots.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoaiext-osx-slots.a";
-			remoteRef = 0720DD8016F3D3E70096A3E3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0720DD8316F3D3E70096A3E3 /* libmoaiext-ios-slots.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libmoaiext-ios-slots.a";
-			remoteRef = 0720DD8216F3D3E70096A3E3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		07D91D1815CC367C00ACC811 /* libmoai-ios-vungle.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -897,6 +915,48 @@
 			fileType = archive.ar;
 			path = "libmoai-osx-zlcore.a";
 			remoteRef = 1B70C4D11475F198009C6869 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9BB1742FE0600E8058B /* libmoai-ios-crittercism.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-crittercism.a";
+			remoteRef = 89ADB9BA1742FE0600E8058B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9BD1742FE0600E8058B /* libmoai-ios-harness.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-harness.a";
+			remoteRef = 89ADB9BC1742FE0600E8058B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9BF1742FE0600E8058B /* libmoai-ios-http-server.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-ios-http-server.a";
+			remoteRef = 89ADB9BE1742FE0600E8058B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9C11742FE0600E8058B /* liblibmoai-ios-facebook copy.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "liblibmoai-ios-facebook copy.a";
+			remoteRef = 89ADB9C01742FE0600E8058B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9C31742FE0600E8058B /* libmoai-osx-harness.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-harness.a";
+			remoteRef = 89ADB9C21742FE0600E8058B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		89ADB9C51742FE0600E8058B /* libmoai-osx-http-server.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libmoai-osx-http-server.a";
+			remoteRef = 89ADB9C41742FE0600E8058B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		89BE725A173AD20E00DFE837 /* libmoai-ios-sim.a */ = {
@@ -976,17 +1036,17 @@
 			remoteRef = CD07C41613A185E200C9386C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CD6DC25A1574B334008C3996 /* liblibmoai-ios-fmod-designer.a */ = {
+		CD6DC25A1574B334008C3996 /* libmoai-ios-fmod-designer.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "liblibmoai-ios-fmod-designer.a";
+			path = "libmoai-ios-fmod-designer.a";
 			remoteRef = CD6DC2591574B334008C3996 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		CD6DC25C1574B334008C3996 /* liblibmoai-osx-fmod-designer.a */ = {
+		CD6DC25C1574B334008C3996 /* libmoai-osx-fmod-designer.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "liblibmoai-osx-fmod-designer.a";
+			path = "libmoai-osx-fmod-designer.a";
 			remoteRef = CD6DC25B1574B334008C3996 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1258,6 +1318,7 @@
 					"\"../../src/hosts\"",
 					"\"../../src\"",
 					"\"../../src/config-default\"",
+					"\"../../3rdparty/lua-5.1.3/src\"",
 				);
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
@@ -1310,6 +1371,7 @@
 					"\"../../src/hosts\"",
 					"\"../../src\"",
 					"\"../../src/config-default\"",
+					"\"../../3rdparty/lua-5.1.3/src\"",
 				);
 				SDKROOT = "";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Some sources in moai-iphone looked like they should be in separate build targets, such as MOAIFacebookIOS => libmoai-ios-facebook, but some seem like iOS-specific additions to targets; like MOAIGameCenterIOS => libmoai-ios, or MOAIHttpTaskNSURL => libmoai-ios-http-client.

I split those sources into separate targets where it made sense, and ended up with a set of targets like this:

![Xcode targets](https://www.evernote.com/shard/s59/sh/655b0232-ae2d-4089-b6a7-4db90510241c/ec234f6861ed981662f9dc56bf567f88/res/fbc1c80b-7439-41b9-8162-5c2ae46088b1/skitch.png)

What is the role of libmoai-ios-3rdparty supposed to be? Is it supposed to be a "give me all of the 3rd-party stuff I might want" target, or just the basics that are necessary for using Moai?

Also, I'd like to generate as much of this as possible through CMake, but I have limited experience writing CMake stuff, so maybe @franciscotufro could help with that.

@patrickmeehan 
