### PR TITLE
Updating the android run-host script so that the init.lua file gets run ...

### DIFF
--- a/ant/host-source/d.run-host.sh
+++ b/ant/host-source/d.run-host.sh
@@ -177,14 +177,17 @@
 	
 	working_dir_depth=`grep -o "\/" <<<"$working_dir" | wc -l`
 	(( working_dir_depth += 1 ))
-	
-	for (( i=1; i<=$working_dir_depth; i++ )); do
-		if [ $i == 1 ]; then
-			init_dir=\.\.
-		else
-			init_dir=$init_dir\/\.\.
-		fi
-	done
+
+    init_dir=\.
+    if [ x$working_dir != x"." ]; then
+        for (( i=1; i<=$working_dir_depth; i++ )); do
+            if [ $i == 1 ]; then
+                init_dir=\.\.
+            else
+                init_dir=$init_dir\/\.\.
+            fi
+        done
+    fi
 	
 	run_command="\"$init_dir/init.lua\""
 	


### PR DESCRIPTION
...when working directory is .

When the android working_dir was "." the init.lua was not run because
its directory was not determined properly.  Added a check for a working
dir of "." in the run-host and skipping the default directory
determination if found.
