### PR TITLE
Add Box2D closest raycast support

### DIFF
--- a/3rdparty/untz/src/native/openal/UntzSystem.cpp
+++ b/3rdparty/untz/src/native/openal/UntzSystem.cpp
@@ -55,7 +55,7 @@ static inline SInt16 limit_float_conv_SInt16(float inValue)
 }
 
 void *audio_loop (void *ptr) {
-	fprintf(stdout, "Audio Thread running\n:");
+	//fprintf(stdout, "Audio Thread running\n:");
 
 	alutInit(0, NULL);
 	alGetError();

--- a/3rdparty/untz/src/native/openal/WaveFile.cpp
+++ b/3rdparty/untz/src/native/openal/WaveFile.cpp
@@ -30,7 +30,7 @@ int WaveFile::open(const char *path)
 	
 	char s[5];
 	FOURCC2STR(formatCode(), s);
-	printf("type = %s\n", s);
+	//printf("type = %s\n", s);
 
 	if(formatCode() != STR2FOURCC("WAVE"))
 	{

--- a/3rdparty/untz/src/native/openal/WaveFileAudioSource.cpp
+++ b/3rdparty/untz/src/native/openal/WaveFileAudioSource.cpp
@@ -132,7 +132,7 @@ Int64 WaveFileAudioSource::decodeData(float* buffer, UInt32 numFrames)
 	//sprintf(str, "read %ld frames", readFrames);
     //__android_log_write(ANDROID_LOG_ERROR, "UntzJNI", str);
 #else
-	printf("read %d frames\n", readFrames);
+	//printf("read %d frames\n", readFrames);
 #endif
 
 	if(readFrames == 0)
@@ -140,7 +140,7 @@ Int64 WaveFileAudioSource::decodeData(float* buffer, UInt32 numFrames)
 #if defined(__ANDROID__)
 		//__android_log_write(ANDROID_LOG_ERROR, "UntzJNI", "EOF reached");
 #else
-		printf("EOF reached\n", readFrames);
+		//printf("EOF reached\n", readFrames);
 #endif
 		mEOF = true;
 	}

--- a/src/moai-box2d/MOAIBox2DWorld.h
+++ b/src/moai-box2d/MOAIBox2DWorld.h
@@ -13,6 +13,7 @@ class MOAIBox2DDebugDraw;
 class MOAIBox2DFixture;
 class MOAIBox2DJoint;
 class MOAIBox2DWorld;
+class MOAIBox2DRayCastCallback;
 
 //================================================================//
 // MOAIBox2DPrim

--- a/src/moai-box2d/MOAIBox2DWorld.h
+++ b/src/moai-box2d/MOAIBox2DWorld.h
@@ -105,6 +105,7 @@ private:
 	static int		_setLinearSleepTolerance	( lua_State* L );
 	static int		_setTimeToSleep				( lua_State* L );
 	static int		_setUnitsToMeters			( lua_State* L );
+	static int		_getRayCast				( lua_State* L );
 	
 	//----------------------------------------------------------------//
 	void			Destroy					();
@@ -143,6 +144,33 @@ public:
 	void			OnUpdate				( float step );
 	void			RegisterLuaClass		( MOAILuaState& state );
 	void			RegisterLuaFuncs		( MOAILuaState& state );
+};
+
+//================================================================//
+// MOAIBox2DRayCastCallback
+//================================================================//
+class MOAIBox2DRayCastCallback : public b2RayCastCallback
+{
+public:
+	  MOAIBox2DRayCastCallback()
+  {
+     m_fixture = NULL;
+	 m_point.SetZero();
+	 m_normal.SetZero();
+  }
+ 
+  float32 ReportFixture(   b2Fixture* fixture, const b2Vec2& point, const b2Vec2& normal, float32 fraction)
+  {
+     m_fixture = fixture;
+     m_point = point;
+     m_normal = normal;
+     
+     return fraction;
+  }
+ 
+  b2Fixture* m_fixture;
+  b2Vec2 m_point;
+  b2Vec2 m_normal;
 };
 
 #endif

--- a/src/moai-box2d/MOAIBox2DWorld.h
+++ b/src/moai-box2d/MOAIBox2DWorld.h
@@ -153,15 +153,13 @@ public:
 class MOAIBox2DRayCastCallback : public b2RayCastCallback
 {
 public:
-	  MOAIBox2DRayCastCallback()
-  {
+  MOAIBox2DRayCastCallback() {
      m_fixture = NULL;
-	 m_point.SetZero();
-	 m_normal.SetZero();
+     m_point.SetZero();
+     m_normal.SetZero();
   }
  
-  float32 ReportFixture(   b2Fixture* fixture, const b2Vec2& point, const b2Vec2& normal, float32 fraction)
-  {
+  float32 ReportFixture(b2Fixture* fixture, const b2Vec2& point, const b2Vec2& normal, float32 fraction) {
      m_fixture = fixture;
      m_point = point;
      m_normal = normal;


### PR DESCRIPTION
Adding closest raycast support, as taken from the following thread/post:
- http://getmoai.com/forums/raycast-for-box2d-hack-t562/
- http://www.fivevolthigh.com/2013/10/moai-exposing-box2d-world-ray-casting-to-moai/

This feature is working well and complete in its own right but Box2D does have additional raycasting functionality that should be exposed too, via a callback to test if raycast should continue on through a fixture or not.  However even without that callback this closest raycast is still extremely useful.
