### PR TITLE
Fix backport patch to remove strlcat from curl. 

### DIFF
--- a/3rdparty/curl-7.19.7/lib/if2ip.c
+++ b/3rdparty/curl-7.19.7/lib/if2ip.c
@@ -102,7 +102,6 @@ char *Curl_if2ip(int af, const char *interface, char *buf, int buf_size)
         ip = (char *) Curl_inet_ntop(af, addr, ipstr, sizeof(ipstr));
         snprintf(buf, buf_size, "%s%s", ip, scope);
         ip = buf;
-        strlcat(buf, scope, buf_size);
         break;
       }
     }


### PR DESCRIPTION
Accidentally leaved call of strlcat
