### PR TITLE
Updating android host to work after the reorg

### DIFF
--- a/3rdparty/contrib/whirlpool.c
+++ b/3rdparty/contrib/whirlpool.c
@@ -61,34 +61,6 @@
 #include <string.h>
 #include <time.h>
 
-#ifndef u8
-	typedef unsigned char u8;
-#endif
-
-#ifndef u16
-	typedef unsigned short u16;
-#endif
-
-#ifndef u32
-	typedef unsigned long u32;
-#endif
-
-#ifndef u64
-	typedef unsigned long long u64;
-#endif
-
-#ifndef s16
-	typedef signed short s16;
-#endif
-
-#ifndef s32
-	typedef signed long s32;
-#endif
-
-#ifndef s64
-	typedef signed long long s64;
-#endif
-
 #include "whirlpool.h"
 
 /* #define TRACE_INTERMEDIATE_VALUES */
@@ -105,7 +77,7 @@
  * employed).
  */
 
-static const u64 C0[256] = {
+static const wp_u64 C0[256] = {
     LL(0x18186018c07830d8), LL(0x23238c2305af4626), LL(0xc6c63fc67ef991b8), LL(0xe8e887e8136fcdfb),
     LL(0x878726874ca113cb), LL(0xb8b8dab8a9626d11), LL(0x0101040108050209), LL(0x4f4f214f426e9e0d),
     LL(0x3636d836adee6c9b), LL(0xa6a6a2a6590451ff), LL(0xd2d26fd2debdb90c), LL(0xf5f5f3f5fb06f70e),
@@ -172,7 +144,7 @@ static const u64 C0[256] = {
     LL(0x2828a0285d885075), LL(0x5c5c6d5cda31b886), LL(0xf8f8c7f8933fed6b), LL(0x8686228644a411c2),
 };
 
-static const u64 C1[256] = {
+static const wp_u64 C1[256] = {
     LL(0xd818186018c07830), LL(0x2623238c2305af46), LL(0xb8c6c63fc67ef991), LL(0xfbe8e887e8136fcd),
     LL(0xcb878726874ca113), LL(0x11b8b8dab8a9626d), LL(0x0901010401080502), LL(0x0d4f4f214f426e9e),
     LL(0x9b3636d836adee6c), LL(0xffa6a6a2a6590451), LL(0x0cd2d26fd2debdb9), LL(0x0ef5f5f3f5fb06f7),
@@ -239,7 +211,7 @@ static const u64 C1[256] = {
     LL(0x752828a0285d8850), LL(0x865c5c6d5cda31b8), LL(0x6bf8f8c7f8933fed), LL(0xc28686228644a411),
 };
 
-static const u64 C2[256] = {
+static const wp_u64 C2[256] = {
     LL(0x30d818186018c078), LL(0x462623238c2305af), LL(0x91b8c6c63fc67ef9), LL(0xcdfbe8e887e8136f),
     LL(0x13cb878726874ca1), LL(0x6d11b8b8dab8a962), LL(0x0209010104010805), LL(0x9e0d4f4f214f426e),
     LL(0x6c9b3636d836adee), LL(0x51ffa6a6a2a65904), LL(0xb90cd2d26fd2debd), LL(0xf70ef5f5f3f5fb06),
@@ -306,7 +278,7 @@ static const u64 C2[256] = {
     LL(0x50752828a0285d88), LL(0xb8865c5c6d5cda31), LL(0xed6bf8f8c7f8933f), LL(0x11c28686228644a4),
 };
 
-static const u64 C3[256] = {
+static const wp_u64 C3[256] = {
     LL(0x7830d818186018c0), LL(0xaf462623238c2305), LL(0xf991b8c6c63fc67e), LL(0x6fcdfbe8e887e813),
     LL(0xa113cb878726874c), LL(0x626d11b8b8dab8a9), LL(0x0502090101040108), LL(0x6e9e0d4f4f214f42),
     LL(0xee6c9b3636d836ad), LL(0x0451ffa6a6a2a659), LL(0xbdb90cd2d26fd2de), LL(0x06f70ef5f5f3f5fb),
@@ -373,7 +345,7 @@ static const u64 C3[256] = {
     LL(0x8850752828a0285d), LL(0x31b8865c5c6d5cda), LL(0x3fed6bf8f8c7f893), LL(0xa411c28686228644),
 };
 
-static const u64 C4[256] = {
+static const wp_u64 C4[256] = {
     LL(0xc07830d818186018), LL(0x05af462623238c23), LL(0x7ef991b8c6c63fc6), LL(0x136fcdfbe8e887e8),
     LL(0x4ca113cb87872687), LL(0xa9626d11b8b8dab8), LL(0x0805020901010401), LL(0x426e9e0d4f4f214f),
     LL(0xadee6c9b3636d836), LL(0x590451ffa6a6a2a6), LL(0xdebdb90cd2d26fd2), LL(0xfb06f70ef5f5f3f5),
@@ -440,7 +412,7 @@ static const u64 C4[256] = {
     LL(0x5d8850752828a028), LL(0xda31b8865c5c6d5c), LL(0x933fed6bf8f8c7f8), LL(0x44a411c286862286),
 };
 
-static const u64 C5[256] = {
+static const wp_u64 C5[256] = {
     LL(0x18c07830d8181860), LL(0x2305af462623238c), LL(0xc67ef991b8c6c63f), LL(0xe8136fcdfbe8e887),
     LL(0x874ca113cb878726), LL(0xb8a9626d11b8b8da), LL(0x0108050209010104), LL(0x4f426e9e0d4f4f21),
     LL(0x36adee6c9b3636d8), LL(0xa6590451ffa6a6a2), LL(0xd2debdb90cd2d26f), LL(0xf5fb06f70ef5f5f3),
@@ -507,7 +479,7 @@ static const u64 C5[256] = {
     LL(0x285d8850752828a0), LL(0x5cda31b8865c5c6d), LL(0xf8933fed6bf8f8c7), LL(0x8644a411c2868622),
 };
 
-static const u64 C6[256] = {
+static const wp_u64 C6[256] = {
     LL(0x6018c07830d81818), LL(0x8c2305af46262323), LL(0x3fc67ef991b8c6c6), LL(0x87e8136fcdfbe8e8),
     LL(0x26874ca113cb8787), LL(0xdab8a9626d11b8b8), LL(0x0401080502090101), LL(0x214f426e9e0d4f4f),
     LL(0xd836adee6c9b3636), LL(0xa2a6590451ffa6a6), LL(0x6fd2debdb90cd2d2), LL(0xf3f5fb06f70ef5f5),
@@ -574,7 +546,7 @@ static const u64 C6[256] = {
     LL(0xa0285d8850752828), LL(0x6d5cda31b8865c5c), LL(0xc7f8933fed6bf8f8), LL(0x228644a411c28686),
 };
 
-static const u64 C7[256] = {
+static const wp_u64 C7[256] = {
     LL(0x186018c07830d818), LL(0x238c2305af462623), LL(0xc63fc67ef991b8c6), LL(0xe887e8136fcdfbe8),
     LL(0x8726874ca113cb87), LL(0xb8dab8a9626d11b8), LL(0x0104010805020901), LL(0x4f214f426e9e0d4f),
     LL(0x36d836adee6c9b36), LL(0xa6a2a6590451ffa6), LL(0xd26fd2debdb90cd2), LL(0xf5f3f5fb06f70ef5),
@@ -641,7 +613,7 @@ static const u64 C7[256] = {
     LL(0x28a0285d88507528), LL(0x5c6d5cda31b8865c), LL(0xf8c7f8933fed6bf8), LL(0x86228644a411c286),
 };
 
-static const u64 rc[R + 1] = {
+static const wp_u64 rc[R + 1] = {
     LL(0x0000000000000000),
     LL(0x1823c6e887b8014f),
     LL(0x36a6d2f5796f9152),
@@ -660,25 +632,25 @@ static const u64 rc[R + 1] = {
  */
 static void processBuffer(struct Whirlpool * const structpointer) {
     int i, r;
-    u64 K[8];        /* the round key */
-    u64 block[8];    /* mu(buffer) */
-    u64 state[8];    /* the cipher state */
-    u64 L[8];
-    u8 *buffer = structpointer->buffer;
+    wp_u64 K[8];        /* the round key */
+    wp_u64 block[8];    /* mu(buffer) */
+    wp_u64 state[8];    /* the cipher state */
+    wp_u64 L[8];
+    wp_u8 *buffer = structpointer->buffer;
 
     /*
      * map the buffer to a block:
      */
     for (i = 0; i < 8; i++, buffer += 8) {
         block[i] =
-            (((u64)buffer[0]        ) << 56) ^
-            (((u64)buffer[1] & 0xffL) << 48) ^
-            (((u64)buffer[2] & 0xffL) << 40) ^
-            (((u64)buffer[3] & 0xffL) << 32) ^
-            (((u64)buffer[4] & 0xffL) << 24) ^
-            (((u64)buffer[5] & 0xffL) << 16) ^
-            (((u64)buffer[6] & 0xffL) <<  8) ^
-            (((u64)buffer[7] & 0xffL)      );
+            (((wp_u64)buffer[0]        ) << 56) ^
+            (((wp_u64)buffer[1] & 0xffL) << 48) ^
+            (((wp_u64)buffer[2] & 0xffL) << 40) ^
+            (((wp_u64)buffer[3] & 0xffL) << 32) ^
+            (((wp_u64)buffer[4] & 0xffL) << 24) ^
+            (((wp_u64)buffer[5] & 0xffL) << 16) ^
+            (((wp_u64)buffer[6] & 0xffL) <<  8) ^
+            (((wp_u64)buffer[7] & 0xffL)      );
     }
     /*
      * compute and apply K^0 to the cipher state:
@@ -922,23 +894,23 @@ void Whirlpool_Add(const unsigned char * const source,
                     |
                     bufferPos
     */
-    int sourcePos    = 0; /* index of leftmost source u8 containing data (1 to 8 bits). */
+    int sourcePos    = 0; /* index of leftmost source wp_u8 containing data (1 to 8 bits). */
     int sourceGap    = (8 - ((int)sourceBits & 7)) & 7; /* space on source[sourcePos]. */
     int bufferRem    = structpointer->bufferBits & 7; /* occupied bits on buffer[bufferPos]. */
     int i;
-    u32 b, carry;
-    u8 *buffer       = structpointer->buffer;
-    u8 *bitLength    = structpointer->bitLength;
+    wp_u32 b, carry;
+    wp_u8 *buffer       = structpointer->buffer;
+    wp_u8 *bitLength    = structpointer->bitLength;
     int bufferBits   = structpointer->bufferBits;
     int bufferPos    = structpointer->bufferPos;
 
     /*
      * tally the length of the added data:
      */
-    u64 value = sourceBits;
+    wp_u64 value = sourceBits;
     for (i = 31, carry = 0; i >= 0 && (carry != 0 || value != LL(0)); i--) {
-        carry += bitLength[i] + ((u32)value & 0xff);
-        bitLength[i] = (u8)carry;
+        carry += bitLength[i] + ((wp_u32)value & 0xff);
+        bitLength[i] = (wp_u8)carry;
         carry >>= 8;
         value >>= 8;
     }
@@ -955,7 +927,7 @@ void Whirlpool_Add(const unsigned char * const source,
         /*
          * process this byte:
          */
-        buffer[bufferPos++] |= (u8)(b >> bufferRem);
+        buffer[bufferPos++] |= (wp_u8)(b >> bufferRem);
         bufferBits += 8 - bufferRem; /* bufferBits = 8*bufferPos; */
         if (bufferBits == DIGESTBITS) {
             /*
@@ -967,7 +939,7 @@ void Whirlpool_Add(const unsigned char * const source,
              */
             bufferBits = bufferPos = 0;
         }
-        buffer[bufferPos] = ( u8 )( b << (8 - bufferRem));
+        buffer[bufferPos] = ( wp_u8 )( b << (8 - bufferRem));
         bufferBits += bufferRem;
         /*
          * proceed to remaining data:
@@ -1013,7 +985,7 @@ void Whirlpool_Add(const unsigned char * const source,
              */
             bufferBits = bufferPos = 0;
         }
-        buffer[bufferPos] = ( u8 )( b << (8 - bufferRem));
+        buffer[bufferPos] = ( wp_u8 )( b << (8 - bufferRem));
         bufferBits += (int)sourceBits;
     }
     structpointer->bufferBits   = bufferBits;
@@ -1028,17 +1000,17 @@ void Whirlpool_Add(const unsigned char * const source,
 void Whirlpool_Finalize(struct Whirlpool * const structpointer,
                     unsigned char * const result) {
     int i;
-    u8 *buffer      = structpointer->buffer;
-    u8 *bitLength   = structpointer->bitLength;
+    wp_u8 *buffer      = structpointer->buffer;
+    wp_u8 *bitLength   = structpointer->bitLength;
     int bufferBits  = structpointer->bufferBits;
     int bufferPos   = structpointer->bufferPos;
-    u8 *digest      = result;
+    wp_u8 *digest      = result;
 
     /*
      * append a '1'-bit:
      */
     buffer[bufferPos] |= 0x80U >> (bufferBits & 7);
-    bufferPos++; /* all remaining bits on the current u8 are set to zero. */
+    bufferPos++; /* all remaining bits on the current wp_u8 are set to zero. */
     /*
      * pad with zero bits to complete (N*WBLOCKBITS - LENGTHBITS) bits:
      */
@@ -1071,14 +1043,14 @@ void Whirlpool_Finalize(struct Whirlpool * const structpointer,
      * return the completed message digest:
      */
     for (i = 0; i < DIGESTBYTES/8; i++) {
-        digest[0] = (u8)(structpointer->hash[i] >> 56);
-        digest[1] = (u8)(structpointer->hash[i] >> 48);
-        digest[2] = (u8)(structpointer->hash[i] >> 40);
-        digest[3] = (u8)(structpointer->hash[i] >> 32);
-        digest[4] = (u8)(structpointer->hash[i] >> 24);
-        digest[5] = (u8)(structpointer->hash[i] >> 16);
-        digest[6] = (u8)(structpointer->hash[i] >>  8);
-        digest[7] = (u8)(structpointer->hash[i]      );
+        digest[0] = (wp_u8)(structpointer->hash[i] >> 56);
+        digest[1] = (wp_u8)(structpointer->hash[i] >> 48);
+        digest[2] = (wp_u8)(structpointer->hash[i] >> 40);
+        digest[3] = (wp_u8)(structpointer->hash[i] >> 32);
+        digest[4] = (wp_u8)(structpointer->hash[i] >> 24);
+        digest[5] = (wp_u8)(structpointer->hash[i] >> 16);
+        digest[6] = (wp_u8)(structpointer->hash[i] >>  8);
+        digest[7] = (wp_u8)(structpointer->hash[i]      );
         digest += 8;
     }
     structpointer->bufferBits   = bufferBits;

--- a/3rdparty/contrib/whirlpool.h
+++ b/3rdparty/contrib/whirlpool.h
@@ -5,12 +5,12 @@
 #include <limits.h>
 
 /* Definition of minimum-width integer types
- * 
- * u8   -> unsigned integer type, at least 8 bits, equivalent to unsigned char
- * u16  -> unsigned integer type, at least 16 bits
- * u32  -> unsigned integer type, at least 32 bits
  *
- * s8, s16, s32  -> signed counterparts of u8, u16, u32
+ * wp_u8   -> unsigned integer type, at least 8 bits, equivalent to unsigned char
+ * wp_u16  -> unsigned integer type, at least 16 bits
+ * wp_u32  -> unsigned integer type, at least 32 bits
+ *
+ * wp_s8, wp_s16, wp_s32  -> signed counterparts of wp_u8, wp_u16, wp_u32
  *
  * Always use macro's T8(), T16() or T32() to obtain exact-width results,
  * i.e., to specify the size of the result of each expression.
@@ -52,25 +52,25 @@
  * U8TO32_BIG(c) returns the 32-bit value stored in big-endian convention
  * in the unsigned char array pointed to by c.
  */
-#define U8TO32_BIG(c)  (((u32)T8(*(c)) << 24) | ((u32)T8(*((c) + 1)) << 16) | ((u32)T8(*((c) + 2)) << 8) | ((u32)T8(*((c) + 3))))
+#define U8TO32_BIG(c)  (((wp_u32)T8(*(c)) << 24) | ((wp_u32)T8(*((c) + 1)) << 16) | ((wp_u32)T8(*((c) + 2)) << 8) | ((wp_u32)T8(*((c) + 3))))
 
 /*
  * U8TO32_LITTLE(c) returns the 32-bit value stored in little-endian convention
  * in the unsigned char array pointed to by c.
  */
-#define U8TO32_LITTLE(c)  (((u32)T8(*(c))) | ((u32)T8(*((c) + 1)) << 8) | (u32)T8(*((c) + 2)) << 16) | ((u32)T8(*((c) + 3)) << 24))
+#define U8TO32_LITTLE(c)  (((wp_u32)T8(*(c))) | ((wp_u32)T8(*((c) + 1)) << 8) | (wp_u32)T8(*((c) + 2)) << 16) | ((wp_u32)T8(*((c) + 3)) << 24))
 
 /*
  * U8TO32_BIG(c, v) stores the 32-bit-value v in big-endian convention
  * into the unsigned char array pointed to by c.
  */
-#define U32TO8_BIG(c, v)    do { u32 x = (v); u8 *d = (c); d[0] = T8(x >> 24); d[1] = T8(x >> 16); d[2] = T8(x >> 8); d[3] = T8(x); } while (0)
+#define U32TO8_BIG(c, v)    do { wp_u32 x = (v); wp_u8 *d = (c); d[0] = T8(x >> 24); d[1] = T8(x >> 16); d[2] = T8(x >> 8); d[3] = T8(x); } while (0)
 
 /*
  * U8TO32_LITTLE(c, v) stores the 32-bit-value v in little-endian convention
  * into the unsigned char array pointed to by c.
  */
-#define U32TO8_LITTLE(c, v)    do { u32 x = (v); u8 *d = (c); d[0] = T8(x); d[1] = T8(x >> 8); d[2] = T8(x >> 16); d[3] = T8(x >> 24); } while (0)
+#define U32TO8_LITTLE(c, v)    do { wp_u32 x = (v); wp_u8 *d = (c); d[0] = T8(x); d[1] = T8(x >> 8); d[2] = T8(x >> 16); d[3] = T8(x >> 24); } while (0)
 
 /*
  * ROTL32(v, n) returns the value of the 32-bit unsigned value v after
@@ -97,12 +97,20 @@
 #define LENGTHBYTES 32
 #define LENGTHBITS  (8*LENGTHBYTES) /* 256 */
 
+typedef unsigned char wp_u8;
+typedef unsigned short wp_u16;
+typedef unsigned long wp_u32;
+typedef unsigned long long wp_u64;
+typedef signed short wp_s16;
+typedef signed long wp_s32;
+typedef signed long long wp_s64;
+
 typedef struct Whirlpool {
-	u8  bitLength[LENGTHBYTES];	/* global number of hashed bits (256-bit counter) */
-	u8  buffer[WBLOCKBYTES];		/* buffer of data to hash */
+	wp_u8  bitLength[LENGTHBYTES];	/* global number of hashed bits (256-bit counter) */
+	wp_u8  buffer[WBLOCKBYTES];		/* buffer of data to hash */
 	int bufferBits;					/* current number of bits on the buffer */
 	int bufferPos;					/* current (possibly incomplete) byte slot on the buffer */
-	u64 hash[DIGESTBYTES/8];		/* the hashing state */
+	wp_u64 hash[DIGESTBYTES/8];		/* the hashing state */
 } Whirlpool;
 
 void Whirlpool_Add(const unsigned char * const source, unsigned long sourceBits, struct Whirlpool * const structpointer);

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -155,6 +155,9 @@ public class Moai {
 	protected static native void 	AKUFinalize 					();
 	protected static native void 	AKUFMODExInit		 			();
 	protected static native void 	AKUInit 						();
+	protected static native void 	AKUInitializeUtil 				();
+	protected static native void 	AKUInitializeSim 				();
+	protected static native void 	AKUInitializeHttpClient 		();
 	protected static native void 	AKUMountVirtualDirectory 		( String virtualPath, String archive );
 	protected static native void 	AKUPause 						( boolean paused );
 	protected static native void 	AKURender	 					();
@@ -288,6 +291,11 @@ public class Moai {
 	public static void init () {
 		
 		synchronized ( sAkuLock ) {
+           
+            AKUInitializeUtil ();
+            AKUInitializeSim ();
+            AKUInitializeHttpClient ();
+
 
 			AKUSetInputConfigurationName 	( "Android" );
 

--- a/ant/libmoai/jni/Android.mk
+++ b/ant/libmoai/jni/Android.mk
@@ -57,9 +57,11 @@
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/config-default
-	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/moaicore
-	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/uslscore
-	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/zlcore
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/moai-core
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/zl-common
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/zl-gfx
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/zl-util
+	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/src/zl-vfs
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/box2d-2.2.1/
 	MY_HEADER_SEARCH_PATHS += $(MY_MOAI_ROOT)/3rdparty/box2d-2.2.1/Box2D
@@ -130,6 +132,7 @@
 #----------------------------------------------------------------#
 
 	LOCAL_STATIC_LIBRARIES += libmoaicore
+	LOCAL_STATIC_LIBRARIES += libzlcore
 	
 	LOCAL_STATIC_LIBRARIES += libmoaiext-android
 	LOCAL_STATIC_LIBRARIES += libmoaiext-luaext
@@ -159,8 +162,7 @@
 	LOCAL_STATIC_LIBRARIES += libsqlite
 	LOCAL_STATIC_LIBRARIES += libssl
 	LOCAL_STATIC_LIBRARIES += libtinyxml
-	LOCAL_STATIC_LIBRARIES += libzlcore
-
+	
 	include $(BUILD_SHARED_LIBRARY)
 
 #----------------------------------------------------------------#
@@ -198,4 +200,3 @@
 	include zlcore/Android.mk
 
 	include moaicore/Android.mk
-	include uslscore/Android.mk

--- a/ant/libmoai/jni/contrib/Android.mk
+++ b/ant/libmoai/jni/contrib/Android.mk
@@ -12,7 +12,7 @@
 
 	LOCAL_C_INCLUDES 	:= $(MY_HEADER_SEARCH_PATHS)
 	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/contrib/utf8.c
-#	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/contrib/whirlpool.c
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/3rdparty/contrib/whirlpool.c
 
 	include $(BUILD_STATIC_LIBRARY)
  

--- a/ant/libmoai/jni/src/moai.cpp
+++ b/ant/libmoai/jni/src/moai.cpp
@@ -16,6 +16,8 @@
 #include <moai-core/host.h>
 #include <moai-sim/headers.h>
 #include <moai-sim/host.h>
+#include <moai-util/host.h>
+#include <moai-http-client/host.h>
 #include <moai-luaext/host.h>
 
 #ifdef USE_FMOD
@@ -341,6 +343,21 @@
 
 		inputQueue = new LockingQueue < InputEvent > ();
 	}
+
+	//----------------------------------------------------------------//
+	extern "C" void Java_com_ziplinegames_moai_Moai_AKUInitializeUtil ( JNIEnv* env, jclass obj ) {
+        AKUInitializeUtil ();
+    }
+
+    //----------------------------------------------------------------//
+	extern "C" void Java_com_ziplinegames_moai_Moai_AKUInitializeSim ( JNIEnv* env, jclass obj ) {
+        AKUInitializeSim ();
+    }
+
+    //----------------------------------------------------------------//
+	extern "C" void Java_com_ziplinegames_moai_Moai_AKUInitializeHttpClient ( JNIEnv* env, jclass obj ) {
+        AKUInitializeHttpClient ();
+    }
 
 	//----------------------------------------------------------------//
 	extern "C" void Java_com_ziplinegames_moai_Moai_AKUMountVirtualDirectory ( JNIEnv* env, jclass obj, jstring jvirtualPath, jstring jarchive ) {

--- a/src/moai-sim/MOAIGfxDevice.cpp
+++ b/src/moai-sim/MOAIGfxDevice.cpp
@@ -547,7 +547,7 @@ MOAIGfxDevice::MOAIGfxDevice () :
 	mCpuUVTransform ( false ),
 	mHasContext ( false ),
 	mIsFramebufferSupported ( 0 ),
-#if defined ( MOAI_OS_NACL ) || defined ( MOAI_OS_IPHONE )
+#if defined ( MOAI_OS_NACL ) || defined ( MOAI_OS_IPHONE ) || defined ( MOAI_OS_ANDROID )
 	mIsOpenGLES ( true ),
 #else
 	mIsOpenGLES ( false ),


### PR DESCRIPTION
The android host was broken after the reorg and was never updated to
fix this.  In the main Android.mk, removed unused uscore, reordered the
static_libs to fix some linking errors with zl and whirlpool.  Also had
to change the typedefs in whirlpool to fix a type conflict with zltypes.

Modified the android host to add similar initializations as the ios
host that are required after the reorg.  Also, something was broken in
MOAIGfxDevice which didn't categorize Android as an OpenGL ES host
which would cause only a black screen to be displayed.

Left to do:  Android host printing is still broken due to some linking
problems.  I may take a look into that next.
