### PR TITLE
Fix for infinite loop in MOAITimer ping-pong mode

### DIFF
--- a/src/moai-sim/MOAITimer.cpp
+++ b/src/moai-sim/MOAITimer.cpp
@@ -303,6 +303,11 @@ void MOAITimer::DoStep ( float step ) {
 					this->OnEndSpan ();
 					this->OnLoop ();
 					this->OnBeginSpan ();
+
+					if ( this->mTime == this->mEndTime ) {
+
+						break;
+					}
 				}
 			}
 			else {


### PR DESCRIPTION
When the time is equal to the end time, the old version will go into an
infinite loop.

See issue #715
