### PR TITLE
Fixed build on Windows

### DIFF
--- a/cmake/third-party/luajit/msvcbuild-moai.bat
+++ b/cmake/third-party/luajit/msvcbuild-moai.bat
@@ -14,7 +14,7 @@
 @if not defined INCLUDE goto :FAIL
 
 @setlocal
-@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE
+@set LJCOMPILE=cl /nologo /c /MD /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE
 @set LJLINK=link /nologo
 @set LJMT=mt /nologo
 @set LJLIB=lib /nologo /nodefaultlib
@@ -72,7 +72,7 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
 @set LJCOMPILE=%LJCOMPILE% %~2
 @if "%1"=="amalg" goto :AMALGDLL
 @if "%1"=="static" goto :STATIC
-%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
+%LJCOMPILE% /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
 @if errorlevel 1 goto :BAD
 %LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
 @if errorlevel 1 goto :BAD


### PR DESCRIPTION
Please do not pull until @halfnelson has had a look at this.

During the switch to LuaJIT 2.0.3, `cmake/third-party/luajit/msvcbuild-moai.bat` was changed and now uses a different version of the run-time library. As a result, the build fails on Windows (see error messages below). I've reverted the compiler switches to what they were before and it seems to work, but I'd like @halfnelson to make sure I haven't missed anything.

```
"C:\dev\projects\moai-dev\cmake\projects\vs2013\moai.sln" (default target) (1) ->
"C:\dev\projects\moai-dev\cmake\projects\vs2013\ALL_BUILD.vcxproj.metaproj" (default target) (2) ->
"C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj.metaproj" (default target) (82) ->
"C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj" (default target) (83) ->
(Link target) ->
  LIBCMT.lib(invarg.obj) : error LNK2005: __invalid_parameter already defined in MSVCRTD.lib(MSVCR120D.dll) [C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj]
  LIBCMT.lib(invarg.obj) : error LNK2005: __invoke_watson already defined in MSVCRTD.lib(MSVCR120D.dll) [C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj]
  MSVCRTD.lib(MSVCR120D.dll) : error LNK2005: __strdup already defined in LIBCMT.lib(strdup.obj) [C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj]
  C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\Debug\moai.exe : fatal error LNK1169: one or more multiply defined symbols found [C:\dev\projects\moai-dev\cmake\projects\vs2013\host-glut\moai.vcxproj]
```
