### PR TITLE
fix glut fullscreen bug (app would not stay in fullscreen mode)

### DIFF
--- a/src/host-glut/GlutHost.cpp
+++ b/src/host-glut/GlutHost.cpp
@@ -223,7 +223,6 @@ static void _onReshape( int w, int h ) {
 		sExitFullscreen = false;
 	}
 
-	glutReshapeWindow ( w, h );
 	AKUSetScreenSize ( w, h );
 	AKUSetViewSize ( w, h );
 }


### PR DESCRIPTION
The GLUT host contains a serious bug which affects its fullscreen behavior. There is an unnecessary call to **glutReshapeWindow()** inside **_onReshape** handler.

A user should call _glutReshapeWindow_ to request window size change which causes __onReshape_ to fire. If you call _glutReshapeWindow_ inside the __onReshape_ handler itself, this results in an infinite series of __onReshape_ calls. Note that the __onReshape_ handler is not invoked immediately by _glutReshapeWindow_ but rather queued for a later time at the end of some internal GLUT loop.

Another side effect is that the application will not stay in fullscreen mode. These behaviors are described in _glutFullScreen_ and _glutReshapeWindow_ docs:

> Subsequent glutReshapeWindow and glutPositionWindow requests on the window will disable the full screen status of the window.
> http://www.opengl.org/documentation/specs/glut/spec3/node24.html
> 
> glutReshapeWindow disables the full screen status of a window if previously enabled.
> http://www.opengl.org/resources/libraries/glut/spec3/node23.html

Since _glutReshapeWindow_ is now being called all the time, the application will pop out of fullscreen mode immediately. This pull request simply removes the extra function call.

Regards,
   Atis
