### PR TITLE
Fix empty string processor for LuaJIT build.

### DIFF
--- a/cmake/third-party/luajit/CMakeLists.txt
+++ b/cmake/third-party/luajit/CMakeLists.txt
@@ -60,7 +60,7 @@ cmake_minimum_required(VERSION 2.8)
     endif(GCC_FORCE_32BIT)
 
 
-    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}")
         # Regular mode - use CMake compiler for building host utils.
         set (luajit_host_cc ${CMAKE_C_COMPILER})
         set (luajit_host_ldflags ${luajit_target_ldflags} )
@@ -74,7 +74,7 @@ cmake_minimum_required(VERSION 2.8)
     
 
     message( "Size of void P =  ${CMAKE_SIZEOF_VOID_P} and ${CMAKE_HOST_SYSTEM_PROCESSOR}")
-    if (${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "64" AND
+    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "64" AND
             ${CMAKE_SIZEOF_VOID_P} EQUAL 4 OR GCC_FORCE_32BIT)
         # The host compiler must have same pointer size as the target compiler.
 


### PR DESCRIPTION
More robust comparison. Fixed Mingw32 build on Fedora, on my end.
