### PR TITLE
Fix to MOAIParticlePexPlugin where open GL flags were being fed to MOAI ...

### DIFF
--- a/src/moai-sim/MOAIParticlePexPlugin.cpp
+++ b/src/moai-sim/MOAIParticlePexPlugin.cpp
@@ -132,6 +132,7 @@ int MOAIParticlePexPlugin::_load( lua_State* L ){
 // MOAIParticlePlugin
 //================================================================//
 #if MOAI_WITH_TINYXML
+#include <zl-gfx/headers.h>
 void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin, TiXmlNode* node )
 {
 	if ( !node ) return;
@@ -166,9 +167,9 @@ void MOAIParticlePexPlugin::Parse( cc8* filename, MOAIParticlePexPlugin& plugin,
 					plugin.mAngleRegister = plugin.mSize++;
 			}
 			else if(text == "blendFuncSource")
-				plugin.mBlendFuncSrc = atoi(attribute->Value());
+				plugin.mBlendFuncSrc = zglMapFromGLEnum( atoi(attribute->Value()));
 			else if(text == "blendFuncDestination")
-				plugin.mBlendFuncDst = atoi(attribute->Value());
+				plugin.mBlendFuncDst = zglMapFromGLEnum( atoi(attribute->Value()));
 			else if(text == "duration")
 				plugin.mDuration = (float)atof(attribute->Value());
 			else if(text == "emitterType")

--- a/src/moai-sim/host.cpp
+++ b/src/moai-sim/host.cpp
@@ -210,7 +210,7 @@ void AKUInitializeSim () {
 	REGISTER_LUA_CLASS ( MOAITextStyle )
 	
 	#if MOAI_WITH_TINYXML
-		//REGISTER_LUA_CLASS ( MOAIParticlePexPlugin )
+		REGISTER_LUA_CLASS ( MOAIParticlePexPlugin )
 	#endif
 	
 	MOAIEnvironment::Get ().DetectEnvironment ();

--- a/src/zl-gfx/headers.h
+++ b/src/zl-gfx/headers.h
@@ -216,6 +216,8 @@ enum {
 };
 
 //----------------------------------------------------------------//
+extern u32 zglMapFromGLEnum( u32 glEnum );
+
 extern void		zglFinalize				();
 extern void		zglInitialize			();
 

--- a/src/zl-gfx/zl_gfx_opengl.cpp
+++ b/src/zl-gfx/zl_gfx_opengl.cpp
@@ -74,6 +74,24 @@ static u32	sMaxTextureSize				= 0;
 
 //----------------------------------------------------------------//
 //----------------------------------------------------------------//
+u32 zglMapFromGLEnum( u32 glEnum ) {
+	switch ( glEnum ) {
+	   case GL_DST_ALPHA:				return ZGL_BLEND_FACTOR_DST_ALPHA;
+		case GL_DST_COLOR:				return ZGL_BLEND_FACTOR_DST_COLOR;
+		case GL_ONE:						return ZGL_BLEND_FACTOR_ONE;
+		case GL_ONE_MINUS_DST_ALPHA:	return ZGL_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
+		case GL_ONE_MINUS_DST_COLOR:	return ZGL_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+		case GL_ONE_MINUS_SRC_ALPHA:	return ZGL_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+		case GL_ONE_MINUS_SRC_COLOR:	return ZGL_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+		case GL_SRC_ALPHA:				return ZGL_BLEND_FACTOR_SRC_ALPHA;
+		case GL_SRC_ALPHA_SATURATE:	return ZGL_BLEND_FACTOR_SRC_ALPHA_SATURATE;
+		case GL_SRC_COLOR:				return ZGL_BLEND_FACTOR_SRC_COLOR;
+		case GL_ZERO:						return ZGL_BLEND_FACTOR_ZERO;
+	};
+	assert ( false );
+	return 0;
+}
+
 GLenum _remapEnum ( u32 zglEnum ) {
 	
 	switch ( zglEnum ) {


### PR DESCRIPTION
...core which now uses the wrapped zgl\* versions of opengl flags and functions causing an assert to trigger when _remapEnum was called.

Also, MOAIParticlePexPlugin was commented out in host.cpp
