### PR TITLE
Fixing IOS sendMail functionality

### DIFF
--- a/src/moai-iphone/MOAIAppIOS.mm
+++ b/src/moai-iphone/MOAIAppIOS.mm
@@ -147,17 +147,17 @@ int MOAIAppIOS::_sendMail ( lua_State* L ) {
 	MOAILuaState state ( L );
 	
 	cc8* recipient = state.GetValue < cc8* >( 1, "" );
-	cc8* subject = state.GetValue < cc8* >( 1, "" );
-	cc8* message = state.GetValue < cc8* >( 1, "" );
+	cc8* subject = state.GetValue < cc8* >( 2, "" );
+	cc8* message = state.GetValue < cc8* >( 3, "" );
 	
 	MFMailComposeViewController* controller = [[ MFMailComposeViewController alloc ] init ];
 	controller.mailComposeDelegate = MOAIAppIOS::Get ().mMailDelegate;
 	
-	NSArray* to = [[ NSArray alloc ] arrayByAddingObject:[[ NSString alloc ] initWithUTF8String:recipient ]];
+	NSArray* to = [ NSArray arrayWithObject:[ NSString  stringWithUTF8String:recipient ]];
 	
 	[ controller setToRecipients:to ];
-	[ controller setSubject:[[ NSString alloc ] initWithUTF8String:subject ]];
-	[ controller setMessageBody:[[ NSString alloc ] initWithUTF8String:message ] isHTML:NO ]; 
+	[ controller setSubject:[ NSString stringWithUTF8String:subject ]];
+	[ controller setMessageBody:[ NSString stringWithUTF8String:message ] isHTML:NO ]; 
 	
 	if (controller) {
 				


### PR DESCRIPTION
The arguments are being pulled from the wrong indexes.  Also fixing some leaked objects by using autoreleased objects.
