### PR TITLE
no longer crashes when a glyph is missing from a static glyph cache

### DIFF
--- a/src/moai-sim/MOAIGlyph.cpp
+++ b/src/moai-sim/MOAIGlyph.cpp
@@ -87,7 +87,7 @@ ZLRect MOAIGlyph::GetRect ( float x, float y, float scale ) const {
 
 //----------------------------------------------------------------//
 MOAIGlyph::MOAIGlyph () :
-	mCode ( 0xffffffff ),
+	mCode ( NULL_CODE_ID ),
 	mPageID ( NULL_PAGE_ID ),
 	mWidth ( 0.0f ),
 	mHeight ( 0.0f ),

--- a/src/moai-sim/MOAIGlyph.h
+++ b/src/moai-sim/MOAIGlyph.h
@@ -24,6 +24,7 @@ class MOAIGlyph {
 private:
 	
 	static const u32 MAX_KERN_TABLE_SIZE	= 512;
+	static const u32 NULL_CODE_ID			= 0xffffffff;
 	static const u32 NULL_PAGE_ID			= 0xffffffff;
 	
 	u32			mCode;   // The character code of the glyph

--- a/src/moai-sim/MOAITextDesigner.cpp
+++ b/src/moai-sim/MOAITextDesigner.cpp
@@ -174,9 +174,9 @@ void MOAITextDesigner::BuildLayout () {
 			}
 		}
 		else {
-			
 			MOAIGlyph* glyph = this->mDeck->GetGlyph ( c );
 			if ( !glyph ) continue;
+			if ( glyph->mCode == MOAIGlyph::NULL_CODE_ID ) continue;
 			
 			// apply kerning
 			if ( this->mPrevGlyph ) {


### PR DESCRIPTION
Not a great solution - the glyph is just skipped in the layout. Would be a lot better to substitute with an error glyph and issue a warning.
