### PR TITLE
Removed TextDesigner offset flooring

### DIFF
--- a/src/moai-sim/MOAITextDesigner.cpp
+++ b/src/moai-sim/MOAITextDesigner.cpp
@@ -90,8 +90,6 @@ void MOAITextDesigner::Align () {
 			yOff = this->mTextBox->mFrame.mYMax - layoutHeight;
 	}
 	
-	yOff = ZLFloat::Floor ( yOff + 0.5f );
-	
 	u32 totalLines = this->mTextBox->mLines.GetTop ();
 	for ( u32 i = 0; i < totalLines; ++i ) {
 		MOAITextLine& line = this->mTextBox->mLines [ i ];
@@ -110,8 +108,6 @@ void MOAITextDesigner::Align () {
 			case MOAITextBox::RIGHT_JUSTIFY:
 				xOff = this->mTextBox->mFrame.mXMax - lineWidth;
 		}
-		
-		xOff = ZLFloat::Floor ( xOff + 0.5f );
 		
 		line.mRect.Offset ( xOff, yOff );
 		


### PR DESCRIPTION
I don't know if this is to help pixel alignment or something, but I don't run my game at a scale that is the same as the resolution, and with the varied devices that are out there I'm not sure many does? With a lower scale that flooring can move the text around big time, which it did for me :)
