### PR TITLE
Remove community fork from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ This SDK uses the [CPAL license](http://www.opensource.org/licenses/cpal_1.0). R
 ## Forks
 
 * [patrickmeehan/moai-dev](https://github.com/patrickmeehan/moai-dev)
-* [moaiforge/moai-sdk](https://github.com/moaiforge/moai-sdk) 
-* [moai-community/moai-dev](https://github.com/moai-community/moai-dev)
+* [moaiforge/moai-sdk](https://github.com/moaiforge/moai-sdk)
 
 ## Links
 


### PR DESCRIPTION
This IS the community fork, the old one is just confusing :)
