### PR TITLE
Added missing include required for min<>()

### DIFF
--- a/src/zl-common/zl_platform.h
+++ b/src/zl-common/zl_platform.h
@@ -123,6 +123,7 @@
 	#include <string>
  	#include <iostream>
 	#include <sstream>
+	#include <algorithm>
 #endif
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
Include is required to build in VS2013. See http://getmoai.com/forums/error-building-vs-solution-via-cmake-t2531/#p13329
