### PR TITLE
Fix Compilation of some iOS Extensions

### DIFF
--- a/src/moai-iphone/MOAIAdColonyIOS.mm
+++ b/src/moai-iphone/MOAIAdColonyIOS.mm
@@ -143,7 +143,7 @@ int MOAIAdColonyIOS::_videoReadyForZone ( lua_State *L ) {
 //----------------------------------------------------------------//
 void MOAIAdColonyIOS::NotifyTakeoverEventOccurred ( int event, cc8* zone ) {
 	
-	MOAILuaStateHandle state = MOAILuaRuntime::Get ().State ();
+	MOAIScopedLuaState state = MOAILuaRuntime::Get ().State ();
 	
 	if ( this->PushListener ( event, state )) {
 		

--- a/src/moai-iphone/MOAIChartBoostIOS.mm
+++ b/src/moai-iphone/MOAIChartBoostIOS.mm
@@ -176,7 +176,7 @@ void MOAIChartBoostIOS::NotifyInterstitialDismissed () {
 	
 	if ( callback ) {
 		
-		MOAILuaStateHandle state = callback.GetSelf ();
+		MOAIScopedLuaState state = callback.GetSelf ();
 		
 		state.DebugCall ( 0, 0 );
 	}
@@ -189,7 +189,7 @@ void MOAIChartBoostIOS::NotifyInterstitialLoadFailed () {
 	
 	if ( callback ) {
 		
-		MOAILuaStateHandle state = callback.GetSelf ();
+		MOAIScopedLuaState state = callback.GetSelf ();
 		
 		state.DebugCall ( 0, 0 );
 	}

--- a/src/moai-iphone/MOAIVungleIOS.mm
+++ b/src/moai-iphone/MOAIVungleIOS.mm
@@ -207,7 +207,7 @@ void MOAIVungleIOS::NotifyMoviePlayed ( bool playedFull ) {
 	
 	if ( callback ) {
 		
-		MOAILuaStateHandle state = callback.GetSelf ();
+		MOAIScopedLuaState state = callback.GetSelf ();
 		
 		lua_pushboolean ( state, playedFull );
 		


### PR DESCRIPTION
These extensions weren't updated when `MOAILuaStateHandle` was renamed to `MOAIScopedLuaState` in changeset 39eba52567b652f9af7f962743d5fd8bee037ce9.
