### PR TITLE
SDLHost: Fixing Segfault caused by wrong handling in huge SDL keycodes

### DIFF
--- a/src/host-sdl/SDLHost.cpp
+++ b/src/host-sdl/SDLHost.cpp
@@ -142,10 +142,13 @@ void MainLoop () {
 					break;
 				
 				case SDL_KEYDOWN:
-				case SDL_KEYUP:
-				
-					AKUEnqueueKeyboardEvent ( InputDeviceID::DEVICE, InputSensorID::KEYBOARD, sdlEvent.key.keysym.sym, sdlEvent.key.type == SDL_KEYDOWN );
-					break;
+				case SDL_KEYUP:	{
+					int key = sdlEvent.key.keysym.sym;
+					if (key & 0x40000000) key = (key & 0x3FFFFFFF) + 256;
+			
+					AKUEnqueueKeyboardEvent ( InputDeviceID::DEVICE, InputSensorID::KEYBOARD, key, sdlEvent.key.type == SDL_KEYDOWN );
+
+				} 	break;
 					
 				case SDL_MOUSEBUTTONDOWN:
 				case SDL_MOUSEBUTTONUP:

--- a/src/moai-sim/MOAIKeyboardSensor.h
+++ b/src/moai-sim/MOAIKeyboardSensor.h
@@ -14,7 +14,7 @@ namespace MOAIKeyCodes {
 		SHIFT	= 256,
 		CONTROL,
 		ALT,
-		TOTAL,
+		TOTAL   = 512,
 	};
 };
 


### PR DESCRIPTION
Keycodes of keys without character representation are bigger than 0x40000000 (see http://wiki.libsdl.org/SDLKeycodeLookup). And keycodes in SDL2 are more than 258. 

This fix translates huge keycodes into minor ones, and extends the key storage array from 258 to 512.
