### PR TITLE
GLUT: set screen (device) resolution for app to use

### DIFF
--- a/src/host-glut/GlutHost.cpp
+++ b/src/host-glut/GlutHost.cpp
@@ -231,7 +231,6 @@ static void _onReshape( int w, int h ) {
 		sExitFullscreen = false;
 	}
 
-	AKUSetScreenSize ( w, h );
 	AKUSetViewSize ( w, h );
 }
 
@@ -331,7 +330,6 @@ void _AKUOpenWindowFunc ( const char* title, int width, int height ) {
 	glutReshapeFunc ( _onReshape );
 	
 	AKUDetectGfxContext ();
-	AKUSetScreenSize ( width, height );
 
 #ifdef __APPLE__
 	GLint sync = 1;
@@ -509,6 +507,11 @@ void GlutRefreshContext () {
 	#if MOAI_WITH_UNTZ
 		AKUInitializeUntz ();
 	#endif
+
+	// Set screen (desktop/device) resolution.
+	int screen_width = glutGet ( GLUT_SCREEN_WIDTH );
+	int screen_height = glutGet ( GLUT_SCREEN_HEIGHT );
+	AKUSetScreenSize ( screen_width, screen_height );
 
 	AKUSetInputConfigurationName ( "AKUGlut" );
 


### PR DESCRIPTION
It's very useful to know desktop (device, screen) resolution when creating your application window. According to this forum thread
  http://getmoai.com/forums/get-screen-resolution-sdk-1-2-t894/
it's supposed to be stored as MOAIEnvironment.horizontal/verticalResolution. The GLUT host, however, presently stores the window size in there (after MOAISim.openWindow() call) which I think is incorrect and useless.

I've created this simple patch which uses glutGet() to fetch screen size as described here:
  http://www.opengl.org/documentation/specs/glut/spec3/node70.html

Please review and include this!
