### PR TITLE
Avoid (some) Lua stack overflows

### DIFF
--- a/src/moai-sim/MOAIPartitionResultBuffer.cpp
+++ b/src/moai-sim/MOAIPartitionResultBuffer.cpp
@@ -197,7 +197,12 @@ void MOAIPartitionResultBuffer::PushProps ( lua_State* L ) {
 	MOAILuaState state ( L );
 
 	u32 total = this->mTotalResults;
-	
+
+	// make sure there is enough stack space to push all props
+	// the +1 is needed because pushing a prop requires an
+	// additional value to be pushed onto the stack temporarily
+	lua_checkstack( L, total + 1 );
+
 	for ( u32 i = 0; i < total; ++i ) {
 		this->mResults [ i ].mProp->PushLuaUserdata ( state );
    }

--- a/src/moai-sim/MOAIPathTerrainDeck.cpp
+++ b/src/moai-sim/MOAIPathTerrainDeck.cpp
@@ -40,13 +40,15 @@ int MOAIPathTerrainDeck::_getTerrainVec ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIPathTerrainDeck, "UN" )
 	
 	u32 idx = state.GetValue < u32 >( 2, 1 ) - 1;
+	float* vector = self->GetVector ( idx + 1 );
+
+	u32 size = self->mVectorSize;
+	lua_checkstack( L, size );
 	
-	float* vector = self->GetVector ( idx + 1 ); 
-	
-	for ( u32 i = 0; i < self->mVectorSize; ++i ) {
+	for ( u32 i = 0; i < size; ++i ) {
 		lua_pushnumber ( state, vector [ i ]);
 	}
-	return self->mVectorSize;
+	return size;
 }
 
 //----------------------------------------------------------------//

--- a/src/moai-sim/MOAITouchSensor.cpp
+++ b/src/moai-sim/MOAITouchSensor.cpp
@@ -43,10 +43,13 @@ int MOAITouchSensor::_down ( lua_State* L ) {
 int MOAITouchSensor::_getActiveTouches ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAITouchSensor, "U" )
 	
-	for ( u32 i = 0; i < self->mTop; ++i ) {
+	u32 count = self->mTop;
+	lua_checkstack( L, count );
+	
+	for ( u32 i = 0; i < count; ++i ) {
 		lua_pushnumber ( state, self->mActiveStack [ i ]);
 	}
-	return self->mTop;
+	return count;
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
[According to the Lua manual](http://www.lua.org/manual/5.1/manual.html#3.2), _"you are responsible for controlling stack overflow"_, especially when pushing elements onto the stack in a loop. A sufficient stack size can be ensured by calling `lua_checkstack()`. Pushing too many elements onto the stack does not crash immediately, but will corrupt the heap, potentially causing random crashes later. See [this forum post](http://getmoai.com/forums/post7274.html) for two examples of intermittent random crashes.

I added `lua_checkstack()` calls for the following methods:
- `MOAIPartitionResultBuffer::PushProps()`
- `MOAIPathTerrainDeck:getTerrainVec()`
- `MOAITouchSensor:getActiveTouches()`

The following methods can also cause Lua stack overflows, unfortunately these are a bit more tricky to fix:
- `MOAIStream:readFormat()`
- `MOAIXmlParser::Parse()`
