### PR TITLE
Added methods for dumping the Lua stack to MOAILuaState

### DIFF
--- a/src/moai-core/MOAILuaState.cpp
+++ b/src/moai-core/MOAILuaState.cpp
@@ -421,6 +421,57 @@ void* MOAILuaState::GetPtrUserData ( int idx ) {
 }
 
 //----------------------------------------------------------------//
+STLString MOAILuaState::GetStackDump () {
+	STLString out;
+	int top = GetTop ();
+	out.write ( "Lua stack: %d element(s)", top );
+
+	for ( int index = top; index >= 1; index-- ) {
+		int type = lua_type ( this->mState, index );
+
+		// Print index and type
+		int relativeIndex = index - top - 1;
+		out.write ( "\n[ %d | %d ] = %s", index, relativeIndex, GetLuaTypeName ( type ) );
+
+		// Print value, if possible
+		switch ( type ) {
+		case LUA_TBOOLEAN:
+			// boolean
+			out.write ( ": %s", lua_toboolean ( this->mState, index ) ? "true" : "false" );
+			break;
+		case LUA_TNUMBER:
+			// number
+			out.write ( ": %g", lua_tonumber ( this->mState, index ) );
+			break;
+		case LUA_TSTRING:
+			// string
+			out.write ( ": \"%s\"", lua_tostring ( this->mState, index ) );
+			break;
+		case LUA_TUSERDATA:
+			// userdata
+		{
+			// Moai uses userdata exclusively for pointers to MOAILuaObject instances.
+			// This code will most likely crash if it encounters userdata that is used differently.
+			MOAILuaObject* luaObject = ( MOAILuaObject* )this->GetPtrUserData ( index );
+			if ( luaObject ) {
+				out.write ( ": %s at %p", luaObject->TypeName (), luaObject );
+			}
+			break;
+		}
+		case LUA_TLIGHTUSERDATA:
+		case LUA_TTABLE:
+		case LUA_TFUNCTION:
+		case LUA_TTHREAD:
+			// anything with an address
+			out.write ( " at %p", lua_topointer ( this->mState, index ) );
+			break;
+		}
+	}
+
+	return out;
+}
+
+//----------------------------------------------------------------//
 STLString MOAILuaState::GetStackTrace ( int level ) {
 
 	int firstpart = 1;  /* still before eventual `...' */
@@ -802,6 +853,18 @@ bool MOAILuaState::PrintErrors ( FILE* file, int status ) {
 		return true;
 	}
 	return false;
+}
+
+//----------------------------------------------------------------//
+void MOAILuaState::PrintStackDump () {
+	STLString stackDump = this->GetStackDump ();
+	ZLLog::Print ( stackDump );
+}
+
+//----------------------------------------------------------------//
+void MOAILuaState::PrintStackDump ( FILE* file  ) {
+	STLString stackDump = this->GetStackDump ();
+	ZLLog::PrintFile ( file, stackDump );
 }
 
 //----------------------------------------------------------------//

--- a/src/moai-core/MOAILuaState.cpp
+++ b/src/moai-core/MOAILuaState.cpp
@@ -468,6 +468,7 @@ STLString MOAILuaState::GetStackDump () {
 		}
 	}
 
+	out.write("\n");
 	return out;
 }
 

--- a/src/moai-core/MOAILuaState.h
+++ b/src/moai-core/MOAILuaState.h
@@ -47,6 +47,7 @@ public:
 	bool			GetFieldWithType		( int idx, int key, int type );
 	static cc8*		GetLuaTypeName			( int type );
 	void*			GetPtrUserData			( int idx );
+	STLString		GetStackDump			();
 	STLString		GetStackTrace			( int level );
 	int				GetTop					();
 	void*			GetUserData				( int idx, void* value );
@@ -69,6 +70,8 @@ public:
 	void			Pop						( int n );
 	bool			PrepMemberFunc			( int idx, cc8* name );
 	bool			PrintErrors				( FILE* file, int status );
+	void			PrintStackDump			();
+	void			PrintStackDump			( FILE* file );
 	void			PrintStackTrace			( FILE* file, int level );
 	void			Push					();
 	void			Push					( bool value );


### PR DESCRIPTION
These methods are handy when debugging Moai's low-level Lua calls.
