### PR TITLE
revert oninvalidate override on image texture

### DIFF
--- a/src/moai-sim/MOAIImageTexture.cpp
+++ b/src/moai-sim/MOAIImageTexture.cpp
@@ -124,10 +124,6 @@ void MOAIImageTexture::OnCreate () {
 void MOAIImageTexture::OnLoad () {
 }
 
-//----------------------------------------------------------------//
-void MOAIImageTexture::OnInvalidate () {
-}
-
 
 //----------------------------------------------------------------//
 void MOAIImageTexture::RegisterLuaClass ( MOAILuaState& state ) {

--- a/src/moai-sim/MOAIImageTexture.h
+++ b/src/moai-sim/MOAIImageTexture.h
@@ -39,7 +39,6 @@ private:
 	void			OnClear					();
 	void			OnCreate				();
 	void			OnLoad					();
-	void			OnInvalidate     		();
 
 public:
 	


### PR DESCRIPTION
By not freeing the texture handle on invalidate, we break fonts on android app resume.
This fixes https://github.com/moai/moai-dev/issues/838

These lines were put in as a fix for texture being realloced for each glyph added. which in turn was caused by
https://github.com/patrickmeehan/moai-dev/commit/96ba90a61897bf7f15bbb45b3547db5748d06e9f
where the line page->mImageTexture->Invalidate (); was added in an attempt to refresh the image texture on glyph addition. I am guessing that is calling the wrong invalidate, we probably just want to update the texture data not blow it away.
