### PR TITLE
Fix PVR Texture Support

### DIFF
--- a/src/moai-sim/MOAITextureBase.cpp
+++ b/src/moai-sim/MOAITextureBase.cpp
@@ -230,7 +230,7 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 	UNUSED ( data );
 	UNUSED ( size );
 
-	#ifdef MOAI_TEST_PVR
+	#ifdef MOAI_OS_IPHONE
 
 		if ( !MOAIGfxDevice::Get ().GetHasContext ()) return;
 		MOAIGfxDevice::Get ().ClearErrors ();

--- a/src/moai-sim/MOAITextureBase.cpp
+++ b/src/moai-sim/MOAITextureBase.cpp
@@ -329,7 +329,7 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 		char* imageData = (char*)(header->GetFileData ( data, size));
 		if ( header->mMipMapCount == 0 ) {
 			
-			u32 currentSize = ( u32 )ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
+			u32 currentSize = std::max ( 32u, width * height * header->mBitCount / 8u );
 			this->mTextureSize += currentSize;
 			
 			if ( compressed ) {
@@ -346,7 +346,7 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 		}
 		else {
 			for ( int level = 0; width > 0 && height > 0; ++level ) {
-				u32 currentSize = ( u32 )ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
+				u32 currentSize = std::max ( 32u, width * height * header->mBitCount / 8u );
 			
 				if ( compressed ) {
 					zglCompressedTexImage2D ( level, this->mGLInternalFormat, width, height, currentSize, imageData );

--- a/src/moai-sim/MOAITextureBase.cpp
+++ b/src/moai-sim/MOAITextureBase.cpp
@@ -245,26 +245,26 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 			
 			case MOAIPvrHeader::OGL_RGBA_4444:
 				compressed = false;
-				this->mGLInternalFormat = GL_RGBA;
-				this->mGLPixelType = GL_UNSIGNED_SHORT_4_4_4_4;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_RGBA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_SHORT_4_4_4_4;
 				break;
 		
 			case MOAIPvrHeader::OGL_RGBA_5551:
 				compressed = false;
-				this->mGLInternalFormat = GL_RGBA;
-				this->mGLPixelType = GL_UNSIGNED_SHORT_5_5_5_1;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_RGBA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_SHORT_5_5_5_1;
 				break;
 			
 			case MOAIPvrHeader::OGL_RGBA_8888:
 				compressed = false;
-				this->mGLInternalFormat = GL_RGBA;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_RGBA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 			
 			case MOAIPvrHeader::OGL_RGB_565:
 				compressed = false;
-				this->mGLInternalFormat = GL_RGB;
-				this->mGLPixelType = GL_UNSIGNED_SHORT_5_6_5;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_RGB;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_SHORT_5_6_5;
 				break;
 			
 			// NO IMAGE FOR THIS
@@ -273,50 +273,54 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 			
 			case MOAIPvrHeader::OGL_RGB_888:
 				compressed = false;
-				this->mGLInternalFormat = GL_RGB;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_RGB;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 			
 			case MOAIPvrHeader::OGL_I_8:
 				compressed = false;
-				this->mGLInternalFormat = GL_LUMINANCE;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_LUMINANCE;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 			
 			case MOAIPvrHeader::OGL_AI_88:
 				compressed = false;
-				this->mGLInternalFormat = GL_LUMINANCE_ALPHA;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_LUMINANCE_ALPHA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 			
 			case MOAIPvrHeader::OGL_PVRTC2:
 				compressed = true;
-				this->mGLInternalFormat = hasAlpha ? GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG : GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
+				this->mGLInternalFormat = hasAlpha ?
+					ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG :
+					ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
 				break;
 			
 			case MOAIPvrHeader::OGL_PVRTC4:
 				compressed = true;
-				this->mGLInternalFormat = hasAlpha ? GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG : GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
+				this->mGLInternalFormat = hasAlpha ?
+					ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG :
+					ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
 				break;
 			
 			case MOAIPvrHeader::OGL_BGRA_8888:
 				compressed = false;
-				this->mGLInternalFormat = GL_BGRA;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_BGRA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 			
 			case MOAIPvrHeader::OGL_A_8:
 				compressed = false;
-				this->mGLInternalFormat = GL_ALPHA;
-				this->mGLPixelType = GL_UNSIGNED_BYTE;
+				this->mGLInternalFormat = ZGL_PIXEL_FORMAT_ALPHA;
+				this->mGLPixelType = ZGL_PIXEL_TYPE_UNSIGNED_BYTE;
 				break;
 		}
 		
 		
-		glGenTextures ( 1, &this->mGLTexID );
+		this->mGLTexID = zglCreateTexture ();
 		if ( !this->mGLTexID ) return;
 
-		glBindTexture ( GL_TEXTURE_2D, this->mGLTexID );
+		zglBindTexture ( this->mGLTexID );
 		
 		this->mTextureSize = 0;
 		
@@ -325,33 +329,33 @@ void MOAITextureBase::CreateTextureFromPVR ( void* data, size_t size ) {
 		char* imageData = (char*)(header->GetFileData ( data, size));
 		if ( header->mMipMapCount == 0 ) {
 			
-			GLsizei currentSize = (GLsizei) ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
+			u32 currentSize = ( u32 )ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
 			this->mTextureSize += currentSize;
 			
 			if ( compressed ) {
-				glCompressedTexImage2D ( GL_TEXTURE_2D, 0, this->mGLInternalFormat, width, height, 0, currentSize, imageData );
+				zglCompressedTexImage2D ( 0, this->mGLInternalFormat, width, height, currentSize, imageData );
 			}
 			else {
-				glTexImage2D( GL_TEXTURE_2D, 0, this->mGLInternalFormat, width, height, 0, this->mGLInternalFormat, this->mGLPixelType, imageData );	
+				zglTexImage2D( 0, this->mGLInternalFormat, width, height, this->mGLInternalFormat, this->mGLPixelType, imageData );
 			}
 			
-			if ( glGetError () != 0 ) {
+			if ( zglGetError () != ZGL_ERROR_NONE ) {
 				this->Clear ();
 				return;
 			}
 		}
 		else {
 			for ( int level = 0; width > 0 && height > 0; ++level ) {
-				GLsizei currentSize = (GLsizei) ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
+				u32 currentSize = ( u32 )ZLFloat::Max ( (float)(32), (float)(width * height * header->mBitCount / 8) );
 			
 				if ( compressed ) {
-					glCompressedTexImage2D ( GL_TEXTURE_2D, level, this->mGLInternalFormat, width, height, 0, currentSize, imageData );
+					zglCompressedTexImage2D ( level, this->mGLInternalFormat, width, height, currentSize, imageData );
 				}
 				else {
-					glTexImage2D( GL_TEXTURE_2D, level, this->mGLInternalFormat, width, height, 0, this->mGLInternalFormat, this->mGLPixelType, imageData );
+					zglTexImage2D( level, this->mGLInternalFormat, width, height, this->mGLInternalFormat, this->mGLPixelType, imageData );
 				}
 				
-				if ( glGetError () != 0 ) {
+				if ( zglGetError () != ZGL_ERROR_NONE ) {
 					this->Clear ();
 					return;
 				}

--- a/src/zl-gfx/headers.h
+++ b/src/zl-gfx/headers.h
@@ -93,6 +93,8 @@ enum {
 	ZGL_PIPELINE_VERTEX_ARRAY,
 	
 	ZGL_PIXEL_FORMAT_ALPHA,
+	ZGL_PIXEL_FORMAT_LUMINANCE,
+	ZGL_PIXEL_FORMAT_LUMINANCE_ALPHA,
 	ZGL_PIXEL_FORMAT_RED,
 	ZGL_PIXEL_FORMAT_RG,
 	ZGL_PIXEL_FORMAT_RGB,
@@ -110,6 +112,10 @@ enum {
 	ZGL_PIXEL_FORMAT_STENCIL_INDEX8,
 
 	ZGL_PIXEL_TYPE_BYTE,
+	ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_2BPPV1_IMG,
+	ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
+	ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG,
+	ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
 	ZGL_PIXEL_TYPE_FLOAT,
 	ZGL_PIXEL_TYPE_INT,
 	ZGL_PIXEL_TYPE_SHORT,
@@ -290,6 +296,7 @@ extern void		zglUseProgram					( u32 program );
 
 //----------------------------------------------------------------//
 extern void		zglBindTexture					( u32 texID );
+extern void		zglCompressedTexImage2D			( u32 level, u32 internalFormat, u32 width, u32 height, u32 imageSize, const void* data );
 extern u32		zglCreateTexture				();
 extern void		zglTexEnvi						( u32 pname, s32 param );
 extern void		zglTexImage2D					( u32 level, u32 internalFormat, u32 width, u32 height, u32 format, u32 type, const void* data );

--- a/src/zl-gfx/zl_gfx_dummy.cpp
+++ b/src/zl-gfx/zl_gfx_dummy.cpp
@@ -406,6 +406,17 @@ void zglBindTexture ( u32 texID ) {
 }
 
 //----------------------------------------------------------------//
+void zglCompressedTexImage2D ( u32 level, u32 internalFormat, u32 width, u32 height, u32 imageSize, const void* data ) {
+
+	UNUSED ( level );
+	UNUSED ( internalFormat );
+	UNUSED ( width );
+	UNUSED ( height );
+	UNUSED ( imageSize );
+	UNUSED ( data );
+}
+
+//----------------------------------------------------------------//
 u32 zglCreateTexture () {
 	return 0;
 }

--- a/src/zl-gfx/zl_gfx_flascc.cpp
+++ b/src/zl-gfx/zl_gfx_flascc.cpp
@@ -406,6 +406,17 @@ void zglBindTexture ( u32 texID ) {
 }
 
 //----------------------------------------------------------------//
+void zglCompressedTexImage2D ( u32 level, u32 internalFormat, u32 width, u32 height, u32 imageSize, const void* data ) {
+
+	UNUSED ( level );
+	UNUSED ( internalFormat );
+	UNUSED ( width );
+	UNUSED ( height );
+	UNUSED ( imageSize );
+	UNUSED ( data );
+}
+
+//----------------------------------------------------------------//
 u32 zglCreateTexture () {
 	return 0;
 }

--- a/src/zl-gfx/zl_gfx_opengl.cpp
+++ b/src/zl-gfx/zl_gfx_opengl.cpp
@@ -27,11 +27,7 @@ using namespace std;
 	#import <OpenGLES/ES2/gl.h>
 	#import <OpenGLES/ES2/glext.h>
 	
-	// TODO: replace this w/ runtime ogl extension checks
-	#define MOAI_TEST_PVR
-	
 	#define GL_RGBA8 GL_RGBA8_OES
-	
 #endif
 
 #ifdef MOAI_OS_ANDROID

--- a/src/zl-gfx/zl_gfx_opengl.cpp
+++ b/src/zl-gfx/zl_gfx_opengl.cpp
@@ -207,6 +207,8 @@ GLenum _remapEnum ( u32 zglEnum ) {
     #endif
 
 		case ZGL_PIXEL_FORMAT_ALPHA:						return GL_ALPHA;
+		case ZGL_PIXEL_FORMAT_LUMINANCE:					return GL_LUMINANCE;
+		case ZGL_PIXEL_FORMAT_LUMINANCE_ALPHA:				return GL_LUMINANCE_ALPHA;
 
 		#if !defined ( MOAI_OS_NACL ) && !defined ( MOAI_OS_IPHONE ) && !defined ( MOAI_OS_BLACKBERRY ) && !defined ( MOAI_OS_ANDROID )
 		  case ZGL_PIXEL_FORMAT_RED:							return GL_RED;
@@ -242,6 +244,14 @@ GLenum _remapEnum ( u32 zglEnum ) {
     #endif
     
 		case ZGL_PIXEL_TYPE_BYTE:							return GL_BYTE;
+
+		#ifdef MOAI_OS_IPHONE
+			case ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_2BPPV1_IMG:	return GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
+			case ZGL_PIXEL_TYPE_COMPRESSED_RGB_PVRTC_4BPPV1_IMG:	return GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
+			case ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG:	return GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
+			case ZGL_PIXEL_TYPE_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG:	return GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
+		#endif
+
 		case ZGL_PIXEL_TYPE_FLOAT:							return GL_FLOAT;
 		case ZGL_PIXEL_TYPE_INT:							return GL_INT;
 		case ZGL_PIXEL_TYPE_SHORT:							return GL_SHORT;
@@ -895,6 +905,21 @@ void zglUseProgram ( u32 program ) {
 //----------------------------------------------------------------//
 void zglBindTexture ( u32 texID ) {
 	glBindTexture ( GL_TEXTURE_2D, ( GLuint )texID );
+}
+
+//----------------------------------------------------------------//
+void zglCompressedTexImage2D ( u32 level, u32 internalFormat, u32 width, u32 height, u32 imageSize, const void* data ) {
+
+	glCompressedTexImage2D (
+		GL_TEXTURE_2D,
+		( GLint )level,
+		( GLint )_remapEnum ( internalFormat ),
+		( GLsizei )width,
+		( GLsizei )height,
+		0,
+		( GLsizei )imageSize,
+		( const GLvoid* )data
+	);
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
On iOS, we used to support the PVR texture format, both compressed and uncompressed. I reenabled the code and updated it to used the zgl OpenGL abstraction layer.

I wasn't sure if this should go into master, but it is a bugfix for a broken feature, so I think it should. However, there is a slight chance this might break other platforms, if they do not support these parts of OpenGL:
- GL_LUMINANCE
- GL_LUMINANCE_ALPHA
- glCompressedTexImage2D()

But these would be easy to fix with an #ifdef in zl-gfx/zl_gfx_opengl.cpp.
