### PR TITLE
A necessary switch to freeglut (multi-touch feature)

### DIFF
--- a/src/host-glut/GlutHost.cpp
+++ b/src/host-glut/GlutHost.cpp
@@ -53,7 +53,7 @@
 
 #ifdef _WIN32
 
-	#include <glut.h>
+	#include <freeglut.h>
 	
 	#if MOAI_WITH_FOLDER_WATCHER
 		#include <FolderWatcher-win.h>
@@ -89,6 +89,7 @@ namespace GlutInputDeviceSensorID {
 		MOUSE_LEFT,
 		MOUSE_MIDDLE,
 		MOUSE_RIGHT,
+		TOUCH,
 		TOTAL,
 	};
 }
@@ -206,6 +207,30 @@ static void _onMouseMove ( int x, int y ) {
 }
 
 //----------------------------------------------------------------//
+static void _onMultiButton( int touch_id, int x, int y, int button, int state ) {
+	AKUEnqueueTouchEvent (
+		GlutInputDeviceID::DEVICE,
+		GlutInputDeviceSensorID::TOUCH,
+		touch_id,
+		state == GLUT_DOWN,
+		(float)x,
+		(float)y
+	);
+}
+
+//----------------------------------------------------------------//
+static void _onMultiMotion( int touch_id, int x, int y ) {
+	AKUEnqueueTouchEvent (
+		GlutInputDeviceID::DEVICE,
+		GlutInputDeviceSensorID::TOUCH,
+		touch_id,
+		true,
+		(float)x,
+		(float)y
+	);
+}
+
+//----------------------------------------------------------------//
 static void _onPaint () {
 	
 	AKURender ();
@@ -319,6 +344,9 @@ void _AKUOpenWindowFunc ( const char* title, int width, int height ) {
 	glutMouseFunc ( _onMouseButton );
 	glutMotionFunc ( _onMouseDrag );
 	glutPassiveMotionFunc ( _onMouseMove );
+
+	glutMultiButtonFunc ( _onMultiButton );
+	glutMultiMotionFunc ( _onMultiMotion );
 	
 	glutDisplayFunc ( _onPaint );
 	glutReshapeFunc ( _onReshape );
@@ -499,6 +527,7 @@ void GlutRefreshContext () {
 	AKUSetInputDeviceButton			( GlutInputDeviceID::DEVICE, GlutInputDeviceSensorID::MOUSE_LEFT,	"mouseLeft" );
 	AKUSetInputDeviceButton			( GlutInputDeviceID::DEVICE, GlutInputDeviceSensorID::MOUSE_MIDDLE,	"mouseMiddle" );
 	AKUSetInputDeviceButton			( GlutInputDeviceID::DEVICE, GlutInputDeviceSensorID::MOUSE_RIGHT,	"mouseRight" );
+	AKUSetInputDeviceTouch			( GlutInputDeviceID::DEVICE, GlutInputDeviceSensorID::TOUCH,		"touch" );
 
 	AKUSetFunc_EnterFullscreenMode ( _AKUEnterFullscreenModeFunc );
 	AKUSetFunc_ExitFullscreenMode ( _AKUExitFullscreenModeFunc );


### PR DESCRIPTION
Moai uses GLUT which, according to the _freeglut_ web page http://freeglut.sourceforge.net/, has not been updated in over a decade. That, by itself, may not be reason enough to switch to freeglut. However, I believe there is a **real and immediate benefit** to doing so!

Not only is freeglut a drop-in replacement for GLUT, in its later releases it adds Windows **multi touch support** (WM_TOUCH). This is great news for those who happen to have a touch sensitive monitor under Windows (and possibly other desktop systems as well). One can then develop touch-enabled applications directly on the desktop (faster prototyping).

This pull request adds code to src/host-glut that employs freeglut's new multi-touch functionality. Switching all the project files properly from GLUT over to freeglut is beyond my competence, but code-wise nothing else needs to change: **freeglut just works**.

Regards,
Atis
