### PR TITLE
Fix const definitions for MOAICameraAnchor2D and MOAICameraFitter2D

### DIFF
--- a/src/moai-sim/MOAICameraAnchor2D.cpp
+++ b/src/moai-sim/MOAICameraAnchor2D.cpp
@@ -92,14 +92,14 @@ void MOAICameraAnchor2D::OnDepNodeUpdate () {
 void MOAICameraAnchor2D::RegisterLuaClass ( MOAILuaState& state ) {
 	
 	MOAINode::RegisterLuaClass ( state );
+
+	state.SetField ( -1, "INHERIT_LOC", MOAICameraAnchor2DAttr::Pack ( INHERIT_LOC ));
 }
 
 //----------------------------------------------------------------//
 void MOAICameraAnchor2D::RegisterLuaFuncs ( MOAILuaState& state ) {
 	
 	MOAINode::RegisterLuaFuncs ( state );
-
-	state.SetField ( -1, "INHERIT_LOC", MOAICameraAnchor2DAttr::Pack ( INHERIT_LOC ));
 
 	luaL_Reg regTable [] = {
 		{ "setParent",			_setParent },

--- a/src/moai-sim/MOAICameraFitter2D.cpp
+++ b/src/moai-sim/MOAICameraFitter2D.cpp
@@ -642,6 +642,13 @@ void MOAICameraFitter2D::RegisterLuaClass ( MOAILuaState& state ) {
 
 	MOAIAction::RegisterLuaClass ( state );
 	MOAINode::RegisterLuaClass ( state );
+
+	state.SetField ( -1, "FITTING_MODE_SEEK_LOC", ( u32 )FITTING_MODE_SEEK_LOC );
+	state.SetField ( -1, "FITTING_MODE_SEEK_SCALE", ( u32 )FITTING_MODE_SEEK_SCALE );
+	state.SetField ( -1, "FITTING_MODE_APPLY_ANCHORS", ( u32 )FITTING_MODE_APPLY_ANCHORS );
+	state.SetField ( -1, "FITTING_MODE_APPLY_BOUNDS", ( u32 )FITTING_MODE_APPLY_BOUNDS );
+	state.SetField ( -1, "FITTING_MODE_DEFAULT", ( u32 )FITTING_MODE_DEFAULT );
+	state.SetField ( -1, "FITTING_MODE_MASK", ( u32 )FITTING_MODE_MASK );
 }
 
 //----------------------------------------------------------------//
@@ -649,13 +656,6 @@ void MOAICameraFitter2D::RegisterLuaFuncs ( MOAILuaState& state ) {
 
 	MOAIAction::RegisterLuaFuncs ( state );
 	MOAINode::RegisterLuaFuncs ( state );
-	
-	state.SetField ( -1, "FITTING_MODE_SEEK_LOC", ( u32 )FITTING_MODE_SEEK_LOC );
-	state.SetField ( -1, "FITTING_MODE_SEEK_SCALE", ( u32 )FITTING_MODE_SEEK_SCALE );
-	state.SetField ( -1, "FITTING_MODE_APPLY_ANCHORS", ( u32 )FITTING_MODE_APPLY_ANCHORS );
-	state.SetField ( -1, "FITTING_MODE_APPLY_BOUNDS", ( u32 )FITTING_MODE_APPLY_BOUNDS );
-	state.SetField ( -1, "FITTING_MODE_DEFAULT", ( u32 )FITTING_MODE_DEFAULT );
-	state.SetField ( -1, "FITTING_MODE_MASK", ( u32 )FITTING_MODE_MASK );
 	
 	luaL_Reg regTable [] = {
 		{ "clearAnchors",		_clearAnchors },


### PR DESCRIPTION
CameraFitter and CameraAnchor consts were set in `RegisterLuaFuncs` instead of `RegisterLuaClass` like other classes.  This fix moves them to the correct method to make them accessible from Lua.
