### PR TITLE
MOAIEnvironment.cacheDirectory support added for Android.

### DIFF
--- a/ant/host-source/source/project/src/app/MoaiActivity.java
+++ b/ant/host-source/source/project/src/app/MoaiActivity.java
@@ -110,7 +110,15 @@ public class MoaiActivity extends Activity {
 
 			MoaiLog.e ( "MoaiActivity onCreate: Unable to set the document directory" );
 		}
-				
+		
+		if (  getCacheDir () != null ) {
+		 
+		 	Moai.setCacheDirectory ( getCacheDir ().getAbsolutePath ());
+		} else {
+
+			MoaiLog.e ( "MoaiActivity onCreate: Unable to set the cache directory" );
+		}
+		
 		Display display = (( WindowManager ) getSystemService ( Context.WINDOW_SERVICE )).getDefaultDisplay ();
 		ConfigurationInfo info = (( ActivityManager ) getSystemService ( Context.ACTIVITY_SERVICE )).getDeviceConfigurationInfo ();
 

--- a/ant/host-source/source/project/src/moai/Moai.java
+++ b/ant/host-source/source/project/src/moai/Moai.java
@@ -146,6 +146,7 @@ public class Moai {
 	protected static native void	AKUSetContext 					( int contextId );
 	protected static native void	AKUSetDeviceProperties 			( String appName, String appId, String appVersion, String abi, String devBrand, String devName, String devManufacturer, String devModel, String devProduct, int numProcessors, String osBrand, String osVersion, String udid );
 	protected static native void	AKUSetDocumentDirectory 		( String path );
+	protected static native void 	AKUSetCacheDirectory 			( String path );
 	protected static native void	AKUSetInputConfigurationName	( String name );
 	protected static native void	AKUSetInputDevice		 		( int deviceId, String name );
 	protected static native void	AKUSetInputDeviceCompass 		( int deviceId, int sensorId, String name );
@@ -410,6 +411,14 @@ public class Moai {
 		}
 	}
 
+	//----------------------------------------------------------------//
+	public static void setCacheDirectory ( String path ) {
+		
+		synchronized ( sAkuLock ) {
+			AKUSetCacheDirectory ( path );
+		}
+	}	
+	
 	//----------------------------------------------------------------//
 	public static void setScreenSize ( int width, int height ) {
 		synchronized ( sAkuLock ) {

--- a/ant/libmoai/jni/src/moai.cpp
+++ b/ant/libmoai/jni/src/moai.cpp
@@ -457,6 +457,16 @@
 	}
 
 	//----------------------------------------------------------------//
+	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetCacheDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
+		
+		JNI_GET_CSTRING ( jpath, path );
+		
+		MOAIEnvironment::Get ().SetValue ( MOAI_ENV_cacheDirectory,	path );
+		
+		JNI_RELEASE_CSTRING ( jpath, path );
+	}
+
+	//----------------------------------------------------------------//
 	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputConfigurationName ( JNIEnv* env, jclass obj, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );


### PR DESCRIPTION
It feeds MOAIEnvironment.cacheDirectory for the Android host.
Builded on Linux and tested on Android.
