### PR TITLE
fix html host for later versions of emscripten

### DIFF
--- a/src/host-html/host-template/www/moaihost.js
+++ b/src/host-html/host-template/www/moaihost.js
@@ -354,8 +354,8 @@ MoaiJS.prototype.run = function(mainLua, romUrl) {
 
 	this.loadedFileSystem.then(function(){
 	   console.log("MoaiJS Filesystem Loaded");	
-  	   that.emscripten.addOnPreMain(function(){ that.runhost(mainLua); });
   	   that.emscripten.run();   
+  	   that.runhost(mainLua);
   	}).rethrow();
 }
 


### PR DESCRIPTION
This prevents a white screen of death.
