### PR TITLE
Remove call to getcwd for Android

### DIFF
--- a/src/zl-vfs/ZLVfsFileSystem.cpp
+++ b/src/zl-vfs/ZLVfsFileSystem.cpp
@@ -359,13 +359,17 @@ std::string ZLVfsFileSystem::GetWorkingPath () {
 void ZLVfsFileSystem::Init () {
 
 	this->mMutex = zl_mutex_create ();;
-
-	char buffer [ FILENAME_MAX ];
-
-	char* result = getcwd ( buffer, FILENAME_MAX );
-	assert ( result );
 	
-	this->mWorkingPath = this->NormalizeDirPath ( buffer );
+	#ifdef ANDROID
+		this->mWorkingPath = this->NormalizeDirPath ( "/" );
+	#else
+		char buffer [ FILENAME_MAX ];
+	
+		char* result = getcwd ( buffer, FILENAME_MAX );
+		assert ( result );
+		
+		this->mWorkingPath = this->NormalizeDirPath ( buffer );
+	#endif
 }
 
 //----------------------------------------------------------------//


### PR DESCRIPTION
It's a fix to the issue https://github.com/moai/moai-dev/issues/894.

In some cases, getcwd returns null which leads to a segmentation fault.
Moreover, the call isn't even needed because the Android host sets the working directory with a JNI call afterwards.

Builded on Windows and Linux.
Tested on Windows and Android.
