### PR TITLE
Fixed an issue that is not GC by strong reference from the runtime.

### DIFF
--- a/src/moai-core/MOAILuaObject.cpp
+++ b/src/moai-core/MOAILuaObject.cpp
@@ -406,10 +406,12 @@ void MOAILuaObject::OnRelease ( u32 refCount ) {
 
 //----------------------------------------------------------------//
 void MOAILuaObject::OnRetain ( u32 refCount ) {
+	UNUSED(refCount);
 	
-	if ( refCount == 1 ) {
-		this->mUserdata.MakeStrong ();
-	}
+	// Fixed a bug that many objects will not be collected by GC
+	//if ( refCount == 1 ) {
+	//	this->mUserdata.MakeStrong ();
+	//}
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
I have deleted the code that is very problematic.
This code, make a strong reference from the LuaRuntime.

As a result, many objects will not be GC.
