### PR TITLE
Use timer for OS X

### DIFF
--- a/cmake/third-party/sdl2/CMakeLists.txt
+++ b/cmake/third-party/sdl2/CMakeLists.txt
@@ -898,6 +898,13 @@ elseif(APPLE)
     set(SDL_FRAMEWORK_AUDIOUNIT 1)
   endif()
 
+  if(SDL_TIMERS)
+    set(SDL_TIMER_UNIX 1)
+    file(GLOB TIMER_SOURCES ${SDL2_SOURCE_DIR}/src/timer/unix/*.c)
+    set(SOURCE_FILES ${SOURCE_FILES} ${TIMER_SOURCES})
+    set(HAVE_SDL_TIMERS TRUE)
+  endif(SDL_TIMERS)
+
   if(SDL_JOYSTICK)
     set(SDL_JOYSTICK_IOKIT 1)
     file(GLOB JOYSTICK_SOURCES ${SDL2_SOURCE_DIR}/src/joystick/darwin/*.c)


### PR DESCRIPTION
The configuration of the SDL timer was contingent on
"if(UNIX AND NOT APPLE)" or "if(WINDOWS)", with no attempt to
configure it for OS X.

The Unix timer is maintained for OS X and works fine. Copying
and pasting a few lines into the APPLE section fixes it.

What this fixes: Without it, if you use Spaces/Mission Control
and page such that the app isn't rendering, it uses 100% of CPU.
Also SDL_GetTicks() always returns zero and SDL_Delay() always
returns instantly.
