### PR TITLE
Allowing parameters to be passed to facebook graph requests.

### DIFF
--- a/ant/libmoai/jni/moaiext-android/Android.mk
+++ b/ant/libmoai/jni/moaiext-android/Android.mk
@@ -29,5 +29,6 @@
 	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/src/moai-android/MOAITwitterAndroid.cpp
 	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/src/moai-android/MOAITstoreWallAndroid.cpp
 	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/src/moai-android/MOAITstoreGamecenterAndroid.cpp
+	LOCAL_SRC_FILES 	+= $(MY_MOAI_ROOT)/src/moai-android/JniUtils.cpp
 
 	include $(BUILD_STATIC_LIBRARY)

--- a/src/moai-android/JniUtils.cpp
+++ b/src/moai-android/JniUtils.cpp
@@ -1,0 +1,115 @@
+#include <moai-android/JniUtils.h>
+
+#include "moai-core/pch.h"
+#include "moai-sim/pch.h"
+
+extern JavaVM* jvm;
+
+/**
+ * Create a jobjectArray from the Lua stack
+ * @param lua_state The lua Stack
+ * @param index The index to convert
+ */
+jobjectArray JniUtils::arrayFromLua ( lua_State* L, int index ) {
+    MOAILuaState state ( L );
+	JNI_GET_ENV ( jvm, env );
+
+    int numEntries = 0;
+    for ( int key = 1; ; ++key ) {
+        state.GetField ( 1, key );
+        cc8* value = JniUtils::parseLuaTable ( state, -1 );
+        lua_pop ( state, 1 );
+
+        if ( !value ) {
+            numEntries = key - 1;
+            break;
+        }
+    }
+
+    jobjectArray array = env->NewObjectArray ( numEntries, env->FindClass( "java/lang/String" ), 0 );
+    for ( int key = 1; ; ++key ) {
+
+        state.GetField ( 1, key );
+        cc8* value = JniUtils::parseLuaTable ( state, -1 );
+        lua_pop ( state, 1 );
+
+        if ( value ) {
+            JNI_GET_JSTRING ( value, jvalue );
+            env->SetObjectArrayElement ( array, key - 1, jvalue );
+        }
+        else {
+            break;
+        }
+    }
+    return array;
+}
+
+/**
+ * Create Android Bundle from the Lua stack
+ * @param L The Lua stack
+ * @param The index to convert
+ */
+jobject JniUtils::bundleFromLua ( lua_State* L, int index ) {
+    MOAILuaState state ( L );
+	JNI_GET_ENV ( jvm, env );
+
+    STLString className = "android.os.Bundle";
+    jobject bundle = JniUtils::createObjectOfClass( className );
+    jmethodID put = JniUtils::getMethod( className, "putString", "(Ljava/lang/String;Ljava/lang/String;)V" );
+
+    // table is in the stack at index 'index'
+    lua_pushnil ( state );  // first key
+    while ( lua_next ( state, index ) != 0 ) {
+        // use the 'key' (at index -2) and 'value' (at index -1)
+        cc8* key = lua_tostring( state, -2 );
+
+        if( key != NULL ) {
+            cc8* value = lua_tostring( state, -1 );
+            if ( value != NULL ) {
+                JNI_GET_JSTRING ( key, jkey );
+                JNI_GET_JSTRING ( value, jvalue );
+
+                env->CallObjectMethod( bundle, put, jkey, jvalue );
+            }
+        }
+
+        // removes 'value'; keeps 'key' for next iteration
+        lua_pop ( state, 1 );
+    }
+
+    return bundle;
+}
+
+/**
+ * Create an object of the provided class type.  The class must have a default constructor.
+ * @param className The name of the class to create an instance of
+ */
+jobject JniUtils::createObjectOfClass ( STLString className ) {
+	JNI_GET_ENV ( jvm, env );
+    jclass Class = env->FindClass(className);
+    jmethodID constructor = env->GetMethodID(Class, "<init>", "()V");
+    return env->NewObject(Class, constructor);
+}
+
+/**
+ * Get the method of the provided signature for the provided class.
+ * @param className The name of the class that has the method
+ * @param methodName The name of the method
+ * @param methodSignature The JNI mehtod signature of the method.
+ */
+jmethodID JniUtils::getMethod ( STLString className, STLString methodName, STLString methodSignature ) {
+	JNI_GET_ENV ( jvm, env );
+    jclass Class = env->FindClass(className);
+    return env->GetMethodID(Class, methodName, methodSignature);
+}
+
+cc8* JniUtils::parseLuaTable ( lua_State* L, int idx ) {
+	switch ( lua_type ( L, idx )) {
+		case LUA_TSTRING: {
+			cc8* str = lua_tostring ( L, idx );
+			return str;
+		}
+	}
+
+	return NULL;
+}

