### PR TITLE
Fix PVR texture data leak on iOS

### DIFF
--- a/src/moai-sim/MOAITexture.cpp
+++ b/src/moai-sim/MOAITexture.cpp
@@ -243,6 +243,12 @@ MOAITexture::MOAITexture () :
 
 //----------------------------------------------------------------//
 MOAITexture::~MOAITexture () {
+
+	if ( this->mData ) {
+		free ( this->mData );
+		this->mData = NULL;
+	}
+	this->mDataSize = 0;
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
When a PVR texture was loaded (from file into memory) but never created (as an OpenGL texture), the texture data was never freed.
