### PR TITLE
Add MOAIEnvironment.languageCode, countryCode to Android host

### DIFF
--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -346,7 +346,7 @@ public class Moai {
 		
 			AKUSetDeviceProperties ( appName, appId, appVersion, Build.CPU_ABI, Build.BRAND, Build.DEVICE, Build.MANUFACTURER, Build.MODEL, Build.PRODUCT, Runtime.getRuntime ().availableProcessors (), "Android", Build.VERSION.RELEASE, udid );
 
-			AKUSetDeviceLocale(Locale.getDefault().getLanguage(), Locale.getDefault().getCountry());
+			AKUSetDeviceLocale(Locale.getDefault().getLanguage(), Locale.getDefault().getCountry());
 		}
 	}	
 

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -24,6 +24,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.Locale;
 
 //================================================================//
 // Moai
@@ -177,7 +178,8 @@ public class Moai {
 	protected static native void 	AKUSetWorkingDirectory 			( String path );
 	protected static native void 	AKUUntzInit			 			();
 	protected static native void 	AKUUpdate				 		();
-
+	protected static native void    AKUSetDeviceLocale              ( String langCode, String countryCode );
+ 
 	//----------------------------------------------------------------//
 	static {
 		
@@ -343,6 +345,8 @@ public class Moai {
 			}
 		
 			AKUSetDeviceProperties ( appName, appId, appVersion, Build.CPU_ABI, Build.BRAND, Build.DEVICE, Build.MANUFACTURER, Build.MODEL, Build.PRODUCT, Runtime.getRuntime ().availableProcessors (), "Android", Build.VERSION.RELEASE, udid );
+
+			AKUSetDeviceLocale(Locale.getDefault().getLanguage(), Locale.getDefault().getCountry());
 		}
 	}	
 

--- a/ant/libmoai/jni/src/moai.cpp
+++ b/ant/libmoai/jni/src/moai.cpp
@@ -596,3 +596,16 @@
 
 		AKUUpdate ();
 	}
+
+	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetDeviceLocale ( JNIEnv* env, jclass obj, jstring jlangCode, jstring jcountryCode ) {
+		JNI_GET_CSTRING ( jlangCode, langCode );
+		JNI_GET_CSTRING ( jcountryCode, countryCode );
+
+		MOAIEnvironment& environment = MOAIEnvironment::Get ();
+
+		environment.SetValue ( MOAI_ENV_languageCode, langCode );
+		environment.SetValue( MOAI_ENV_countryCode, countryCode );
+
+		JNI_RELEASE_CSTRING ( jlangCode, langCode );
+		JNI_RELEASE_CSTRING ( jcountryCode, countryCode );
+	}

--- a/distribute/hosts/ant/host-source/project/src/com/ziplinegames/moai/Moai.java
+++ b/distribute/hosts/ant/host-source/project/src/com/ziplinegames/moai/Moai.java
@@ -24,7 +24,6 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.ArrayList;
 import java.util.UUID;
-import java.util.Locale;
 
 //================================================================//
 // Moai
@@ -176,7 +175,6 @@ public class Moai {
 	protected static native void 	AKUSetWorkingDirectory 			( String path );
 	protected static native void 	AKUUntzInit			 			();
 	protected static native void 	AKUUpdate				 		();
-	protected static native void    AKUSetDeviceLocale              ( String langCode, String countryCode );
 
 	//----------------------------------------------------------------//
 	static {
@@ -343,8 +341,6 @@ public class Moai {
 			}
 		
 			AKUSetDeviceProperties ( appName, appId, appVersion, Build.CPU_ABI, Build.BRAND, Build.DEVICE, Build.MANUFACTURER, Build.MODEL, Build.PRODUCT, Runtime.getRuntime ().availableProcessors (), "Android", Build.VERSION.RELEASE, udid );
-
-			AKUSetDeviceLocale(Locale.getDefault().getLanguage(), Locale.getDefault().getCountry());
 		}
 	}	
 

--- a/distribute/hosts/ant/host-source/project/src/com/ziplinegames/moai/Moai.java
+++ b/distribute/hosts/ant/host-source/project/src/com/ziplinegames/moai/Moai.java
@@ -24,6 +24,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.Locale;
 
 //================================================================//
 // Moai
@@ -175,6 +176,7 @@ public class Moai {
 	protected static native void 	AKUSetWorkingDirectory 			( String path );
 	protected static native void 	AKUUntzInit			 			();
 	protected static native void 	AKUUpdate				 		();
+	protected static native void    AKUSetDeviceLocale              ( String langCode, String countryCode );
 
 	//----------------------------------------------------------------//
 	static {
@@ -341,6 +343,8 @@ public class Moai {
 			}
 		
 			AKUSetDeviceProperties ( appName, appId, appVersion, Build.CPU_ABI, Build.BRAND, Build.DEVICE, Build.MANUFACTURER, Build.MODEL, Build.PRODUCT, Runtime.getRuntime ().availableProcessors (), "Android", Build.VERSION.RELEASE, udid );
+
+			AKUSetDeviceLocale(Locale.getDefault().getLanguage(), Locale.getDefault().getCountry());
 		}
 	}	
 


### PR DESCRIPTION
Code originally authored by An Nguyen at MeYuMe

NOTE: This patch should have been a single commit. It is hard to test since the
current development branch will not run correctly in Android.  You can use this
patch in tag Version-1.3-Build-160, but you'll need to cherry pick.

```
git cherry-pick 60fcf86b7db
if conflict, use the deleted file from the 'git mergetool'
git cherry-pick 93595173b4
git cherry-pick 44c1cd4a45
```
