### PR TITLE
Revisions to Moai Lua binding, memory management and garbage collection

### DIFF
--- a/src/moai-core/MOAIEventSource.cpp
+++ b/src/moai-core/MOAIEventSource.cpp
@@ -76,7 +76,7 @@ int MOAIInstanceEventSource::_getListener ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIInstanceEventSource, "UN" );
 
 	u32 eventID = state.GetValue < u32 >( 2, 0 );
-	if ( !self->PushListener( eventID, state )) {
+	if ( !self->PushListener ( eventID, state )) {
 		state.Push ();
 	}
 

--- a/src/moai-core/MOAILuaObject.h
+++ b/src/moai-core/MOAILuaObject.h
@@ -80,9 +80,10 @@ public:
 	virtual MOAILuaClass*	GetLuaClass					();
 	cc8*					GetLuaClassName				();
 	MOAIScopedLuaState		GetSelf						();
+	void					GetStrongRef				( MOAILuaRef& ref );
+	void					GetWeakRef					( MOAILuaRef& ref );
 	bool					IsBound						();
 	bool					IsSingleton					();
-	void					LockToRefCount				();
 	void					LuaRelease					( MOAILuaObject* object );
 	void					LuaRetain					( MOAILuaObject* object );
 	void					LuaUnbind					();

--- a/src/moai-http-client/MOAIHttpTaskBase.cpp
+++ b/src/moai-http-client/MOAIHttpTaskBase.cpp
@@ -550,6 +550,21 @@ void MOAIHttpTaskBase::InitForPost ( cc8* url, cc8* useragent, const void* buffe
 }
 
 //----------------------------------------------------------------//
+void MOAIHttpTaskBase::LatchRelease () {
+
+	this->mLatch.Clear ();
+	this->Release ();
+}
+
+//----------------------------------------------------------------//
+void MOAIHttpTaskBase::LatchRetain () {
+
+	assert ( !this->mLatch );
+	this->Retain ();
+	this->GetStrongRef ( this->mLatch );
+}
+
+//----------------------------------------------------------------//
 MOAIHttpTaskBase::MOAIHttpTaskBase () :
 	mBusy ( false ),
 	mFollowRedirects ( 0 ),

--- a/src/moai-http-client/MOAIHttpTaskBase.h
+++ b/src/moai-http-client/MOAIHttpTaskBase.h
@@ -41,6 +41,7 @@ protected:
 	MOAILuaSharedPtr < MOAIStream >	mUserStream;
 
 	MOAILuaLocal		mOnFinish;
+	MOAILuaRef			mLatch;
 
 	//----------------------------------------------------------------//
 	static int		_getProgress		( lua_State* L );

--- a/src/moai-http-client/MOAIHttpTaskBase.h
+++ b/src/moai-http-client/MOAIHttpTaskBase.h
@@ -91,6 +91,8 @@ public:
 	void				HttpPost				( cc8* url, cc8* useragent, const void* buffer, u32 size, bool verbose, bool blocking );
 	void				InitForGet				( cc8* url, cc8* useragent, bool verbose );
 	void				InitForPost				( cc8* url, cc8* useragent, const void* buffer, u32 size, bool verbose );
+	void				LatchRelease			();
+	void				LatchRetain				();
 						MOAIHttpTaskBase		();
 						~MOAIHttpTaskBase		();
 	virtual void		PerformAsync			() = 0;

--- a/src/moai-http-client/MOAIUrlMgrCurl.cpp
+++ b/src/moai-http-client/MOAIUrlMgrCurl.cpp
@@ -19,8 +19,9 @@ void MOAIUrlMgrCurl::AddHandle ( MOAIHttpTaskCurl& task ) {
 	CURL* handle = task.mEasyHandle;
 	if ( !handle ) return;
 	
+	assert ( !task.mLatch );
 	task.Retain ();
-	task.LockToRefCount ();
+	task.GetStrongRef ( task.mLatch );
 	
 	curl_multi_add_handle ( this->mMultiHandle, handle );
 	this->mHandleMap [ handle ] = &task;
@@ -72,6 +73,7 @@ void MOAIUrlMgrCurl::Process () {
 				handleMap.erase ( handle );
 				
 				task->CurlFinish ();
+				task->mLatch.Clear ();
 				task->Release ();
 			}
 		}

--- a/src/moai-http-client/MOAIUrlMgrCurl.cpp
+++ b/src/moai-http-client/MOAIUrlMgrCurl.cpp
@@ -19,9 +19,7 @@ void MOAIUrlMgrCurl::AddHandle ( MOAIHttpTaskCurl& task ) {
 	CURL* handle = task.mEasyHandle;
 	if ( !handle ) return;
 	
-	assert ( !task.mLatch );
-	task.Retain ();
-	task.GetStrongRef ( task.mLatch );
+	task.LatchRetain ();
 	
 	curl_multi_add_handle ( this->mMultiHandle, handle );
 	this->mHandleMap [ handle ] = &task;
@@ -73,8 +71,7 @@ void MOAIUrlMgrCurl::Process () {
 				handleMap.erase ( handle );
 				
 				task->CurlFinish ();
-				task->mLatch.Clear ();
-				task->Release ();
+				task.LatchRelease ();
 			}
 		}
 	}

