### PR TITLE
Default to windows mode for Android build.bat

### DIFF
--- a/ant/libmoai/build.bat
+++ b/ant/libmoai/build.bat
@@ -4,5 +4,5 @@
 :: http://getmoai.com
 ::================================================================::
 
-	bash ./build.sh %*
+	bash ./build.sh %* --windows
 	@pause


### PR DESCRIPTION
Took me a while to find that --windows switch in the build script. I think you'll always want it running from the .bat
