### PR TITLE
fix sdl configure with Xcode 5.1

### DIFF
--- a/3rdparty/sdl2-2.0.0/cmake/sdlchecks.cmake
+++ b/3rdparty/sdl2-2.0.0/cmake/sdlchecks.cmake
@@ -494,8 +494,9 @@ endmacro(CheckX11)
 macro(CheckCOCOA)
   if(VIDEO_COCOA)
     check_objc_source_compiles("
-        #import <Cocoa/Cocoa.h>
-        int main (int argc, char** argv) {}" HAVE_VIDEO_COCOA)
+      if(APPLE) # Apple always has Cocoa.
+        set(HAVE_VIDEO_COCOA TRUE)
+      endif(APPLE)
     if(HAVE_VIDEO_COCOA)
       file(GLOB COCOA_SOURCES ${SDL2_SOURCE_DIR}/src/video/cocoa/*.m)
       set_source_files_properties(${COCOA_SOURCES} PROPERTIES LANGUAGE C)


### PR DESCRIPTION
SDL was failing to find video driver with new clang. This fix from SDL repo: http://hg.libsdl.org/SDL/rev/bfea1a568a0a

So maybe it'll be better to just bump SDL version. 
