### PR TITLE
MOAIParticleSystem.cpp: Even when wrapping, respect size of sprite array...

### DIFF
--- a/src/moai-sim/MOAIParticleSystem.cpp
+++ b/src/moai-sim/MOAIParticleSystem.cpp
@@ -436,7 +436,7 @@ MOAIParticleState* MOAIParticleSystem::GetState ( u32 id ) {
 AKUParticleSprite* MOAIParticleSystem::GetTopSprite () {
 
 	if ( this->mSpriteTop ) {
-		u32 idx = this->mSpriteTop - 1;
+		u32 idx = (this->mSpriteTop - 1) % this->mSprites.Size();
 		return &this->mSprites [ idx ];
 	}
 	return 0;


### PR DESCRIPTION
....

When using wrapping with the particle system, GetTopSprite() could return
a pointer to a sprite outside the actual reserved array, because it
always returned the address of the Nth item in the array, even if the
array didn't have that many items. Add a % operator to parallel the
usage for computing the index in PushSprite().

PushParticle() doesn't have a corresponding problem, because it doesn't
use the array as an array, but rather maintains a free list of available
particles.
