### PR TITLE
Feature/ios hide keyboard

### DIFF
--- a/src/moai-iphone/MOAIKeyboardIOS.h
+++ b/src/moai-iphone/MOAIKeyboardIOS.h
@@ -112,6 +112,7 @@ private:
 	//----------------------------------------------------------------//
 	static int		_getText				( lua_State* L );
 	static int		_showKeyboard			( lua_State* L );
+	static int		_hideKeyboard			( lua_State* L );
 
 	//----------------------------------------------------------------//
 	void			ShowKeyboard			( cc8* text, int type, int returnKey, bool secure, int autocap, int appearance );

--- a/src/moai-iphone/MOAIKeyboardIOS.mm
+++ b/src/moai-iphone/MOAIKeyboardIOS.mm
@@ -121,6 +121,20 @@ int MOAIKeyboardIOS::_showKeyboard ( lua_State* L ) {
 	return 0;
 }
 
+//----------------------------------------------------------------//
+/**	@name	hideKeyboard
+ @text	Hide the native software keyboard.
+ 
+ @out	nil
+ */
+int MOAIKeyboardIOS::_hideKeyboard ( lua_State* L ) {
+	UNUSED(L);
+	
+	MOAIKeyboardIOS::Get ().Finish();
+	return 0;
+}
+
+
 //================================================================//
 // MOAIKeyboardIOS
 //================================================================//
@@ -203,6 +217,7 @@ void MOAIKeyboardIOS::RegisterLuaClass ( MOAILuaState& state ) {
 		{ "getText",			_getText },
 		{ "setListener",		&MOAIGlobalEventSource::_setListener < MOAIKeyboardIOS > },
 		{ "showKeyboard",		_showKeyboard },
+		{ "hideKeyboard",		_hideKeyboard },
 		{ NULL, NULL }
 	};
 


### PR DESCRIPTION
I added a hideKeyboard method in the same way as Android.
With this fix, can be operated the keyboard freely.
