### PR TITLE
Add getAlignment method to MOAITextBox

### DIFF
--- a/src/moai-sim/MOAITextBox.cpp
+++ b/src/moai-sim/MOAITextBox.cpp
@@ -76,6 +76,21 @@ int MOAITextBox::_clearHighlights ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	getAlignment
+	@text	Returns the alignment of the text
+
+	@in		MOAITextBox self
+	@out	enum horizontal alignment
+	@out	enum vertical alignment
+*/
+int MOAITextBox::_getAlignment ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAITextBox, "U" )
+	state.Push ( self->mHAlign );
+	state.Push ( self->mVAlign );
+	return 2;
+}
+
+//----------------------------------------------------------------//
 /**	@name	getGlyphScale
 	@text	Returns the current glyph scale.
 
@@ -1266,6 +1281,7 @@ void MOAITextBox::RegisterLuaFuncs ( MOAILuaState& state ) {
 	
 	luaL_Reg regTable [] = {
 		{ "clearHighlights",		_clearHighlights },
+		{ "getAlignment",			_getAlignment },
 		{ "getGlyphScale",			_getGlyphScale },
 		{ "getLineSpacing",			_getLineSpacing },
 		{ "getRect",				_getRect },

--- a/src/moai-sim/MOAITextBox.h
+++ b/src/moai-sim/MOAITextBox.h
@@ -266,6 +266,7 @@ private:
 	
 	//----------------------------------------------------------------//
 	static int			_clearHighlights		( lua_State* L );
+	static int			_getAlignment			( lua_State* L );
 	static int			_getGlyphScale			( lua_State* L );
 	static int			_getLineSpacing			( lua_State* L );
 	static int			_getRect				( lua_State* L );


### PR DESCRIPTION
Adding the getAlignment method to MOAITextbox, useful for when one is
resizing a textbox, you can rettrieve its alignment and then re-align
it after the resize.
