### PR TITLE
Updated CMakeLists so LUA is compiled with loading of dynamic libraries enabled

### DIFF
--- a/cmake/lua-lib/CMakeLists.txt
+++ b/cmake/lua-lib/CMakeLists.txt
@@ -9,6 +9,7 @@ endif(NOT DEFINED IS_ROOT)
 
 set(${PROJECT_NAME}_UnixInclude "${ROOT_DIR}/3rdparty/lua-5.1.3/src/" PARENT_SCOPE)
 set(CMAKE_CURRENT_SOURCE_DIR "${ROOT_DIR}/3rdparty/lua-5.1.3/src/")
+add_definitions(-DLUA_USE_LINUX)
 
 moai_manual(library
     ${CMAKE_CURRENT_SOURCE_DIR}/lapi.c
@@ -43,3 +44,4 @@ moai_manual(library
     ${CMAKE_CURRENT_SOURCE_DIR}/print.c
 )
 moai_needs(m)
+target_link_libraries(lua-lib ${CMAKE_DL_LIBS})

--- a/cmake/lua/CMakeLists.txt
+++ b/cmake/lua/CMakeLists.txt
@@ -8,8 +8,10 @@ if(NOT DEFINED IS_ROOT)
 endif(NOT DEFINED IS_ROOT)
 
 set(CMAKE_CURRENT_SOURCE_DIR "${ROOT_DIR}/3rdparty/lua-5.1.3/src/")
+add_definitions(-DLUA_USE_LINUX)
 
 moai_manual(executable
     ${CMAKE_CURRENT_SOURCE_DIR}/lua.c
 )
 moai_needs(lua-lib)
+target_link_libraries(lua readline ${CMAKE_DL_LIBS})

--- a/cmake/luac/CMakeLists.txt
+++ b/cmake/luac/CMakeLists.txt
@@ -8,6 +8,7 @@ if(NOT DEFINED IS_ROOT)
 endif(NOT DEFINED IS_ROOT)
 
 set(CMAKE_CURRENT_SOURCE_DIR "${ROOT_DIR}/3rdparty/lua-5.1.3/src/")
+add_definitions(-DLUA_USE_LINUX)
 
 moai_manual(executable
     ${CMAKE_CURRENT_SOURCE_DIR}/luac.c


### PR DESCRIPTION
LUA is missing a compilation option for linux. One consequence is it can't load dynamic libraries.
The compilation command used in the official lua makefile is:
`gcc -O2 -Wall -DLUA_USE_LINUX   -c -o xxx.o xxx.c`
(as can be seen from line 99 of [lua-5.1.3/src/Makefile](https://github.com/moai/moai-dev/blob/linux/3rdparty/lua-5.1.3/src/Makefile))
The compilation options used in the CMake of the project currently is:
`/usr/bin/cc -DVERSION_GIT=2ef1ed405 -DVERSION_STAGE=linux -o xxx.o -c xxx.c`

If the define is absent, on line 36 of [luaconf.h](https://github.com/moai/moai-dev/blob/linux/3rdparty/lua-5.1.3/src/luaconf.h), the following defines are absent as well:
`#define LUA_USE_POSIX
# define LUA_USE_DLOPEN          /\* needs an extra library: -ldl */
# define LUA_USE_READLINE        /\* needs some extra libraries */`

which, among other things, disables loading of dynamic libraries.

I also added "dl" as a library requirement to lua-lib. This fixes "make" failing with linker error :
`undefined reference to symbol 'dlclose@@GLIBC_2.2.5'`
which apparently I was not the only one to have (see http://franciscotufro.com/2013/01/compiling-moai-on-linux/).
