### PR TITLE
Fix MOAITimer.EVENT_STOP

### DIFF
--- a/src/moai-sim/MOAIAction.h
+++ b/src/moai-sim/MOAIAction.h
@@ -5,6 +5,7 @@
 #define	MOAIACTION_H
 
 #include <moai-sim/MOAIBlocker.h>
+#include <moai-sim/MOAINode.h>
 
 //================================================================//
 // MOAIAction
@@ -67,7 +68,7 @@ public:
 	DECL_LUA_FACTORY ( MOAIAction )
 	
 	enum {
-		EVENT_STOP,
+		EVENT_STOP = MOAINode::TOTAL_EVENTS,
 		TOTAL_EVENTS,
 	};
 	


### PR DESCRIPTION
The new `MOAINode::EVENT_UPDATE` (enum value 0) collided with `MOAIAction::EVENT_STOP` (also enum value 0) in `MOAITimer`, which is derived from both Node and Action. As a result, `EVENT_STOP` was triggered every frame.

Fixed by starting `MOAIAction` events at `MOAINode::TOTAL_EVENTS`, similar to `MOAITimer` events starting at `MOAIAction::TOTAL_EVENTS`.