--- a/src/moai-http-client/MOAIUrlMgrNaCl.cpp
+++ b/src/moai-http-client/MOAIUrlMgrNaCl.cpp
@@ -16,6 +16,7 @@ SUPPRESS_EMPTY_FILE_WARNING
 //----------------------------------------------------------------//
 void MOAIUrlMgrNaCl::AddHandle ( MOAIHttpTaskNaCl& task ) {
 	
+	task.LatchRetain ();
 	this->mTasks.push_back ( &task );
 }
 
@@ -27,7 +28,7 @@ void MOAIUrlMgrNaCl::Process () {
 		if(( *iter )->IsReady () ) {
 
 			( *iter )->NaClFinish ();
-			( *iter )->Release ();
+			( *iter )->mLatchRelease ();
 
 			STLList < MOAIHttpTaskNaCl* >::iterator old_iter = iter;
 			old_iter--;

--- a/src/moai-sim/MOAIEnvironment.h
+++ b/src/moai-sim/MOAIEnvironment.h
@@ -96,8 +96,6 @@ class MOAIEnvironment :
 	public MOAIGlobalClass < MOAIEnvironment, MOAIGlobalEventSource > {
 private:
 	
-	MOAILuaRef			mListeners;
-	
 	//----------------------------------------------------------------//
 	static int			_generateGUID				( lua_State* L );
 	static int			_getMACAddress				( lua_State* L );

--- a/src/moai-util/MOAITask.cpp
+++ b/src/moai-util/MOAITask.cpp
@@ -10,6 +10,21 @@
 //================================================================//
 
 //----------------------------------------------------------------//
+void MOAITask::LatchRelease () {
+
+	this->mLatch.Clear ();
+	this->Release ();
+}
+
+//----------------------------------------------------------------//
+void MOAITask::LatchRetain () {
+
+	assert ( !this->mLatch );
+	this->Retain ();
+	this->GetStrongRef ( this->mLatch );
+}
+
+//----------------------------------------------------------------//
 MOAITask::MOAITask () :
 	mPriority ( PRIORITY_HIGH ),
 	mQueue ( 0 ),

--- a/src/moai-util/MOAITask.h
+++ b/src/moai-util/MOAITask.h
@@ -23,6 +23,7 @@ private:
 	MOAITaskQueue*			mQueue;
 	MOAITaskSubscriber*		mSubscriber;
 	MOAILuaLocal			mOnFinish;
+	MOAILuaRef				mLatch;
 
 	ZLLeanLink < MOAITask* >	mLink;
 

--- a/src/moai-util/MOAITask.h
+++ b/src/moai-util/MOAITask.h
@@ -54,6 +54,8 @@ public:
 	GET_SET ( u32, Priority, mPriority )
 	
 	//----------------------------------------------------------------//
+	void			LatchRelease			();
+	void			LatchRetain				();
 					MOAITask				();
 	virtual			~MOAITask				();
 	void			RegisterLuaClass		( MOAILuaState& state );

--- a/src/moai-util/MOAITaskQueue.cpp
+++ b/src/moai-util/MOAITaskQueue.cpp
@@ -42,8 +42,7 @@ void MOAITaskQueue::Process () {
 		case MOAITask::PRIORITY_IMMEDIATE:
 
 			task->Publish ();
-			task->mLatch.Clear ();
-			task->Release ();
+			task->LatchRelease ();
 			break;
 
 		default:
@@ -63,9 +62,7 @@ void MOAITaskQueue::Process () {
 //----------------------------------------------------------------//
 void MOAITaskQueue::PushTask ( MOAITask& task ) {
 
-	assert ( !task.mLatch );
-	task.Retain ();
-	task.GetStrongRef ( task.mLatch );
+	task.LatchRetain ();
 
 	this->mMutex.Lock ();
 	this->mPendingTasks.PushBack ( task.mLink );

--- a/src/moai-util/MOAITaskQueue.cpp
+++ b/src/moai-util/MOAITaskQueue.cpp
@@ -42,6 +42,7 @@ void MOAITaskQueue::Process () {
 		case MOAITask::PRIORITY_IMMEDIATE:
 
 			task->Publish ();
+			task->mLatch.Clear ();
 			task->Release ();
 			break;
 
@@ -62,7 +63,9 @@ void MOAITaskQueue::Process () {
 //----------------------------------------------------------------//
 void MOAITaskQueue::PushTask ( MOAITask& task ) {
 
+	assert ( !task.mLatch );
 	task.Retain ();
+	task.GetStrongRef ( task.mLatch );
 
 	this->mMutex.Lock ();
 	this->mPendingTasks.PushBack ( task.mLink );

--- a/src/moai-util/MOAITaskSubscriber.cpp
+++ b/src/moai-util/MOAITaskSubscriber.cpp
@@ -36,6 +36,7 @@ void MOAITaskSubscriber::Publish () {
 		this->mMutex.Unlock ();
 
 		task->Publish ();
+		task->mLatch.Clear ();
 		task->Release ();
 	}
 
@@ -55,6 +56,7 @@ void MOAITaskSubscriber::Publish () {
 		this->mMutex.Unlock ();
 
 		task->Publish ();
+		task->mLatch.Clear ();
 		task->Release ();
 
 		curTime = ZLDeviceTime::GetTimeInSeconds ();

--- a/src/moai-util/MOAITaskSubscriber.cpp
+++ b/src/moai-util/MOAITaskSubscriber.cpp
@@ -36,8 +36,7 @@ void MOAITaskSubscriber::Publish () {
 		this->mMutex.Unlock ();
 
 		task->Publish ();
-		task->mLatch.Clear ();
-		task->Release ();
+		task->LatchRelease ();
 	}
 
 	double curTime = ZLDeviceTime::GetTimeInSeconds ();
@@ -56,8 +55,7 @@ void MOAITaskSubscriber::Publish () {
 		this->mMutex.Unlock ();
 
 		task->Publish ();
-		task->mLatch.Clear ();
-		task->Release ();
+		task->LatchRelease ();
 
 		curTime = ZLDeviceTime::GetTimeInSeconds ();
 		timeElapsed = curTime - startTime;


### PR DESCRIPTION
This is just to get the discussion started. I revised the way Moai thinks about Lua GC to handle circular references quite a while ago, but there are still some edge cases that can crop up.

This particular pull requests restores the last 'good' behavior that avoids circular references and allows the GC to operate normally. I mistakenly added a call to MakeStrong in MOAILuaObject::OnRetain (), which fixed a sporadic crash I was seeing but inadvertently reintroduced circular references.

The problems stem from the divergence of the engine's internal ref counting sematic and Lua's GC. To avoid circular references, the engine's Release/Retain is decoupled from the Lua GC - Lua can collect an object but the engine can hang on to it. Likewise, the engine can be done with an object but Lua will hang on to it. 

I would rely entirely on the Lua runtime entirely for managing references between objects, but performance is a concern. There are cases where the engine will want to ensure an object exists (via Retain) and not have to go out to the Lua runtime every time it needs access.

I think there are some intermittent crashes where an object gets GC'd but is kept around by the engine which then expects the object's Lua-side references to still be valid. For example, the object might have a callback that the engine needs to invoke, but if the callback was also collected then its ref will be stale. The ref will _appear_ valid to the engine and (worse) may have already been re-purposed to refer to something else leading to sporadic and hard to debug crashes.

We can keep the current system, but the every use of MOAILuaRef, MOAILuaLocal and Release/Retain needs to be audited. It is also not safe to take the bool value of a MOAILuaLocal or a weak MOAILuaRef at face value as these objects may have been garbage collected and the ref number reused. Probably weak MOAILuaRef's should be avoided altogether and MOAILuaLocal's should never be used if their owner has been flagged for garbage collection. 

I'm pushing this fix (and comments) mainly for the discussion. Will be doing more work on this in the coming days.
