### PR TITLE
Fixing issues with determining a textbox string bounds.

### DIFF
--- a/src/moai-sim/MOAIGlyph.cpp
+++ b/src/moai-sim/MOAIGlyph.cpp
@@ -64,19 +64,22 @@ MOAIKernVec MOAIGlyph::GetKerning ( u32 name ) const {
 	return kernVec;
 }
 
-//----------------------------------------------------------------//
-ZLRect MOAIGlyph::GetRect ( float x, float y ) const {
+/**
+ * Get the rect of the glyph which includes the bearing + the size of the bounding box of the glyph.
+ * 
+ * @param x The x pen position when drawing this glyph
+ * @param y The y pen position when drawing this glyph
+ * @param scale The scale at which the glyph would be drawn
+ */
+ZLRect MOAIGlyph::GetRect ( float x, float y, float scale ) const {
 
 	ZLRect rect;
-		
-	x += ( this->mBearingX );
-	y -= ( this->mBearingY ); 
 
 	rect.Init (
 		x,
 		y,
-		x + this->mWidth,
-		y + this->mHeight
+		x + (this->mBearingX + this->mWidth) * scale,
+		y + (this->mBearingY + this->mHeight) * scale
 	);
 
 	return rect;

--- a/src/moai-sim/MOAIGlyph.h
+++ b/src/moai-sim/MOAIGlyph.h
@@ -26,14 +26,14 @@ private:
 	static const u32 MAX_KERN_TABLE_SIZE	= 512;
 	static const u32 NULL_PAGE_ID			= 0xffffffff;
 	
-	u32			mCode;
+	u32			mCode;   // The character code of the glyph
 	u32			mPageID; // ID of texture page in glyph cache
 	
-	float		mWidth; // width in pixels
-	float		mHeight; // height in pixels
-	float		mAdvanceX;
-	float		mBearingX;
-	float		mBearingY;
+	float		mWidth; // width of the bounding box in pixels
+	float		mHeight; // height of the bounding box in pixels
+	float		mAdvanceX; // The distance the pen moves to the next glyph
+	float		mBearingX; // The distance from the pen's x coordinate to the bounding box
+	float		mBearingY; // The distance from the pen's y coordinate to the bounding box
 	
 	u32			mSrcX; // corresponds to glyph location on page
 	u32			mSrcY; // corresponds to glyph location on page
@@ -62,7 +62,7 @@ public:
 	//----------------------------------------------------------------//
 	void			Draw				( MOAITextureBase& texture, float x, float y, float scale ) const;
 	MOAIKernVec		GetKerning			( u32 name ) const;
-	ZLRect			GetRect				( float x, float y ) const;
+	ZLRect			GetRect				( float x, float y, float scale = 1) const;
 					MOAIGlyph			();
 					~MOAIGlyph			();
 	void			ReserveKernTable	( u32 total );

--- a/src/moai-sim/MOAITextBox.cpp
+++ b/src/moai-sim/MOAITextBox.cpp
@@ -993,7 +993,14 @@ bool MOAITextBox::GetBoundsForRange ( u32 idx, u32 size, ZLRect& rect ) {
 
 		if ( glyph.mWidth > 0.0f ) {
 
-			ZLRect glyphRect = glyph.GetRect ( sprite.mX, sprite.mY );
+			ZLRect glyphRect = glyph.GetRect ( sprite.mX, sprite.mY, sprite.mScale );
+		
+			// Update the glyphRect height with the size of the of the glyphset's height for
+			// the max possible line height.
+			float fontSize = sprite.mStyle->GetSize();
+			MOAIGlyphSet* glyphSet = sprite.mStyle->GetFont()->GetGlyphSet(fontSize);
+			float deckHeight = glyphSet->GetHeight() * sprite.mScale;
+			glyphRect.mYMax = glyphRect.mYMin + deckHeight;
 
 			if ( result ) {
 				rect.Grow ( glyphRect );

--- a/src/moai-sim/MOAITextBox.h
+++ b/src/moai-sim/MOAITextBox.h
@@ -56,9 +56,9 @@ private:
 	MOAITextureBase*		mTexture; // caching this here to avoid add'l virtual calls when drawing
 	
 	u32			mIdx; // index in original string
-	float		mX;
-	float		mY;
-	float		mScale;
+	float		mX;   // The pen position's x coordinate
+	float		mY;   // The pen position's y coordinate
+	float		mScale; 
 	u32			mRGBA;
 	u32			mMask;
 	

--- a/src/moai-sim/MOAITextDesigner.cpp
+++ b/src/moai-sim/MOAITextDesigner.cpp
@@ -45,7 +45,8 @@ void MOAITextDesigner::AcceptLine () {
 	}
 	else {
 		this->mPen.mX = 0.0f;
-		this->mTokenRect.Init ( 0.0f, this->mPen.mY, 0.0f, this->mPen.mY + this->mDeck->mHeight );
+		float scale = this->mTextBox->mGlyphScale * ( this->mStyle ? this->mStyle->mScale : 1.0f ) * this->mDeckScale;
+		this->mTokenRect.Init ( 0.0f, this->mPen.mY, 0.0f, this->mPen.mY + this->mDeck->mHeight * scale );
 	}
 }
 
@@ -192,7 +193,7 @@ void MOAITextDesigner::BuildLayout () {
 			else {
 				
 				float glyphBottom = this->mPen.mY + ( this->mDeck->mHeight * scale );
-				float glyphRight = this->mPen.mX + (( glyph->mBearingX + glyph->mWidth ) * scale );
+				float glyphRight = this->mPen.mX + ( glyph->mBearingX + glyph->mWidth ) * scale ;
 				
 				// handle new token
 				if ( this->mTokenSize == 0 ) {


### PR DESCRIPTION
Currently the GetStringBounds returns a rect which is not correct.
Drawing the textbox with the rect provided doesn't create a textbox
with the text laid out as expected.  Fixing some bugs in the build
layout of text box designer and an issue with MOAIGlyph::GetRect which
was causing these problems.

See the before and after pictures:
![before](https://f.cloud.github.com/assets/3893074/678903/d2ebca06-d949-11e2-8407-059c4e45e78e.png)
![after](https://f.cloud.github.com/assets/3893074/678902/d2e203f4-d949-11e2-8889-48bbfae2d12b.png)