--- a/src/moai-android/JniUtils.h
+++ b/src/moai-android/JniUtils.h
@@ -1,0 +1,18 @@
+#include "moai-core/pch.h"
+#include "moai-sim/pch.h"
+
+#include <jni.h>
+
+#include <moai-android/moaiext-jni.h>
+
+/**
+ * Provides utility methods for dealing with the JNI.
+ */
+class JniUtils {
+public:
+    static jobjectArray arrayFromLua ( lua_State* L, int index );
+    static jobject bundleFromLua ( lua_State* L, int index );
+    static jobject createObjectOfClass ( STLString type );
+    static jmethodID getMethod ( STLString className, STLString methodName, STLString methodSignature );
+    static cc8* parseLuaTable ( lua_State* L, int idx );
+};

--- a/src/moai-android/MOAIFacebookAndroid.h
+++ b/src/moai-android/MOAIFacebookAndroid.h
@@ -14,13 +14,15 @@
 /**	@name	MOAIFacebookAndroid
 	@text	Wrapper for Facebook integration on Android devices.
 			Facebook provides social integration for sharing on
-			www.facebook.com. Exposed to lua via MOAIFacebook on 
+			www.facebook.com. Exposed to lua via MOAIFacebook on
 			all mobile platforms.
 
 	@const	DIALOG_DID_COMPLETE			Event code for a successfully completed Facebook dialog.
 	@const	DIALOG_DID_NOT_COMPLETE		Event code for a failed (or canceled) Facebook dialog.
 	@const	SESSION_DID_LOGIN			Event code for a successfully completed Facebook login.
 	@const	SESSION_DID_NOT_LOGIN		Event code for a failed (or canceled) Facebook login.
+	@const	REQUEST_RESPONSE			Event code for graph request responses.
+	@const	REQUEST_RESPONSE_FAILED		Event code for failed graph request responses.
 */
 class MOAIFacebookAndroid :
 	public MOAIGlobalClass < MOAIFacebookAndroid, MOAILuaObject > {
@@ -28,13 +30,12 @@ private:
 
 	//----------------------------------------------------------------//
 	static int	_extendToken	( lua_State* L );
-	static int	_getExpirationDate	( lua_State* L );	
+	static int	_getExpirationDate	( lua_State* L );
 	static int	_getToken		( lua_State* L );
 	static int	_graphRequest	( lua_State* L );
 	static int	_init			( lua_State* L );
 	static int	_login			( lua_State* L );
 	static int	_logout			( lua_State* L );
-	static cc8*	_luaParseTable 	( lua_State* L, int idx );
 	static int	_postToFeed		( lua_State* L );
 	static int	_sendRequest	( lua_State* L );
 	static int	_sessionValid	( lua_State* L );
@@ -42,7 +43,7 @@ private:
 	static int	_setExpirationDate	( lua_State* L );
 	static int	_setToken	 	( lua_State* L );
 
-public:	
+public:
 
 	DECL_LUA_SINGLETON ( MOAIFacebookAndroid );
 
@@ -51,21 +52,25 @@ public:
 		DIALOG_DID_NOT_COMPLETE,
 		SESSION_DID_LOGIN,
 		SESSION_DID_NOT_LOGIN,
+        REQUEST_RESPONSE,
+		REQUEST_RESPONSE_FAILED,
 		TOTAL,
 	};
