### PR TITLE
Safeguard for systems not supporting STREAMS

### DIFF
--- a/3rdparty/curl-7.19.7/lib/if2ip.c
+++ b/3rdparty/curl-7.19.7/lib/if2ip.c
@@ -51,7 +51,11 @@
 #  include <ifaddrs.h>
 #endif
 #ifdef HAVE_STROPTS_H
+#if defined _XOPEN_STREAMS && _XOPEN_STREAMS == -1
+#  include <sys/ioctl.h>
+#else
 #  include <stropts.h>
+#endif
 #endif
 #ifdef VMS
 #  include <inet.h>


### PR DESCRIPTION
Recent Linux systems don't support STREAMS, but have the flag #ifdef HAVE_STROPTS_H leading to a compilation error when trying to reach <stropts.h>. The following safeguard tests explicitly the presence and support of STREAMS and uses <sys/ioctl.h> as a replacement.
