### PR TITLE
Support Android url scheme and event APP_OPENED_FROM_URL

### DIFF
--- a/ant/host-source/source/project/AndroidManifest.xml
+++ b/ant/host-source/source/project/AndroidManifest.xml
@@ -27,6 +27,13 @@
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<!-- Add your URL-scheme here -->
+				<data android:scheme="moaisample" />
+			</intent-filter>
 		</activity>
 		
 		<activity 

--- a/ant/host-source/source/project/src/app/MoaiActivity.java
+++ b/ant/host-source/source/project/src/app/MoaiActivity.java
@@ -148,6 +148,10 @@ public class MoaiActivity extends Activity {
 		
 		MoaiLog.i ( "MoaiActivity onNewIntent: application started from NEW INTENT" );
 		
+		Uri data = intent.getData();
+		if (data != null) {
+			Moai.AppOpenedFromURL ( data.toString() );
+		}
 		setIntent ( intent );
 	}
 

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -126,6 +126,7 @@ public class Moai {
 	protected static native void    AKUModulesContextInitialize     ();
 	protected static native void	AKUAppDialogDismissed			( int dialogResult );
 	protected static native void	AKUAppDidStartSession			( boolean resumed );
+	protected static native void	AKUAppOpenedFromURL			( String url );
 	protected static native void	AKUAppWillEndSession 			();
 	protected static native int		AKUCreateContext 				();
 	protected static native void	AKUDetectGfxContext 			();
@@ -200,6 +201,12 @@ public class Moai {
 	public static void dialogDismissed ( int dialogResult ) {
 		synchronized ( sAkuLock ) {
 			AKUAppDialogDismissed ( dialogResult );
+		}
+	}
+
+	public static void AppOpenedFromURL ( String Url ) {
+		synchronized ( sAkuLock ) {
+			AKUAppOpenedFromURL ( url );
 		}
 	}
 

--- a/src/moai-android/MOAIAppAndroid.cpp
+++ b/src/moai-android/MOAIAppAndroid.cpp
@@ -289,6 +289,10 @@ bool MOAIAppAndroid::NotifyBackButtonPressed () {
 	}
 }
 
+extern "C" bool Java_com_ziplinegames_moai_Moai_AKUAppOpenedFromURL ( JNIEnv* env, jclass obj, jstring url ) {
+	MOAIAppAndroid::Get ().AppOpenedFromURL ( url );
+}
+
 //----------------------------------------------------------------//
 void MOAIAppAndroid::NotifyDidStartSession ( bool resumed ) {
 
@@ -416,4 +420,3 @@ extern "C" void Java_com_ziplinegames_moai_Moai_AKUAppWillEndSession ( JNIEnv* e
 extern "C" void Java_com_ziplinegames_moai_MoaiCamera_AKUNotifyPictureTaken( JNIEnv* env, jclass obj ) {
 	MOAIAppAndroid::Get().NotifyPictureTaken();
 }
-

--- a/src/moai-android/MOAIAppAndroid.cpp
+++ b/src/moai-android/MOAIAppAndroid.cpp
@@ -230,7 +230,8 @@ MOAIAppAndroid::~MOAIAppAndroid () {
 //----------------------------------------------------------------//
 void MOAIAppAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 
-	state.SetField ( -1, "SESSION_START",		    ( u32 )SESSION_START );
+	state.SetField ( -1, "APP_OPENED_FROM_URL",     ( u32 )APP_OPENED_FROM_URL );
+       state.SetField ( -1, "SESSION_START",		    ( u32 )SESSION_START );
 	state.SetField ( -1, "SESSION_END",			    ( u32 )SESSION_END );
 	state.SetField ( -1, "BACK_BUTTON_PRESSED",		( u32 )BACK_BUTTON_PRESSED );
 	state.SetField ( -1, "EVENT_PICTURE_TAKEN",		( u32 )EVENT_PICTURE_TAKEN );
@@ -251,6 +252,26 @@ void MOAIAppAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 }
 
 //----------------------------------------------------------------//
+void MOAIAppAndroid::AppOpenedFromURL ( jstring url ) {
+  MOAILuaRef& callback = this->mListeners [ APP_OPENED_FROM_URL ];
+
+       if ( callback ) {
+
+               MOAILuaStateHandle state = callback.GetSelf ();
+
+               JNI_GET_ENV ( jvm, env );
+
+               JNI_GET_CSTRING ( url, returnurl );
+
+               lua_pushstring ( state, returnurl );
+
+               state.DebugCall ( 1, 0 );
+
+               JNI_RELEASE_CSTRING ( url, returnurl );
+
+       }
+}
+
 bool MOAIAppAndroid::NotifyBackButtonPressed () {
 
 	MOAILuaRef& callback = this->mListeners [ BACK_BUTTON_PRESSED ];

--- a/src/moai-android/MOAIAppAndroid.h
+++ b/src/moai-android/MOAIAppAndroid.h
@@ -25,6 +25,7 @@ class MOAIAppAndroid :
 private:
 
 	enum {
+		APP_OPENED_FROM_URL,
 		SESSION_START,
 		SESSION_END,
 		BACK_BUTTON_PRESSED,
@@ -57,6 +58,7 @@ public:
 			MOAIAppAndroid				();
 			~MOAIAppAndroid				();
 	bool	NotifyBackButtonPressed		();
+	void	AppOpenedFromURL		( jstring url );
 	void	NotifyDidStartSession		( bool resumed );
 	void	NotifyWillEndSession		();
 


### PR DESCRIPTION
This adds the event APP_OPENED_FROM_URL to the android host as well. Very useful for deep-linking. We are using this in our host, but it presents one problem:

The code included here in the pull request will only trigger the event if the app is already running. As this very often is not the case, we hacked around it by triggering the event a little bit delayed in the onResume function. If anyone with android skills and knowledge have a good solution to this, that would make the pull request more complete.
