### PR TITLE
Make MOAIParticleSystem:setColor() do something useful

### DIFF
--- a/src/moai-sim/MOAIParticleScript.cpp
+++ b/src/moai-sim/MOAIParticleScript.cpp
@@ -246,6 +246,26 @@ int MOAIParticleScript::_angleVec ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	color
+ @text	r0, r1, r2, r3 = color (of the MOAIParticleSystem)
+
+ Note that if you do not specify SPRITE_RED and related values,
+ sprites are rendered with the current values. This function is
+ useful to store the values when the initialization script is
+ run in registers.
+ 
+ @in		MOAIParticleScript self
+ @in		number r0 (r)
+ @in		number r1 (g)
+ @in		number r2 (b)
+ @in		number r3 (a) (optional)
+ @out	nil
+ */
+int MOAIParticleScript::_color ( lua_State* L ) {
+	IMPL_LUA_PARTICLE_OP ( COLOR, "RRRR" )
+}
+
+//----------------------------------------------------------------//
 /**	@name	cos
  @text	r0 = cos(v0)
  
@@ -710,6 +730,7 @@ void MOAIParticleScript::RegisterLuaFuncs ( MOAILuaState& state ) {
 	luaL_Reg regTable [] = {
 		{ "add",				_add },
 		{ "angleVec",			_angleVec },
+		{ "color",				_color },
 		{ "cos",				_cos },
 		{ "cycle",				_cycle },
 		{ "div",				_div },
@@ -735,17 +756,17 @@ void MOAIParticleScript::RegisterLuaFuncs ( MOAILuaState& state ) {
 }
 
 //----------------------------------------------------------------//
-void MOAIParticleScript::ResetRegisters ( float* spriteRegisters, float* particleRegisters ) {
+void MOAIParticleScript::ResetRegisters ( float* spriteRegisters, float* particleRegisters, const MOAIParticleSystem &system ) {
 
 	spriteRegisters [ SPRITE_X_LOC ]		= particleRegisters [ MOAIParticle::PARTICLE_X ];
 	spriteRegisters [ SPRITE_Y_LOC ]		= particleRegisters [ MOAIParticle::PARTICLE_Y ];
 	spriteRegisters [ SPRITE_ROT ]			= 0.0f;
 	spriteRegisters [ SPRITE_X_SCL ]		= 1.0f;
 	spriteRegisters [ SPRITE_Y_SCL ]		= 1.0f;
-	spriteRegisters [ SPRITE_RED ]			= 1.0f;
-	spriteRegisters [ SPRITE_GREEN ]		= 1.0f;
-	spriteRegisters [ SPRITE_BLUE ]			= 1.0f;
-	spriteRegisters [ SPRITE_OPACITY ]		= 1.0f;
+	spriteRegisters [ SPRITE_RED ]			= system.mR;
+	spriteRegisters [ SPRITE_GREEN ]		= system.mG;
+	spriteRegisters [ SPRITE_BLUE ]			= system.mB;
+	spriteRegisters [ SPRITE_OPACITY ]		= system.mA;
 	spriteRegisters [ SPRITE_GLOW ]			= 0.0f;
 	spriteRegisters [ SPRITE_IDX ]			= 1.0f;
 }
@@ -764,6 +785,8 @@ void MOAIParticleScript::Run ( MOAIParticleSystem& system, MOAIParticle& particl
 	
 	float* r0;
 	float* r1;
+	float* r2;
+	float* r3;
 	float v0, v1, v2, v3;
 	u32 i0;
 	
@@ -800,6 +823,22 @@ void MOAIParticleScript::Run ( MOAIParticleSystem& system, MOAIParticle& particl
 				}
 				break;
 			
+			case COLOR: // RRRR
+				READ_ADDR   ( r0, bytecode );
+				READ_ADDR   ( r1, bytecode );
+				READ_ADDR   ( r2, bytecode );
+				READ_ADDR   ( r3, bytecode );
+
+				if (r0 && r1 && r2) {
+					*r0 = system.mR;
+					*r1 = system.mG;
+					*r2 = system.mB;
+					// allow Alpha to be omitted.
+					if (r3) {
+						*r3 = system.mA;
+					}
+				}
+				break;
 			case COS: // RVV
 				READ_ADDR   ( r0, bytecode );
 				READ_VALUE  ( v0, bytecode );
@@ -958,7 +997,7 @@ void MOAIParticleScript::Run ( MOAIParticleSystem& system, MOAIParticle& particl
 				if ( push ) {
 					this->PushSprite ( system, spriteRegisters );
 				}
-				this->ResetRegisters ( spriteRegisters, particleRegisters );
+				this->ResetRegisters ( spriteRegisters, particleRegisters, system );
 				push = true;
 				break;
 			

--- a/src/moai-sim/MOAIParticleScript.h
+++ b/src/moai-sim/MOAIParticleScript.h
@@ -65,6 +65,7 @@ private:
 		END = 0,
 		ADD,
 		ANGLE_VEC,
+		COLOR,
 		COS,
 		CYCLE,
 		DIV,
@@ -114,6 +115,7 @@ private:
 	//----------------------------------------------------------------//
 	static int		_add				( lua_State* L );
 	static int		_angleVec			( lua_State* L );
+	static int		_color				( lua_State* L );
 	static int		_cos				( lua_State* L );
 	static int		_cycle				( lua_State* L );
 	static int		_div				( lua_State* L );
@@ -140,7 +142,7 @@ private:
 	static u64		Pack64					( u32 low, u32 hi );
 	Instruction&	PushInstruction			( u32 op, cc8* format );
 	void			PushSprite				( MOAIParticleSystem& system, float* registers );
-	void			ResetRegisters			( float* spriteRegisters, float* particleRegisters );
+	void			ResetRegisters			( float* spriteRegisters, float* particleRegisters, const MOAIParticleSystem& );
 
 public:
 	


### PR DESCRIPTION
Since a MOAIParticleSystem is already a prop, and thus has a color,
why not use that color (and opacity) as the defaults for particles
which don't have explicit writes to SPRITE_RED, etc.?

So we do two things. First, the sprite defaults change from {1,1,1,1}
to {mR,mG,mB,mA} of the MOAIParticleSystem a script is running on
when it creates the sprite. Second, we add a color() op that lets you
store the current colors of that system in registers. This can be
used in an init script, with set(...SPRITE_RED, r1) calls in the render
script, to cause a sprite to preserve the color the ParticleSystem
had when the init script ran.

(Note: This does not make the previous patch useless, but it does certainly more-neatly solve one of the specific problems I had in mind when I wrote it.)
