### PR TITLE
Pull untz improvements

### DIFF
--- a/3rdparty/untz/src/UntzSound.cpp
+++ b/3rdparty/untz/src/UntzSound.cpp
@@ -13,7 +13,9 @@
 // Audio sources
 #include "UserAudioSource.h"
 #include "MemoryAudioSource.h"
-#include "OggAudioSource.h"
+#if MOAI_WITH_VORBIS
+   #include "OggAudioSource.h"
+#endif
 #if defined(WIN32)
 	#include <Native/Win/DShowAudioSource.h>
 #else
@@ -32,9 +34,10 @@ Sound* Sound::create(const RString& path, bool loadIntoMemory)
 {
 	Sound* prevSound = UNTZ::System::get()->getData()->getInMemorySound(path);
 	Sound* newSound = new Sound();
-
+	
 	if (path.find(OGG_FILE_EXT) != RString::npos)
 	{
+#if MOAI_WITH_VORBIS
 		OggAudioSource* source;
 		if(prevSound && loadIntoMemory && prevSound->getData()->getSource()->isLoadedInMemory())
 			// Use the existing AudioSource
@@ -62,6 +65,10 @@ Sound* Sound::create(const RString& path, bool loadIntoMemory)
 			delete newSound;
 			return 0;
 		}
+#else
+			delete newSound;
+			return 0;
+#endif
 	}
 	else
 	{
@@ -157,10 +164,12 @@ bool Sound::decode(const RString& path, SoundInfo& info, float** data)
 	AudioSource* source = 0;
 	if (path.find(OGG_FILE_EXT) != RString::npos)
 	{
+#if MOAI_WITH_VORBIS
 		OggAudioSource* as = new OggAudioSource();
 		source = as;
 		if(as->init(path, true))
 			decoded = true;
+#endif
 	}
 	else
 	{

--- a/ant/libmoai/jni/src/moai.cpp
+++ b/ant/libmoai/jni/src/moai.cpp
@@ -347,7 +347,11 @@
 	//----------------------------------------------------------------//
 	extern "C" void Java_com_ziplinegames_moai_Moai_AKUPause ( JNIEnv* env, jclass obj, jboolean paused ) {
 
-		AKUPause ( paused );
+		if (paused) {
+			AKUModulesPause ();
+		} else {
+			AKUModulesResume ();
+		}
 	}
 
 	//----------------------------------------------------------------//

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -261,8 +261,9 @@ add_subdirectory ( moai-chipmunk )
 add_subdirectory ( moai-untz )
 add_subdirectory ( moai-http-client )
 add_subdirectory ( moai-luaext )
-
-add_subdirectory ( moai-test)
+if (MOAI_TEST)
+   add_subdirectory ( moai-test)
+endif (MOAI_TEST)
 
 if (MOAI_PLUGINS)
   add_subdirectory ( moai-plugins )

--- a/src/host-ios/Classes/MoaiView.mm
+++ b/src/host-ios/Classes/MoaiView.mm
@@ -264,12 +264,12 @@ namespace MoaiInputDeviceSensorID {
 	-( void ) pause :( BOOL )paused {
 	
 		if ( paused ) {
-			AKUPause ( YES );
+			AKUModulesPause ();
 			[ self stopAnimation ];
 		}
 		else {
 			[ self startAnimation ];
-			AKUPause ( NO );
+			AKUModulesResume ();
 		}
 	}
 	

--- a/src/host-modules/aku_modules.cpp
+++ b/src/host-modules/aku_modules.cpp
@@ -279,3 +279,24 @@ void AKUModulesUpdate () {
 		AKUPluginsUpdate ();
 	#endif
 }
+
+void AKUModulesPause () {
+	#if AKU_WITH_UNTZ
+		AKUUntzPause ();
+	#endif
+	
+	#if AKU_WITH_SIM
+		AKUPause ( true );
+	#endif
+
+}
+
+void AKUModulesResume () {
+	#if AKU_WITH_UNTZ
+		AKUUntzResume ();
+	#endif
+
+	#if AKU_WITH_SIM
+		AKUPause ( false );
+	#endif
+}

--- a/src/host-modules/aku_modules.h
+++ b/src/host-modules/aku_modules.h
@@ -64,5 +64,7 @@ void		AKUModulesContextInitialize				();
 void		AKUModulesParseArgs						( int argc, char** argv );
 void		AKUModulesRunLuaAPIWrapper				();
 void		AKUModulesUpdate						();
+void		AKUModulesPause							();
+void		AKUModulesResume						();
 
 #endif

--- a/src/host-modules/aku_modules_config.h
+++ b/src/host-modules/aku_modules_config.h
@@ -29,7 +29,7 @@
 	#endif
 	
 	#ifndef AKU_WITH_HTTP_SERVER
-		#define AKU_WITH_HTTP_SERVER 1
+		#define AKU_WITH_HTTP_SERVER 0
 	#endif
 	
 	#ifndef AKU_WITH_LUAEXT

--- a/src/moai-untz/host.cpp
+++ b/src/moai-untz/host.cpp
@@ -29,3 +29,10 @@ void AKUUntzContextInitialize () {
 	REGISTER_LUA_CLASS ( MOAIUntzSystem )
 }
 
+void AKUUntzPause() {
+	MOAIUntzSystem::Get ().Suspend ();
+}
+
+void AKUUntzResume() {
+	MOAIUntzSystem::Get ().Resume ();
+}

--- a/src/moai-untz/host.h
+++ b/src/moai-untz/host.h
@@ -12,5 +12,6 @@
 AKU_API void	AKUUntzAppFinalize					();
 AKU_API void	AKUUntzAppInitialize				();
 AKU_API void	AKUUntzContextInitialize			();
-
+AKU_API void	AKUUntzPause			();
+AKU_API void	AKUUntzResume			();
 #endif


### PR DESCRIPTION
Allow untz to be compiled without vorbis (https://github.com/moai/moai-dev/issues/860)
Allow host-glut to be compiled without tinyxml by skipping moai-test dependency
Reintroduce untssuspend and untzresume by adding modulesPause and modulesResume and wrapping existing AKUPause code in those calls along with calls to untz
Should fix battery drain when minimized
