### PR TITLE
Fix MOAICamera so it does not respond to all activityresults.

### DIFF
--- a/ant/host-source/source/project/src/moai/MoaiCamera.java
+++ b/ant/host-source/source/project/src/moai/MoaiCamera.java
@@ -41,12 +41,12 @@ public class MoaiCamera  {
 		            // Image capture failed, advise user
 		        	sResultPath = "";
 		        }
+		        // tell jni that we are finished
+		        AKUNotifyPictureTaken();
 		    } else {
 		    	sResultCode = 666;
 	        	sResultPath = "";
 		    }
-		    // tell jni that we are finished
-		    AKUNotifyPictureTaken();
 		}
     }
 	


### PR DESCRIPTION
MOAICamera used to answer to all activity results, so that for example suing facebook or play services caused a crash. This fixes that.

Also discussed in http://getmoai.com/forums/problems-with-external-services-in-android-1-5-t2631/
