### PR TITLE
Hiq numeric keyboard support

### DIFF
--- a/ant/host-source/source/project/src/moai/MoaiKeyboard.java
+++ b/ant/host-source/source/project/src/moai/MoaiKeyboard.java
@@ -23,17 +23,19 @@ import android.widget.TextView;
 
 // These are necessary for the mKeyInTextView hack
 import android.widget.EditText;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.text.Editable;
+
 
 //================================================================//
 // MoaiLog
 //================================================================//
 public class MoaiKeyboard {
 	
-	private static Activity sActivity = null;
+	private static Activity mActivity = null;
 	private static EditText mKeyInTextView = null;
-
+	
 	protected static native void AKUNotifyKeyEvent ();
 	protected static native void AKUNotifyTextDone ();
 
@@ -42,21 +44,21 @@ public class MoaiKeyboard {
 
 	private static String mKeyString = new String ();
 
-	private static Context sContext;
+	private static Context mContext;
 	private static InputMethodManager mInputMethodManager;
 
 	private static LinearLayoutIMETrap mContainer;
 	
 	//----------------------------------------------------------------//
 	public static void onCreate ( Activity activity ) {
-		sActivity = activity;
-		sContext = activity;
+		mActivity = activity;
+		mContext = activity;
 		
 		// input manager is used to pop up the native Android keyboard as needed
-		mInputMethodManager = ( InputMethodManager ) sContext.getSystemService ( Context.INPUT_METHOD_SERVICE );
+		mInputMethodManager = ( InputMethodManager ) mContext.getSystemService ( Context.INPUT_METHOD_SERVICE );
 		
 		// Our main container holds the EGL view as well as our fake TextEdit view for keyboard entry ..
-		mContainer = ( LinearLayoutIMETrap ) new LinearLayoutIMETrap ( sContext );
+		mContainer = ( LinearLayoutIMETrap ) new LinearLayoutIMETrap ( mContext );
 		mContainer.setLayoutParams ( new LinearLayout.LayoutParams ( LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT ));
 		mContainer.setOrientation ( LinearLayout.VERTICAL );
 		mContainer.setMainActivity ( activity );
@@ -91,7 +93,7 @@ public class MoaiKeyboard {
 				return false;
 			}
 		});
-
+		
 		// Create the fake EditText, and push it outside the margins so that its not visible.
 		LinearLayout.LayoutParams paramsKeyInTextView = new LinearLayout.LayoutParams ( LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT );
 
@@ -126,16 +128,36 @@ public class MoaiKeyboard {
 		return mKeyString;
 	}
 	
-	public static void showKeyboard () {
-		sActivity.runOnUiThread( new Runnable () {
-			public void run () {
-				mInputMethodManager.showSoftInput ( mKeyInTextView, 0 );
-			}
-		});
+    public static void _showKeyboard ( final int inputType ) {
+         mActivity.runOnUiThread( new Runnable () {
+             public void run () {
+                 mKeyInTextView.setInputType( inputType );
+                 mInputMethodManager.showSoftInput ( mKeyInTextView, 0 );
+             }
+         });
+     }
+    public static void showKeyboard () {
+        showTextKeyboard();
+     }
+	
+	public static void showTextKeyboard() {
+		_showKeyboard( InputType.TYPE_CLASS_TEXT );
+	}
+	
+	public static void showNumberKeyboard() {
+	    _showKeyboard( InputType.TYPE_CLASS_NUMBER );
+	}
+	
+	public static void showDateTimeKeyboard() {
+	    _showKeyboard( InputType.TYPE_CLASS_DATETIME );
+	}
+	
+	public static void showPhoneKeyboard() {
+	    _showKeyboard( InputType.TYPE_CLASS_PHONE );
 	}
 
 	public static void hideKeyboard () {
-		sActivity.runOnUiThread( new Runnable () {
+		mActivity.runOnUiThread( new Runnable () {
 			public void run () {
 				mKeyInTextView.setText ( "" );
 				mInputMethodManager.hideSoftInputFromWindow ( mKeyInTextView.getWindowToken (), 0 );
@@ -144,7 +166,7 @@ public class MoaiKeyboard {
 	}
 		
 	public static void setText ( final String text ) {
-		sActivity.runOnUiThread( new Runnable () {
+		mActivity.runOnUiThread( new Runnable () {
 			public void run () {
 				mKeyInTextView.setText ( text );
 				mKeyInTextView.setSelection ( text.length ());

--- a/src/moai-android/MOAIKeyboardAndroid.cpp
+++ b/src/moai-android/MOAIKeyboardAndroid.cpp
@@ -24,11 +24,11 @@ extern JavaVM* jvm;
   
 //----------------------------------------------------------------//
 // The listeners need to be called on the event
-extern "C" bool Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyKeyEvent ( JNIEnv* env, jclass cls ) {
+extern "C" void Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyKeyEvent ( JNIEnv* env, jclass cls ) {
 	MOAIKeyboardAndroid::Get ().NotifyKeyEvent();
 }
 
-extern "C" bool Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyTextDone ( JNIEnv* env, jclass cls ) {
+extern "C" void Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyTextDone ( JNIEnv* env, jclass cls ) {
 	MOAIKeyboardAndroid::Get ().NotifyTextDone();
 }
 
@@ -40,15 +40,21 @@ int MOAIKeyboardAndroid::_hideKeyboard ( lua_State* L ) {
 	jclass moai = env->FindClass ( "com/ziplinegames/moai/MoaiKeyboard" );
 
 	if ( moai ) {
-		jmethodID hideSoftKeyboard = env->GetStaticMethodID ( moai, "hideKeyboard", "()Z" );
+        jmethodID hideSoftKeyboard = env->GetStaticMethodID ( moai, "hideKeyboard", "()V" );
 		if ( hideSoftKeyboard ) {
-			bool result = ( bool )env->CallStaticBooleanMethod ( moai, hideSoftKeyboard ); 
-			lua_pushboolean ( state, result );
+            env->CallStaticVoidMethod ( moai, hideSoftKeyboard );
+            // !hiq-max - max@dynlab.at !: pushing "false", because old code returned the value from call to nonexisting
+            // function "bool hideKeyboard()", signature is "void hideKeyboard()"
+            // void was casted to bool and returned to the lua vm
+            // this worked up until now, wrong function lookup and call caused segfault
+            lua_pushboolean ( state, false );
 			return 1;
 		}
 	}
 
 	MOAIKeyboardAndroid::Get ().Finish ();
+
+	return 0;
 }
 
 // Listeners use getText to retrieve the input
@@ -89,22 +95,40 @@ int MOAIKeyboardAndroid::_setText ( lua_State* L ) {
 			return 1;
 		}
 	}
-
+	return 0;
 }
 
 int MOAIKeyboardAndroid::_showKeyboard ( lua_State* L ) {
-  	MOAILuaState state ( L );
+    return _showTextKeyboard( L );
+}
 
-	JNI_GET_ENV ( jvm, env );
+int MOAIKeyboardAndroid::_showTextKeyboard( lua_State* L ) {
+    return _showKeyboardHelper( "showTextKeyboard" );
+}
 
-	jclass moai = env->FindClass ( "com/ziplinegames/moai/MoaiKeyboard" );
-	if ( moai ) {
-		jmethodID showKeyboard = env->GetStaticMethodID(moai, "showKeyboard", "()V");
-		if ( showKeyboard ) {
-			env->CallStaticVoidMethod ( moai, showKeyboard );
-		}
-	}
-	return 0;
+int MOAIKeyboardAndroid::_showNumberKeyboard( lua_State* L ) {
+    return _showKeyboardHelper( "showNumberKeyboard" );
+}
+
+int MOAIKeyboardAndroid::_showDateTimeKeyboard( lua_State* L ) {
+    return _showKeyboardHelper( "showDateTimeKeyboard" );
+}
+
+int MOAIKeyboardAndroid::_showPhoneKeyboard( lua_State* L ) {
+    return _showKeyboardHelper( "showPhoneKeyboard" );
+}
+
+int MOAIKeyboardAndroid::_showKeyboardHelper( const char* j_func ) {
+    JNI_GET_ENV ( jvm, env );
+
+    jclass t_class = env->FindClass ( "com/ziplinegames/moai/MoaiKeyboard" );
+    if ( t_class ) {
+        jmethodID t_func = env->GetStaticMethodID(t_class, j_func, "()V");
+        if ( t_func ) {
+            env->CallStaticVoidMethod ( t_class, t_func );
+        }
+    }
+    return 0;
 }
 
 //================================================================//
@@ -193,8 +217,14 @@ void MOAIKeyboardAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 	luaL_Reg regTable [] = {
 		{ "getText",        _getText },
 		{ "setListener",    _setListener  },
-		{ "showKeyboard",   _showKeyboard },
-		{ "hideKeyboard",   _hideKeyboard },
+
+		{ "showKeyboard",           _showKeyboard },
+        { "showTextKeyboard",       _showTextKeyboard },
+        { "showNumberKeyboard",     _showNumberKeyboard },
+        { "showDateTimeKeyboard",   _showDateTimeKeyboard },
+        { "showPhoneKeyboard",      _showPhoneKeyboard },
+
+        { "hideKeyboard",   _hideKeyboard },
 		{ "setText",      _setText },
 		{ NULL, NULL }
 	};

--- a/src/moai-android/MOAIKeyboardAndroid.h
+++ b/src/moai-android/MOAIKeyboardAndroid.h
@@ -27,11 +27,19 @@ class MOAIKeyboardAndroid :
 private:
 
 	//----------------------------------------------------------------//
-	static int    _getText        ( lua_State* L );
-	static int    _showKeyboard   ( lua_State* L );
-	static int    _hideKeyboard   ( lua_State* L );
-	static int    _setListener    ( lua_State* L );
-	static int    _setText        ( lua_State* L );
+	static int _getText              ( lua_State* L );
+
+	static int _showKeyboard         ( lua_State* L );
+	static int _showTextKeyboard     ( lua_State* L );
+	static int _showNumberKeyboard   ( lua_State* L );
+	static int _showDateTimeKeyboard ( lua_State* L );
+	static int _showPhoneKeyboard    ( lua_State* L );
+
+	static int _hideKeyboard         ( lua_State* L );
+	static int _setListener          ( lua_State* L );
+	static int _setText              ( lua_State* L );
+
+	static int _showKeyboardHelper   ( const char* j_func );
 
 	//----------------------------------------------------------------//
 	void      ShowKeyboard      ( cc8* text, int type, int returnKey, bool secure, int autocap, int appearance );


### PR DESCRIPTION
 added support for number-, datetime, phone-keyboard on android

fixed critical bug on MOAIKeyboardAndroid::_hideKeyboard (segfault because of wrong java method lookup - strange that this worked until now)
fixed return types for functions called from java
