### PR TITLE
Fix LUAJIT crash when compiled with MSVC in debug mode

### DIFF
--- a/cmake/third-party/luajit/CMakeLists.txt
+++ b/cmake/third-party/luajit/CMakeLists.txt
@@ -134,9 +134,10 @@ cmake_minimum_required(VERSION 2.8)
     )
 
     if (MSVC)
-	      add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/luajit/src/lua51.lib
+       
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/luajit/src/lua51.lib
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/luajit/src
-            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/msvcbuild-moai.bat" static ${VFS_INCLUDE}
+            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/msvcbuild-moai.bat" $<$<CONFIG:Debug>:debug> static ${VFS_INCLUDE}
             DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/luajit 
         ) 
 

--- a/cmake/third-party/luajit/msvcbuild-moai.bat
+++ b/cmake/third-party/luajit/msvcbuild-moai.bat
@@ -14,7 +14,15 @@
 @if not defined INCLUDE goto :FAIL
 
 @setlocal
-@set LJCOMPILE=cl /nologo /c /MD /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE
+@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE
+@if "%1" neq "debug" goto :LINKMD
+@set LJCOMPILE=%LJCOMPILE% /MDd
+@echo using Debug CRT /MDd
+goto :LINKMDD
+:LINKMD
+@set LJCOMPILE=%LJCOMPILE% /MD
+:LINKMDD
+
 @set LJLINK=link /nologo
 @set LJMT=mt /nologo
 @set LJLIB=lib /nologo /nodefaultlib


### PR DESCRIPTION
Luajit was always linking against /MD but cmake was using the correct /MDd for debug compiles. It now passes the debug setting through to luajit batch file.
