### PR TITLE
Fix Curl

### DIFF
--- a/3rdparty/curl-7.19.7/lib/if2ip.c
+++ b/3rdparty/curl-7.19.7/lib/if2ip.c
@@ -102,7 +102,6 @@ char *Curl_if2ip(int af, const char *interface, char *buf, int buf_size)
         ip = (char *) Curl_inet_ntop(af, addr, ipstr, sizeof(ipstr));
         snprintf(buf, buf_size, "%s%s", ip, scope);
         ip = buf;
-        strlcat(buf, scope, buf_size);
         break;
       }
     }


### PR DESCRIPTION
As reported [here](https://github.com/moai/moai-dev/commit/7ddf061485d54828320f1a160aa7478e5021a427#commitcomment-4701278), Curl does not compile (at least on Ubuntu) at the moment. That is because [this patch](http://curl.haxx.se/mail/lib-2013-02/att-0214/0001-strlcat-remove-function.patch) hasn't been applied correctly in 7ddf061485d54828320f1a160aa7478e5021a427.
