### PR TITLE
Fixed bad upvalue for MOAILuaClass::_extendSingleton()

### DIFF
--- a/src/moai-core/MOAILuaClass.cpp
+++ b/src/moai-core/MOAILuaClass.cpp
@@ -293,7 +293,7 @@ void MOAILuaClass::InitLuaSingletonClass ( MOAILuaObject& data, MOAILuaState& st
 	data.RegisterLuaClass ( state );
 	
 	// init the extend method
-	lua_pushvalue ( state, -1 ); // copy of userdata //used to be 1
+	state.PushPtrUserData ( &data ); // copy of userdata
 	lua_pushvalue ( state, -2 ); // copy of class table
 	lua_pushcclosure ( state, _extendSingleton, 2 );
 	lua_setfield ( state, -2, "extend" );


### PR DESCRIPTION
`MOAILuaClass::InitLuaSingletonClass()` tries to create a C closure from the `_extendSingleton()` method with the userdata and class table as upvalues. Even after @halfnelson's fix, however, it instead used two copies of the class table as upvalues. As a result, `_extendSingleton()` always received a NULL-pointer as first upvalue (because a table cannot be converted to userdata).
