### PR TITLE
Add required flags, classes and definitions for play services.

### DIFF
--- a/ant/host-source/d.settings-global.sh
+++ b/ant/host-source/d.settings-global.sh
@@ -25,8 +25,8 @@
 # (this list is created by make-host.sh using command-line 
 # information)
 # available: facebook, tapjoy, twitter, chartboost, crittercism,
-# google-push, google-billing, miscellaneous (required by
-# google-billing)
+# google-push, google-billing, google-play-services, miscellaneous
+# (required by google-billing)
 #----------------------------------------------------------------#
 
 	requires=( @REQUIRED_LIBS@ )

--- a/ant/host-source/d.settings-local.sh
+++ b/ant/host-source/d.settings-local.sh
@@ -19,7 +19,7 @@
 # the assets directory of the bundle
 #----------------------------------------------------------------#
 
-	src_dirs=( "../../samples/anim/anim-basic" )
+	src_dirs=( "../../../samples/anim/anim-basic" )
 	dest_dirs=(	"lua" )
 
 #----------------------------------------------------------------#

--- a/ant/host-source/source/project/src/app/MoaiActivity.java
+++ b/ant/host-source/source/project/src/app/MoaiActivity.java
@@ -81,13 +81,13 @@ public class MoaiActivity extends Activity {
 
 		mAccelerometerData = new float[3];
 		
+		requestWindowFeature ( Window.FEATURE_NO_TITLE );
 		super.onCreate ( savedInstanceState );
 		Moai.onCreate ( this );
 		
 		Moai.createContext ();
 		Moai.init ();
 		
-		requestWindowFeature ( Window.FEATURE_NO_TITLE );
 		getWindow ().addFlags ( WindowManager.LayoutParams.FLAG_FULLSCREEN );
 		getWindow ().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 		//getWindow ().addFlags ( WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON );

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -108,6 +108,7 @@ public class Moai {
 		"com.ziplinegames.moai.MoaiFacebook",
 		"com.ziplinegames.moai.MoaiKeyboard",
 		"com.ziplinegames.moai.MoaiGoogleBilling",
+		"com.ziplinegames.moai.MoaiGooglePlayServices",
 		"com.ziplinegames.moai.MoaiGooglePush",
 		"com.ziplinegames.moai.MoaiTapjoy",
 		"com.ziplinegames.moai.MoaiTwitter",

--- a/ant/libmoai/build.sh
+++ b/ant/libmoai/build.sh
@@ -18,7 +18,7 @@ fi
 usage="usage: $0  \
     [--use-untz true | false] [--use-luajit true | false] [--disable-adcolony] [--disable-billing] \
     [--disable-chartboost] [--disable-crittercism] [--disable-facebook] [--disable-push] [--disable-tapjoy] \
-    [--disable-twitter] [--windows] [--release]"
+    [--disable-twitter] [--disable-playservices] [--windows] [--release]"
 
 use_untz="true"
 use_luajit="false"
@@ -33,6 +33,7 @@ tapjoy_flags=
 twitter_flags=
 buildtype_flags="Debug"
 windows_flags=
+playservices_flags=
 
 while [ $# -gt 0 ];	do
     case "$1" in
@@ -46,6 +47,7 @@ while [ $# -gt 0 ];	do
         --disable-push)  push_flags="-DDISABLE_NOTIFICATIONS";;
         --disable-tapjoy)  tapjoy_flags="-DDISABLE_TAPJOY";;
         --disable-twitter)  twitter_flags="-DDISABLE_TWITTER";;
+        --disable-playservices)  playservices_flags="-DDISABLE_PLAYSERVICES";;
         --release) buildtype_flags="Release";;
         --windows) windows_flags=-G"MinGW Makefiles";; 
         -*)

--- a/ant/libmoai/jni/src/moai.cpp
+++ b/ant/libmoai/jni/src/moai.cpp
@@ -312,6 +312,11 @@
 		REGISTER_LUA_CLASS ( MOAITstoreGamecenterAndroid );
 #endif
 		
+#ifndef DISABLE_PLAYSERVICES
+		MOAIGooglePlayServicesAndroid::Affirm ();
+		REGISTER_LUA_CLASS ( MOAIGooglePlayServicesAndroid );
+#endif
+
 		inputQueue = new LockingQueue < InputEvent > ();
 	}
 	

--- a/ant/make-host.sh
+++ b/ant/make-host.sh
@@ -13,7 +13,7 @@ cd `dirname $0`/
 usage="usage: $0 [-p <package>] [-s] [-i thumb | arm] [-a all | armeabi | armeabi-v7a] [-l appPlatform] [--use-fmod \
     true | false] [--use-untz true | false] [--use-luajit true | false] [--disable-adcolony] [--disable-billing] \
     [--disable-chartboost] [--disable-crittercism] [--disable-facebook] [--disable-push] [--disable-tapjoy] \
-    [--disable-twitter] [--windows]"
+    [--disable-twitter] [--disable-playservices] [--windows]"
 skip_build="false"
 package_name="com.getmoai.samples"
 arm_mode="arm"
@@ -31,6 +31,7 @@ push_flags=
 tapjoy_flags=
 twitter_flags=
 windows_flags=
+playservices_flags=
 
 while [ $# -gt 0 ];	do
     case "$1" in
@@ -50,6 +51,7 @@ while [ $# -gt 0 ];	do
         --disable-push)  push_flags="--disable-push";;
         --disable-tapjoy)  tapjoy_flags="--disable-tapjoy";;
         --disable-twitter)  twitter_flags="--disable-twitter";;
+        --disable-playservices)  playservices_flags="-DDISABLE_PLAYSERVICES";;
         --windows) windows_flags="--windows";;
         -*)
             echo >&2 \
@@ -165,6 +167,10 @@ fi
 
 if [ x"$twitter_flags" == x ]; then
     required_libs="$required_libs \"twitter\""
+fi
+
+if [ x"$playservices_flags" == x ]; then
+    required_libs="$required_libs \"google-play-services\""
 fi
 
 cp -f host-source/d.settings-local.sh $new_host_dir/settings-local.sh


### PR DESCRIPTION
Testing 1.5 it seems that not all changes required to expose Google play services are in order. 

This fixes that.
