### PR TITLE
Feature: CMake MOAI_ROOT variable

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -8,6 +8,9 @@
 cmake_minimum_required ( VERSION 2.8.5 )
 project ( moai )
 
+# Setup the "MOAI_ROOT" variable
+get_filename_component(MOAI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+
 #
 # Multi-platform flags
 #
@@ -24,7 +27,6 @@ option ( BUILD_OSX         FALSE )
 #set ( BUILD_WIN32       FALSE CACHE STRING "Build Moai SDK for Windows"           FORCE )
 #set ( BUILD_IOS         FALSE CACHE STRING "Build Moai SDK for iOS"               FORCE )
 #set ( BUILD_FLASCC      FALSE CACHE STRING "Build Moai SDK for FlasCC"            FORCE )
-
 
 #
 # Platform Definitions

--- a/cmake/host-glut/CMakeLists.txt
+++ b/cmake/host-glut/CMakeLists.txt
@@ -57,7 +57,7 @@ if ( BUILD_LINUX )
 target_link_libraries ( moai 
   pthread 
   rt
-  ${OpenGL_LIBRARIES}
+  ${OPENGL_LIBRARIES}
   ${GLUT_LIBRARIES}
 )
 endif ( BUILD_LINUX )

--- a/cmake/host-glut/CMakeLists.txt
+++ b/cmake/host-glut/CMakeLists.txt
@@ -8,9 +8,9 @@ if ( BUILD_LINUX )
 endif ( BUILD_LINUX )
 
 set ( INCLUDES_MOAIHOSTGLUT 
-  "../../src/"
-  "../../src/config-default/"
-  "../../src/host-glut/"
+  "${MOAI_ROOT}/src/"
+  "${MOAI_ROOT}/src/config-default/"
+  "${MOAI_ROOT}/src/host-glut/"
   ${OPENGL_INCLUDE_DIRS}
   ${GLUT_INCLUDE_DIRS}
   ${THIRD_PARTY_INCLUDES}
@@ -22,7 +22,7 @@ include_directories ( ${INCLUDES_MOAIHOSTGLUT} )
 #   "third-party"
 # )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../src/host-glut" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/src/host-glut" )
 # set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
 
 if ( BUILD_OSX )

--- a/cmake/host-test/CMakeLists.txt
+++ b/cmake/host-test/CMakeLists.txt
@@ -8,9 +8,9 @@ if ( BUILD_LINUX )
 endif ( BUILD_LINUX )
 
 set ( INCLUDES_MOAIHOSTTEST 
-  "../../src/"
-  "../../src/config-default/"
-  "../../src/host-test/"
+  "${MOAI_ROOT}/src/"
+  "${MOAI_ROOT}/src/config-default/"
+  "${MOAI_ROOT}/src/host-test/"
   ${OPENGL_INCLUDE_DIRS}
   ${GLUT_INCLUDE_DIRS}
   ${THIRD_PARTY_INCLUDES}
@@ -22,7 +22,7 @@ include_directories ( ${INCLUDES_MOAIHOSTTEST} )
 #   "third-party"
 # )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../src/host-test" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/src/host-test" )
 # set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
 
 if ( BUILD_OSX )
@@ -59,7 +59,7 @@ target_link_libraries ( moai-test-runner
   pthread 
   rt
   ${OpenGL_LIBRARIES}
-  ${GLUT_LIBRARIES}
+  $${MOAI_ROOT}{GLUT_LIBRARIES}
 )
 endif ( BUILD_LINUX )
 

--- a/cmake/host-test/CMakeLists.txt
+++ b/cmake/host-test/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries ( moai-test-runner
   pthread 
   rt
   ${OPENGL_LIBRARIES}
-  $${MOAI_ROOT}{GLUT_LIBRARIES}
+  ${GLUT_LIBRARIES}
 )
 endif ( BUILD_LINUX )
 

--- a/cmake/host-test/CMakeLists.txt
+++ b/cmake/host-test/CMakeLists.txt
@@ -58,7 +58,7 @@ if ( BUILD_LINUX )
 target_link_libraries ( moai-test-runner
   pthread 
   rt
-  ${OpenGL_LIBRARIES}
+  ${OPENGL_LIBRARIES}
   $${MOAI_ROOT}{GLUT_LIBRARIES}
 )
 endif ( BUILD_LINUX )

--- a/cmake/moai-untz/CMakeLists.txt
+++ b/cmake/moai-untz/CMakeLists.txt
@@ -3,12 +3,12 @@ project ( moai-untz )
 
 if ( MOAI_UNTZ )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../src/moai-untz/" )
-  set ( MOAI_UNTZ_INCLUDES "../../src/;../../src/moai-untz/" CACHE INTERNAL "doc string" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/src/moai-untz/" )
+  set ( MOAI_UNTZ_INCLUDES "${MOAI_ROOT}/src/;${MOAI_ROOT}/src/moai-untz/" CACHE INTERNAL "doc string" )
 
   if ( FLASCC_BUILD )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_CURL=false -DUSE_OPENSSL=false")
-    include_directories ( "../../3rdparty/GLS3D/install/usr/include/")
+    include_directories ( "${MOAI_ROOT}/3rdparty/GLS3D/install/usr/include/")
     include_directories ( "${FLASCC}/usr/include/SDL")
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FLASCC__ -DPOSIX -D__SDL__" )
     

--- a/cmake/moaiext-server/CMakeLists.txt
+++ b/cmake/moaiext-server/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required ( VERSION 2.8.5 )
 project ( moaiext-server )
 
-set ( MOAIEXT_SERVER_INCLUDES "../../src/;../../3rdparty/;../../src/config-default/;../../3rdparty/mongoose/" CACHE INTERNAL "doc string" )
+set ( MOAIEXT_SERVER_INCLUDES "${MOAI_ROOT}/src/;${MOAI_ROOT}/3rdparty/;${MOAI_ROOT}/src/config-default/;${MOAI_ROOT}/3rdparty/mongoose/" CACHE INTERNAL "doc string" )
 
 include_directories ( 
   ${MOAICORE_INCLUDES} 
@@ -9,6 +9,6 @@ include_directories (
   ${MONGOOSE_INCLUDES}
 )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../src/moaiext-server/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/src/moaiext-server/" )
 file ( GLOB SRC_MOAIEXT_SERVER "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" )
 add_library ( moaiext-server STATIC ${SRC_MOAIEXT_SERVER} )

--- a/cmake/third-party/CMakeLists.txt
+++ b/cmake/third-party/CMakeLists.txt
@@ -54,7 +54,7 @@ set ( THIRD_PARTY_INCLUDES
   ${VORBIS_INCLUDES}
   ${ZLIB_INCLUDES}
   ${GLEW_INCLUDES}
-  "../../3rdparty/ooid-0.99/"
+  "${MOAI_ROOT}/3rdparty/ooid-0.99/"
 
 CACHE INTERNAL "doc string" )
 

--- a/cmake/third-party/CMakeLists.txt
+++ b/cmake/third-party/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required ( VERSION 2.8.5 )
 project ( third-party )
 
 
-set ( CMAKE_CURRENT_SOURCE_DIR "${ROOT_DIR}../../../3rdparty" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty" )
 
 add_subdirectory ( box2d )
 add_subdirectory ( chipmunk )
@@ -29,8 +29,8 @@ add_subdirectory ( untz )
 add_subdirectory ( vorbis )
 add_subdirectory ( zlib )
 
-set ( THIRD_PARTY_INCLUDES 
-  
+set ( THIRD_PARTY_INCLUDES
+
   ${BOX2D_INCLUDES}
   ${CHIPMUNK_INCLUDES}
   ${CONTRIB_INCLUDES}
@@ -55,7 +55,7 @@ set ( THIRD_PARTY_INCLUDES
   ${ZLIB_INCLUDES}
   ${GLEW_INCLUDES}
   "../../3rdparty/ooid-0.99/"
-  
+
 CACHE INTERNAL "doc string" )
 
 include_directories ( ${THIRD_PARTY_INCLUDES} )
@@ -64,7 +64,7 @@ if ( BUILD_BLACKBERRY )
   include_directories ( ${BLACKBERRY_INCLUDES} )
 endif ( BUILD_BLACKBERRY)
 
-add_library ( third-party STATIC 
+add_library ( third-party STATIC
   ${BOX2D_SOURCES}
   ${CHIPMUNK_SOURCES}
   ${CONTRIB_SOURCES}
@@ -73,13 +73,13 @@ add_library ( third-party STATIC
   ${FREETYPE_SOURCES}
   ${JANSSON_SOURCES}
   ${JPG_SOURCES}
-  ${LUA_SOURCES} 
+  ${LUA_SOURCES}
   ${LUAEXT_SOURCES}
-  ${MONGOOSE_SOURCES} 
-  ${OGG_SOURCES} 
-  ${PNG_SOURCES} 
+  ${MONGOOSE_SOURCES}
+  ${OGG_SOURCES}
+  ${PNG_SOURCES}
   ${SFMT_SOURCES}
-  ${SQLITE3_SOURCES} 
+  ${SQLITE3_SOURCES}
   ${TINYXML_SOURCES}
   ${TLSF_SOURCES}
   ${UNTZ_SOURCES}
@@ -88,7 +88,7 @@ add_library ( third-party STATIC
   ${GLEW_SOURCES}
 )
 
-if( MOAI_OPENSSL ) 
+if( MOAI_OPENSSL )
   target_link_libraries( third-party ssl )
 endif( MOAI_OPENSSL )
 

--- a/cmake/third-party/box2d/CMakeLists.txt
+++ b/cmake/third-party/box2d/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_BOX2D )
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_BOX2D=1" CACHE INTERNAL "doc string")
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_BOX2D=1" CACHE INTERNAL "doc string")
 
-    set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/box2d-2.2.1/" )
+    set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/box2d-2.2.1/" )
 
-    set ( BOX2D_INCLUDES "../../3rdparty/box2d-2.2.1/" CACHE INTERNAL "doc string" )
+    set ( BOX2D_INCLUDES "${MOAI_ROOT}/3rdparty/box2d-2.2.1/" CACHE INTERNAL "doc string" )
 
     set ( BOX2D_SOURCES 
 

--- a/cmake/third-party/chipmunk/CMakeLists.txt
+++ b/cmake/third-party/chipmunk/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_CHIPMUNK )
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_CHIPMUNK=1" CACHE INTERNAL "doc string")
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_CHIPMUNK=1" CACHE INTERNAL "doc string")
 
-    set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/chipmunk-5.3.4/src/" )
+    set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/chipmunk-5.3.4/src/" )
 
-    set ( CHIPMUNK_INCLUDES "../../3rdparty/chipmunk-5.3.4/include/chipmunk/;../../3rdparty/chipmunk-5.3.4/include/" CACHE INTERNAL "doc string" )
+    set ( CHIPMUNK_INCLUDES "${MOAI_ROOT}/3rdparty/chipmunk-5.3.4/include/chipmunk/;${MOAI_ROOT}/3rdparty/chipmunk-5.3.4/include/" CACHE INTERNAL "doc string" )
 
     set ( CHIPMUNK_SOURCES 
 

--- a/cmake/third-party/contrib/CMakeLists.txt
+++ b/cmake/third-party/contrib/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required ( VERSION 2.8.5 )
 
 project ( contrib )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/contrib/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/contrib/" )
 
-set ( CONTRIB_INCLUDES 
-  "../../3rdparty/"
+set ( CONTRIB_INCLUDES
+  "${MOAI_ROOT}/3rdparty/"
 CACHE INTERNAL "doc string" )
 
-set ( CONTRIB_SOURCES 
+set ( CONTRIB_SOURCES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/utf8.c
     ${CMAKE_CURRENT_SOURCE_DIR}/whirlpool.c
-    
+
 CACHE INTERNAL "doc string" )

--- a/cmake/third-party/crypto/CMakeLists.txt
+++ b/cmake/third-party/crypto/CMakeLists.txt
@@ -3,7 +3,7 @@ project ( crypto )
 
 if ( MOAI_CRYPTO )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/openssl-1.0.0d/crypto/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_LIBCRYPTO=1" CACHE INTERNAL "doc string")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_LIBCRYPTO=1" CACHE INTERNAL "doc string")
@@ -11,14 +11,14 @@ if ( MOAI_CRYPTO )
   SET_SOURCE_FILES_PROPERTIES( . PROPERTIES LANGUAGE CXX )
 
   set ( CRYPTO_INCLUDES 
-    "../../../3rdparty/openssl-1.0.0d/crypto/"
-    "../../../3rdparty/openssl-1.0.0d/include/"
-    "../../../3rdparty/openssl-1.0.0d/crypto/asn1/"
-    "../../../3rdparty/openssl-1.0.0d/crypto/evp/"
-    "../../../3rdparty/openssl-1.0.0d/" 
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/include/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/asn1/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/evp/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/" 
     
     if ( BUILD_LINUX )
-      "../../../3rdparty/openssl-1.0.0d/include-linux"
+      "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/include-linux"
     endif ( BUILD_LINUX )
 
   CACHE INTERNAL "doc string" )

--- a/cmake/third-party/curl/CMakeLists.txt
+++ b/cmake/third-party/curl/CMakeLists.txt
@@ -4,14 +4,14 @@ project ( curl )
 
 if ( MOAI_CURL )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/curl-7.19.7/lib" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/curl-7.19.7/lib" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_LIBCURL=1" CACHE INTERNAL "doc string")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_LIBCURL=1" CACHE INTERNAL "doc string")
 
 
   set ( CURL_INCLUDES 
-    "../../../3rdparty/curl-7.19.7/include/" 
+    "${MOAI_ROOT}/3rdparty/curl-7.19.7/include/" 
     "${CMAKE_BINARY_DIR}/../third-party/curl/"
   CACHE INTERNAL "doc string" )
 

--- a/cmake/third-party/expat/CMakeLists.txt
+++ b/cmake/third-party/expat/CMakeLists.txt
@@ -4,13 +4,13 @@ project ( expat )
 
 if ( MOAI_EXPAT )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/expat-2.0.1/lib/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/expat-2.0.1/lib/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_EXPAT=1" CACHE INTERNAL "doc string")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_EXPAT=1" CACHE INTERNAL "doc string")
 
 
-  set ( EXPAT_INCLUDES "../../3rdparty/expat-2.0.1/lib/" CACHE INTERNAL "doc string" )
+  set ( EXPAT_INCLUDES "${MOAI_ROOT}/3rdparty/expat-2.0.1/lib/" CACHE INTERNAL "doc string" )
 
   set ( EXPAT_SOURCES 
 

--- a/cmake/third-party/freetype/CMakeLists.txt
+++ b/cmake/third-party/freetype/CMakeLists.txt
@@ -9,9 +9,9 @@ if ( MOAI_FREETYPE )
 
     # add_definitions("-DFT2_BUILD_LIBRARY -D__MOAI_LINUX_BUILD")
 
-    set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/freetype-2.4.4/src/" )
+    set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/freetype-2.4.4/src/" )
 
-    set ( FREETYPE_INCLUDES "../../3rdparty/freetype-2.4.4/include" CACHE INTERNAL "doc string" )
+    set ( FREETYPE_INCLUDES "${MOAI_ROOT}/3rdparty/freetype-2.4.4/include" CACHE INTERNAL "doc string" )
 
     set ( FREETYPE_SOURCES 
 

--- a/cmake/third-party/glew/CMakeLists.txt
+++ b/cmake/third-party/glew/CMakeLists.txt
@@ -3,14 +3,14 @@ project ( glew )
 
 if ( NOT BUILD_BLACKBERRY )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/glew-1.5.6/src" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/glew-1.5.6/src" )
 
-set ( GLEW_INCLUDES "../../3rdparty/glew-1.5.6/include" CACHE INTERNAL "doc string" )
+set ( GLEW_INCLUDES "${MOAI_ROOT}/3rdparty/glew-1.5.6/include" CACHE INTERNAL "doc string" )
 
-set ( GLEW_SOURCES 
+set ( GLEW_SOURCES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/glew.c
-    
+
 CACHE INTERNAL "doc string" )
 
 endif ( NOT BUILD_BLACKBERRY )

--- a/cmake/third-party/jansson/CMakeLists.txt
+++ b/cmake/third-party/jansson/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_JSON )
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_JANSSON=1" CACHE INTERNAL "doc string")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_JANSSON=1" CACHE INTERNAL "doc string")
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/jansson-2.1/src/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/jansson-2.1/src/" )
 
-  set ( JANSSON_INCLUDES "../../3rdparty/jansson-2.1/src/" CACHE INTERNAL "doc string" )
+  set ( JANSSON_INCLUDES "${MOAI_ROOT}/3rdparty/jansson-2.1/src/" CACHE INTERNAL "doc string" )
 
   set ( JANSSON_SOURCES 
 

--- a/cmake/third-party/jpg/CMakeLists.txt
+++ b/cmake/third-party/jpg/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_JPG )
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_LIBJPG=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_LIBJPG=1" CACHE INTERNAL "doc string" )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/jpeg-8c/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/jpeg-8c/" )
 
-  set ( JPG_INCLUDES "../../3rdparty/jpeg-8c/" CACHE INTERNAL "doc string" )
+  set ( JPG_INCLUDES "${MOAI_ROOT}/3rdparty/jpeg-8c/" CACHE INTERNAL "doc string" )
 
   set ( JPG_SOURCES 
 

--- a/cmake/third-party/lua/CMakeLists.txt
+++ b/cmake/third-party/lua/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 2.8.5)
 
 project(lua)
 
-set ( CMAKE_CURRENT_SOURCE_DIR "${ROOT_DIR}../../../3rdparty/lua-5.1.3/src/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/lua-5.1.3/src/" )
 
-set ( LUA_INCLUDES "../../3rdparty/lua-5.1.3/src/" CACHE INTERNAL "doc string" )
+set ( LUA_INCLUDES "${MOAI_ROOT}/3rdparty/lua-5.1.3/src/" CACHE INTERNAL "doc string" )
 
 
-set ( LUA_SOURCES 
+set ( LUA_SOURCES
 
   ${CMAKE_CURRENT_SOURCE_DIR}lapi.c
   ${CMAKE_CURRENT_SOURCE_DIR}lauxlib.c

--- a/cmake/third-party/luaext/CMakeLists.txt
+++ b/cmake/third-party/luaext/CMakeLists.txt
@@ -3,13 +3,16 @@ project ( luaext )
 
 if ( MOAI_LUAEXT )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/" )
-  set ( MOAI_LUAEXT_SOURCE_DIR "../../../src/moai-luaext/")
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/" )
+  set ( MOAI_LUAEXT_SOURCE_DIR "${MOAI_ROOT}/src/moai-luaext/")
   
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_LUAEXT=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_LUAEXT=1" CACHE INTERNAL "doc string" )
 
-  set ( LUAEXT_INCLUDES "../../3rdparty/lua-5.1.3/src/;../../3rdparty/luasocket-2.0.2/src/;../../src/" CACHE INTERNAL "doc string" )
+  set ( LUAEXT_INCLUDES "${MOAI_ROOT}/3rdparty/lua-5.1.3/src/"
+      "${MOAI_ROOT}/3rdparty/luasocket-2.0.2/src/"
+      "${MOAI_ROOT}/src/"
+    CACHE INTERNAL "doc string" )
 
   set ( LUAEXT_SOURCES 
     ${CMAKE_CURRENT_SOURCE_DIR}/luasocket-2.0.2-embed/fullluasocket.c

--- a/cmake/third-party/mongoose/CMakeLists.txt
+++ b/cmake/third-party/mongoose/CMakeLists.txt
@@ -3,12 +3,12 @@ project ( mongoose )
 
 if ( MOAI_MONGOOSE )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/mongoose/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/mongoose/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_MONGOOSE=1" CACHE INTERNAL "doc string")
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_MONGOOSE=1" CACHE INTERNAL "doc string")
 
-  set ( MONGOOSE_INCLUDES "../../3rdparty/mongoose/" CACHE INTERNAL "doc string" )
+  set ( MONGOOSE_INCLUDES "${MOAI_ROOT}/3rdparty/mongoose/" CACHE INTERNAL "doc string" )
 
   set ( MONGOOSE_SOURCES 
 

--- a/cmake/third-party/ogg/CMakeLists.txt
+++ b/cmake/third-party/ogg/CMakeLists.txt
@@ -3,12 +3,12 @@ project ( ogg )
 
 if ( MOAI_OGG )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/libogg-1.2.2/src/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/libogg-1.2.2/src/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_OGG=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_OGG=1" CACHE INTERNAL "doc string" )
 
-  set ( OGG_INCLUDES "../../3rdparty/libogg-1.2.2/include/" CACHE INTERNAL "doc string" )
+  set ( OGG_INCLUDES "${MOAI_ROOT}/3rdparty/libogg-1.2.2/include/" CACHE INTERNAL "doc string" )
 
   set ( OGG_SOURCES 
     ${CMAKE_CURRENT_SOURCE_DIR}/bitwise.c

--- a/cmake/third-party/png/CMakeLists.txt
+++ b/cmake/third-party/png/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_PNG )
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_LIBPNG=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_LIBPNG=1" CACHE INTERNAL "doc string" )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/lpng140/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/lpng140/" )
 
-  set ( PNG_INCLUDES "../../3rdparty/lpng140/" CACHE INTERNAL "doc string" )
+  set ( PNG_INCLUDES "${MOAI_ROOT}/3rdparty/lpng140/" CACHE INTERNAL "doc string" )
 
   set ( PNG_SOURCES 
 

--- a/cmake/third-party/sfmt/CMakeLists.txt
+++ b/cmake/third-party/sfmt/CMakeLists.txt
@@ -3,12 +3,12 @@ project ( sfmt )
 
 if ( MOAI_SFMT )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/sfmt-1.4/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/sfmt-1.4/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_SFMT=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_SFMT=1" CACHE INTERNAL "doc string" )
 
-  set ( SFMT_INCLUDES "../../3rdparty/sfmt-1.4/" CACHE INTERNAL "doc string" )
+  set ( SFMT_INCLUDES "${MOAI_ROOT}/3rdparty/sfmt-1.4/" CACHE INTERNAL "doc string" )
 
   set ( SFMT_MEXP 19937 )
   set ( SFMT_SOURCES 

--- a/cmake/third-party/sqlite3/CMakeLists.txt
+++ b/cmake/third-party/sqlite3/CMakeLists.txt
@@ -6,9 +6,9 @@ if ( MOAI_SQLITE3 )
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_SQLITE=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_SQLITE=1" CACHE INTERNAL "doc string" )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/sqlite-3.6.16/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/sqlite-3.6.16/" )
 
-  set ( SQLITE3_INCLUDES "../../3rdparty/sqlite-3.6.16/" CACHE INTERNAL "doc string" )
+  set ( SQLITE3_INCLUDES "${MOAI_ROOT}/3rdparty/sqlite-3.6.16/" CACHE INTERNAL "doc string" )
 
   set ( SQLITE3_SOURCES 
 

--- a/cmake/third-party/ssl/CMakeLists.txt
+++ b/cmake/third-party/ssl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required ( VERSION 2.8.5 )
 project ( ssl )
 
 if ( MOAI_OPENSSL ) 
- set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/openssl-1.0.0d/" )
+ set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/" )
  
  set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_OPENSSL=1 " CACHE INTERNAL "doc string" )
  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_OPENSSL=1" CACHE INTERNAL "doc string" )
@@ -12,11 +12,11 @@ if ( MOAI_OPENSSL )
  endif ( BUILD_LINUX)
 
  set ( SSL_INCLUDES 
-    "../../../3rdparty/openssl-1.0.0d/crypto/"
-    "../../../3rdparty/openssl-1.0.0d/include/"
-    "../../../3rdparty/openssl-1.0.0d/crypto/asn1/"
-    "../../../3rdparty/openssl-1.0.0d/crypto/evp/"
-    "../../../3rdparty/openssl-1.0.0d/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/include/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/asn1/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/crypto/evp/"
+    "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/"
     
   CACHE INTERNAL "doc string" )
 
@@ -76,7 +76,7 @@ if ( MOAI_OPENSSL )
   )
 
   if ( BUILD_LINUX )
-    include_directories ( "../../../3rdparty/openssl-1.0.0d/include-linux" )
+    include_directories ( "${MOAI_ROOT}/3rdparty/openssl-1.0.0d/include-linux" )
   endif ( BUILD_LINUX )
  
   add_library ( ssl STATIC 

--- a/cmake/third-party/tinyxml/CMakeLists.txt
+++ b/cmake/third-party/tinyxml/CMakeLists.txt
@@ -3,14 +3,14 @@ project ( tinyxml )
 
 if ( MOAI_TINYXML )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/tinyxml/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/tinyxml/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_TINYXML=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_TINYXML=1" CACHE INTERNAL "doc string" )
 
-  set ( TINYXML_INCLUDES "../../3rdparty/tinyxml/" CACHE INTERNAL "doc string" )
+  set ( TINYXML_INCLUDES "${MOAI_ROOT}/3rdparty/tinyxml/" CACHE INTERNAL "doc string" )
 
-  set ( TINYXML_SOURCES 
+  set ( TINYXML_SOURCES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/tinystr.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tinyxml.cpp

--- a/cmake/third-party/tlsf/CMakeLists.txt
+++ b/cmake/third-party/tlsf/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required ( VERSION 2.8.5 )
 project ( tlsf )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/tlsf-2.0/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/tlsf-2.0/" )
 
-set ( TLSF_INCLUDES 
-  "../../3rdparty/tlsf-2.0/"
+set ( TLSF_INCLUDES
+  "${MOAI_ROOT}/3rdparty/tlsf-2.0/"
 CACHE INTERNAL "doc string" )
 
-set ( TLSF_SOURCES 
+set ( TLSF_SOURCES
 
   ${CMAKE_CURRENT_SOURCE_DIR}/tlsf.c
 

--- a/cmake/third-party/untz/CMakeLists.txt
+++ b/cmake/third-party/untz/CMakeLists.txt
@@ -35,20 +35,20 @@ if ( MOAI_UNTZ )
     set ( SDL_LIBRARY "${SDL_LIBRARIES}" CACHE INTERNAL "" )
   endif ( MOAI_SDL OR BUILD_BLACKBERRY )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/untz/src/" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/untz/src/" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_UNTZ=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_UNTZ=1" CACHE INTERNAL "doc string" )
 
   set ( UNTZ_INCLUDES 
     ${SDL_INCLUDES}
-    "../../3rdparty/untz/include/"
-    "../../3rdparty/untz/src/"
-    "../../3rdparty/untz/src/native/sdl/" 
+    "${MOAI_ROOT}/3rdparty/untz/include/"
+    "${MOAI_ROOT}/3rdparty/untz/src/"
+    "${MOAI_ROOT}/3rdparty/untz/src/native/sdl/" 
   CACHE INTERNAL "doc string" )
 
   if ( BUILD_BLACKBERRY )
-    set ( UNTZ_INCLUDES "${UNTZ_INCLUDES};../../3rdparty/SDL/include/" CACHE INTERNAL "doc string" )
+    set ( UNTZ_INCLUDES "${UNTZ_INCLUDES};${MOAI_ROOT}/3rdparty/SDL/include/" CACHE INTERNAL "doc string" )
   endif ( BUILD_BLACKBERRY )
 
   set ( UNTZ_SOURCES 

--- a/cmake/third-party/vorbis/CMakeLists.txt
+++ b/cmake/third-party/vorbis/CMakeLists.txt
@@ -3,12 +3,12 @@ project ( vorbis )
 
 if ( MOAI_VORBIS )
 
-  set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/libvorbis-1.3.2/lib" )
+  set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/libvorbis-1.3.2/lib" )
 
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOAI_WITH_VORBIS=1" CACHE INTERNAL "doc string" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOAI_WITH_VORBIS=1" CACHE INTERNAL "doc string" )
 
-  set ( VORBIS_INCLUDES "../../3rdparty/libvorbis-1.3.2/lib/;../../3rdparty/libvorbis-1.3.2/include/" CACHE INTERNAL "doc string" )
+  set ( VORBIS_INCLUDES "${MOAI_ROOT}/3rdparty/libvorbis-1.3.2/lib/;${MOAI_ROOT}/3rdparty/libvorbis-1.3.2/include/" CACHE INTERNAL "doc string" )
 
   set ( VORBIS_SOURCES 
 

--- a/cmake/third-party/zlib/CMakeLists.txt
+++ b/cmake/third-party/zlib/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required ( VERSION 2.8.5 )
 project ( zlib )
 
 
-set ( CMAKE_CURRENT_SOURCE_DIR "../../../3rdparty/zlib-1.2.3/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/zlib-1.2.3/" )
 
-set ( ZLIB_INCLUDES "../../3rdparty/zlib-1.2.3/" CACHE INTERNAL "doc string" )
+set ( ZLIB_INCLUDES "${MOAI_ROOT}/3rdparty/zlib-1.2.3/" CACHE INTERNAL "doc string" )
 
-set ( ZLIB_SOURCES 
+set ( ZLIB_SOURCES
 
   ${CMAKE_CURRENT_SOURCE_DIR}/adler32.c
   ${CMAKE_CURRENT_SOURCE_DIR}/compress.c
@@ -20,5 +20,5 @@ set ( ZLIB_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/trees.c
   ${CMAKE_CURRENT_SOURCE_DIR}/uncompr.c
   ${CMAKE_CURRENT_SOURCE_DIR}/zutil.c
-  
+
 CACHE INTERNAL "doc string" )


### PR DESCRIPTION
I added a MOAI_ROOT variable to the CMake build scripts, and changed all the source paths to be relative to this variable as opposed to having paths relative to the build scripts themselves. This will prevent the source paths from breaking if the build scripts get shuffled around (or moved in/out of subdirectories). This also allows the build directory to reside in an arbitrary location.
