### PR TITLE
add showCursor() and hideCursor() functions to MOAISim

### DIFF
--- a/src/host-glut/GlutHost.cpp
+++ b/src/host-glut/GlutHost.cpp
@@ -298,6 +298,16 @@ void _AKUExitFullscreenModeFunc () {
 }
 
 //----------------------------------------------------------------//
+void _AKUShowCursor () {
+	glutSetCursor( GLUT_CURSOR_INHERIT ) ;
+}
+
+//----------------------------------------------------------------//
+void _AKUHideCursor () {
+	glutSetCursor( GLUT_CURSOR_NONE ) ;
+}
+
+//----------------------------------------------------------------//
 void _AKUOpenWindowFunc ( const char* title, int width, int height ) {
 
 	
@@ -524,6 +534,8 @@ void GlutRefreshContext () {
 
 	AKUSetFunc_EnterFullscreenMode ( _AKUEnterFullscreenModeFunc );
 	AKUSetFunc_ExitFullscreenMode ( _AKUExitFullscreenModeFunc );
+	AKUSetFunc_ShowCursor ( _AKUShowCursor );
+	AKUSetFunc_HideCursor ( _AKUHideCursor );
 	AKUSetFunc_OpenWindow ( _AKUOpenWindowFunc );
 
 	AKURunData ( moai_lua, moai_lua_SIZE, AKU_DATA_STRING, AKU_DATA_ZIPPED );

--- a/src/moai-sim/MOAISim.cpp
+++ b/src/moai-sim/MOAISim.cpp
@@ -99,6 +99,42 @@ int MOAISim::_exitFullscreenMode ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	showCursor
+	@text	Shows system cursor.
+
+	@out	nil
+*/
+int MOAISim::_showCursor ( lua_State* L ) {
+
+	MOAILuaState state ( L );
+
+	ShowCursorFunc func = MOAISim::Get ().GetShowCursorFunc ();
+	if ( func ) {
+		func ();
+	}
+
+	return 0;
+}
+
+//----------------------------------------------------------------//
+/**	@name	hideCursor
+	@text	Hides system cursor.
+
+	@out	nil
+*/
+int MOAISim::_hideCursor ( lua_State* L ) {
+
+	MOAILuaState state ( L );
+
+	HideCursorFunc func = MOAISim::Get ().GetHideCursorFunc ();
+	if ( func ) {
+		func ();
+	}
+
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /**	@name forceGarbageCollection
 	@text	Runs the garbage collector repeatedly until no more MOAIObjects
 			can be collected.
@@ -672,6 +708,8 @@ MOAISim::MOAISim () :
 	mSimDuration ( 1.0 / 60.0 ),
 	mEnterFullscreenModeFunc ( 0 ),
 	mExitFullscreenModeFunc ( 0 ),
+	mShowCursorFunc ( 0 ),
+	mHideCursorFunc ( 0 ),
 	mOpenWindowFunc ( 0 ),
 	mSetSimStepFunc ( 0 ) {
 	

--- a/src/moai-sim/MOAISim.h
+++ b/src/moai-sim/MOAISim.h
@@ -45,6 +45,8 @@ public:
 
 	typedef void ( *EnterFullscreenModeFunc )		();
 	typedef void ( *ExitFullscreenModeFunc )		();
+	typedef void ( *ShowCursorFunc )				();
+	typedef void ( *HideCursorFunc )				();
 	typedef void ( *OpenWindowFunc )				( const char* title, int width, int height );
 	typedef void ( *SetSimStepFunc )				( double step );
 
@@ -89,12 +91,16 @@ private:
 	ExitFullscreenModeFunc		mExitFullscreenModeFunc;
 	OpenWindowFunc				mOpenWindowFunc;
 	SetSimStepFunc				mSetSimStepFunc;
+	ShowCursorFunc				mShowCursorFunc;
+	HideCursorFunc				mHideCursorFunc;
 	
 	//----------------------------------------------------------------//
 	static int		_clearLoopFlags				( lua_State* L );
 	static int		_crash						( lua_State* L );
 	static int		_enterFullscreenMode		( lua_State* L );
 	static int		_exitFullscreenMode			( lua_State* L );
+	static int		_showCursor					( lua_State* L );
+	static int		_hideCursor					( lua_State* L );
 	static int		_forceGarbageCollection		( lua_State* L );
 	static int		_framesToTime				( lua_State* L );
 	static int		_getDeviceTime				( lua_State* L );
@@ -161,6 +167,8 @@ public:
 	
 	GET_SET ( EnterFullscreenModeFunc, EnterFullscreenModeFunc, mEnterFullscreenModeFunc );
 	GET_SET ( ExitFullscreenModeFunc, ExitFullscreenModeFunc, mExitFullscreenModeFunc );
+	GET_SET ( ShowCursorFunc, ShowCursorFunc, mShowCursorFunc );
+	GET_SET ( HideCursorFunc, HideCursorFunc, mHideCursorFunc );
 	GET_SET ( OpenWindowFunc, OpenWindowFunc, mOpenWindowFunc );
 	GET_SET ( SetSimStepFunc, SetSimStepFunc, mSetSimStepFunc );
 	

--- a/src/moai-sim/host.cpp
+++ b/src/moai-sim/host.cpp
@@ -269,6 +269,18 @@ void AKUSetFunc_ExitFullscreenMode ( AKUExitFullscreenModeFunc func ) {
 }
 
 //----------------------------------------------------------------//
+void AKUSetFunc_ShowCursor ( AKUShowCursorFunc func ) {
+
+	MOAISim::Get ().SetShowCursorFunc ( func );
+}
+
+//----------------------------------------------------------------//
+void AKUSetFunc_HideCursor ( AKUHideCursorFunc func ) {
+
+	MOAISim::Get ().SetHideCursorFunc ( func );
+}
+
+//----------------------------------------------------------------//
 void AKUSetFunc_OpenWindow ( AKUOpenWindowFunc func ) {
 
 	MOAISim::Get ().SetOpenWindowFunc ( func );

--- a/src/moai-sim/host.h
+++ b/src/moai-sim/host.h
@@ -17,6 +17,8 @@ enum {
 // Callbacks
 typedef void ( *AKUEnterFullscreenModeFunc )	();
 typedef void ( *AKUExitFullscreenModeFunc )		();
+typedef void ( *AKUShowCursorFunc )				();
+typedef void ( *AKUHideCursorFunc )				();
 typedef void ( *AKUOpenWindowFunc )				( const char* title, int width, int height );
 typedef void ( *AKUSetSimStepFunc )				( double step );
 
@@ -40,6 +42,8 @@ AKU_API void			AKUUpdate						();
 // callback management
 AKU_API void			AKUSetFunc_EnterFullscreenMode	( AKUEnterFullscreenModeFunc func );
 AKU_API void			AKUSetFunc_ExitFullscreenMode	( AKUExitFullscreenModeFunc func );
+AKU_API void			AKUSetFunc_ShowCursor			( AKUShowCursorFunc func );
+AKU_API void			AKUSetFunc_HideCursor			( AKUHideCursorFunc func );
 AKU_API void			AKUSetFunc_OpenWindow			( AKUOpenWindowFunc func );
 AKU_API void			AKUSetFunc_SetSimStep			( AKUSetSimStepFunc func );
 


### PR DESCRIPTION
When developing something game-like on a PC system, it is usually necessary to disable the system cursor. I've added MOAISim.showCursor() and MOAISim.hideCursor() functions so that this would be possible. Just so you know, they are copy-pasted versions of EnterFullscreen and ExitFullscreen, This change also affects the GLUT host which sets the AKU\* callbacks.

Please check it out!
