### PR TITLE
Fix Shader Reload After Resuming the Game

### DIFF
--- a/src/moai-sim/MOAIShader.cpp
+++ b/src/moai-sim/MOAIShader.cpp
@@ -690,13 +690,13 @@ void MOAIShader::OnCreate () {
 		return;
 	}
 	
-	// get the uniform locations and clear out the names (no longer needed)
+	// get the uniform locations
 	for ( u32 i = 0; i < this->mUniforms.Size (); ++i ) {
 		MOAIShaderUniform& uniform = this->mUniforms [ i ];
 		
 		if ( uniform.mType != MOAIShaderUniform::UNIFORM_NONE ) {
 			uniform.mAddr = zglGetUniformLocation ( this->mProgram, uniform.mName );
-			uniform.mName.clear ();
+			uniform.mIsDirty = true;
 		}
 	}
 


### PR DESCRIPTION
This is a long-standing bug that has been reported many times (e.g. in #788). I got it reproduced on Android and got it resolved using this minimal fix (as opposed to the one proposed in #788).