-	
+
 	enum {
         DIALOG_RESULT_SUCCESS,
         DIALOG_RESULT_CANCEL,
         DIALOG_RESULT_ERROR,
 	};
-		
+
 	MOAILuaRef		mListeners [ TOTAL ];
-	
+
 			MOAIFacebookAndroid		();
 			~MOAIFacebookAndroid	();
 	void 	NotifyLoginComplete		( int code );
 	void 	NotifyDialogComplete	( int code );
+	void 	NotifyRequestComplete	( cc8* result );
+	void 	NotifyRequestFailed	    ();
 	void	RegisterLuaClass		( MOAILuaState& state );
 };
 

--- a/src/moai-iphone/MOAIFacebookIOS.h
+++ b/src/moai-iphone/MOAIFacebookIOS.h
@@ -32,6 +32,8 @@
 	@const	DIALOG_DID_NOT_COMPLETE		Event code for a failed (or canceled) Facebook dialog.
 	@const	SESSION_DID_LOGIN			Event code for a successfully completed Facebook login.
 	@const	SESSION_DID_NOT_LOGIN		Event code for a failed (or canceled) Facebook login.
+	@const	REQUEST_RESPONSE			Event code for graph request responses.
+	@const	REQUEST_RESPONSE_FAILED		Event code for failed graph request responses.
 */
 class MOAIFacebookIOS :
 	public MOAIGlobalClass < MOAIFacebookIOS, MOAILuaObject >,
@@ -69,22 +71,24 @@ public:
 		DIALOG_DID_COMPLETE,
 		DIALOG_DID_NOT_COMPLETE,
 		REQUEST_RESPONSE,
+		REQUEST_RESPONSE_FAILED,
 		SESSION_DID_LOGIN,
 		SESSION_DID_NOT_LOGIN,
 		SESSION_EXTENDED
 	};
 		
-    		MOAIFacebookIOS			();
-			~MOAIFacebookIOS		();
-	void	DialogDidNotComplete	();
-	void	DialogDidComplete		();
-	void	HandleOpenURL			( NSURL* url );
-	void	RegisterLuaClass		( MOAILuaState& state );
-	void	ReceivedRequestResponse	( cc8* response );
-	void	ReceivedRequestResponse	( NSData * response );
-	void	SessionDidLogin			();
-	void	SessionDidNotLogin		();
-	void	SessionExtended			( cc8* token, cc8* expDate );
+    		MOAIFacebookIOS			        ();
+			~MOAIFacebookIOS		        ();
+	void	DialogDidNotComplete	        ();
+	void	DialogDidComplete		        ();
+	void	HandleOpenURL			        ( NSURL* url );
+	void	RegisterLuaClass		        ( MOAILuaState& state );
+	void	ReceivedRequestResponse	        ( cc8* response );
+	void	ReceivedRequestResponse	        ( NSData * response );
+	void	ReceivedRequestResponseFailure	();
+	void	SessionDidLogin			        ();
+	void	SessionDidNotLogin		        ();
+	void	SessionExtended			        ( cc8* token, cc8* expDate );
 };
 
 //================================================================//


### PR DESCRIPTION
*Allows parameters in IOS and Android facebook graph requests.
*Modified Android graphRequest to be asynchronous, like the IOS verison.
*Fixed a null pointer issue in IOS facebook getSession
*Adding REQUEST_RESPONSE_FAILED call back for graph requests.
*Updating doc comments.
*Adding JniUtils for common JNI operations.

In the future I'd like to see a means of passing what request the call
back is for as well as more information about errors that occured.
