### PR TITLE
Expose Box2D Body property: GravityScale

### DIFF
--- a/src/moai-box2d/MOAIBox2DBody.cpp
+++ b/src/moai-box2d/MOAIBox2DBody.cpp
@@ -438,6 +438,28 @@ int MOAIBox2DBody::_getInertia ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	getGravityScale
+	@text	See Box2D documentation.
+	
+	@in		MOAIBox2DBody self
+	@out	number gravityScale
+*/
+int MOAIBox2DBody::_getGravityScale ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIBox2DBody, "U" )
+	
+	if ( !self->mBody ) {
+		MOAILog ( state, MOAILogMessages::MOAIBox2DBody_MissingInstance );
+		return 0;
+	}
+	
+	float scale = self->mBody->GetGravityScale ();
+
+	lua_pushnumber ( state, scale );
+	
+	return 1;
+}
+
+//----------------------------------------------------------------//
 /**	@name	getLinearVelocity
 	@text	See Box2D documentation.
 	
@@ -789,6 +811,28 @@ int MOAIBox2DBody::_setFixedRotation ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	setGravityScale
+	@text	See Box2D documentation.
+	
+	@in		MOAIBox2DBody self
+	@opt	number gravityScale.
+	@out	nil
+*/
+int MOAIBox2DBody::_setGravityScale ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIBox2DBody, "UN" );
+
+	if ( !self->mBody ) {
+		MOAILog ( state, MOAILogMessages::MOAIBox2DBody_MissingInstance );
+		return 0;
+	}
+
+	float scale = state.GetValue < float >( 2, 0.0f );
+	self->mBody->SetGravityScale ( scale );
+
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /**	@name	setLinearDamping
 	@text	See Box2D documentation.
 	
@@ -1021,6 +1065,7 @@ void MOAIBox2DBody::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "getAngle",				_getAngle },
 		{ "getAngularVelocity",		_getAngularVelocity },
 		{ "getInertia",				_getInertia },
+		{ "getGravityScale",		_getGravityScale },
 		{ "getLinearVelocity",		_getLinearVelocity },
 		{ "getLocalCenter",			_getLocalCenter },
 		{ "getMass",				_getMass },
@@ -1037,6 +1082,7 @@ void MOAIBox2DBody::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "setAwake",				_setAwake },
 		{ "setBullet",				_setBullet },
 		{ "setFixedRotation",		_setFixedRotation },
+		{ "setGravityScale",		_setGravityScale },
 		{ "setLinearDamping",		_setLinearDamping },
 		{ "setLinearVelocity",		_setLinearVelocity },
 		{ "setMassData",			_setMassData },

--- a/src/moai-box2d/MOAIBox2DBody.h
+++ b/src/moai-box2d/MOAIBox2DBody.h
@@ -40,6 +40,7 @@ private:
 	static int		_getAngle				( lua_State* L );
 	static int		_getAngularVelocity		( lua_State* L );
 	static int		_getInertia				( lua_State* L );
+	static int		_getGravityScale		( lua_State* L );
 	static int		_getLinearVelocity		( lua_State* L );
 	static int		_getLocalCenter			( lua_State* L );
 	static int		_getMass				( lua_State* L );
@@ -56,6 +57,7 @@ private:
 	static int		_setAwake				( lua_State* L );
 	static int		_setBullet				( lua_State* L );
 	static int		_setFixedRotation		( lua_State* L );
+	static int		_setGravityScale		( lua_State* L );
 	static int		_setLinearDamping		( lua_State* L );
 	static int		_setLinearVelocity		( lua_State* L );
 	static int		_setMassData			( lua_State* L );


### PR DESCRIPTION
Two new methods for MOAIBox2DBody, setGravityScale and getGravityScale. Enable modifications in GravityScale for some handy interactions. Is the only way for making a body float in the world without any tilting effect.
