### PR TITLE
Invalid null check in JSON parser caused infinite loop when encoding lua...

### DIFF
--- a/src/moai-util/MOAIJsonParser.cpp
+++ b/src/moai-util/MOAIJsonParser.cpp
@@ -152,7 +152,7 @@ json_t* _luaToJSONArray ( lua_State* L, int idx ) {
 		json_t* value = _luaToJSON ( state, -1 );
 		lua_pop ( state, 1 );
 		
-		if ( value ) {
+		if ( value && value->type != JSON_NULL ) {
 			json_array_append_new ( arr, value );
 		}
 		else {


### PR DESCRIPTION
... numeric arrays. Warning! I have not tested this change on the current branch, so take it as you will.
