### PR TITLE
MOAIProp: Add getScissorRect()

### DIFF
--- a/src/moai-sim/MOAIProp.cpp
+++ b/src/moai-sim/MOAIProp.cpp
@@ -615,6 +615,23 @@ int MOAIProp::_setScissorRect ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	getScissorRect
+	@text	Retrieve the prop's scissor rect.
+	
+	@in		MOAIProp self
+	@out	MOAIScissorRect scissorRect		Or nil if none exists.
+*/
+int MOAIProp::_getScissorRect ( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIProp, "U" )
+	
+	if ( self->mScissorRect ) {
+		self->mScissorRect->PushLuaUserdata ( state );
+		return 1;
+	}
+	return 0;
+}
+
+//----------------------------------------------------------------//
 /**	@name	setShader
 	@text	Sets or clears the prop's shader. The prop's shader takes
 			precedence over any shader specified by the deck or its
@@ -1197,6 +1214,7 @@ void MOAIProp::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "getGrid",			_getGrid },
 		{ "getIndex",			_getIndex },
 		{ "getPriority",		_getPriority },
+		{ "getScissorRect",		_getScissorRect },
 		{ "getTexture",			_getTexture },
 		{ "getWorldBounds",		_getWorldBounds },
 		{ "isVisible",			_isVisible },

--- a/src/moai-sim/MOAIProp.h
+++ b/src/moai-sim/MOAIProp.h
@@ -124,6 +124,7 @@ private:
 	static int		_setPriority		( lua_State* L );
 	static int		_setRemapper		( lua_State* L );
 	static int		_setScissorRect		( lua_State* L );
+	static int		_getScissorRect		( lua_State* L );
 	static int		_setShader			( lua_State* L );
 	static int		_setTexture			( lua_State* L );
 	static int		_setUVTransform		( lua_State* L );
@@ -215,6 +216,7 @@ public:
 	GET_SET ( u32, Mask, mMask )
 	GET ( s32, Priority, mPriority )
 	GET ( MOAIPartition*, Partition, mPartition )
+	GET ( MOAIScissorRect*, ScissorRect, mScissorRect )
 	
 	GET ( MOAIDeck*, Deck, mDeck )
 	GET ( MOAIDeckRemapper*, Remapper, mRemapper )


### PR DESCRIPTION
It is occasionally desireable to be able to find out whether
a prop has a scissorRect assigned to it.
