### PR TITLE
work around incompatibility with lua_jit and the coroutine error handlin...

### DIFF
--- a/src/moai-sim/MOAICoroutine.cpp
+++ b/src/moai-sim/MOAICoroutine.cpp
@@ -162,13 +162,23 @@ void MOAICoroutine::OnUpdate ( float step ) {
 			if (( result != LUA_YIELD )) {
 			
 				if ( result != 0 ) {
-					
 					cc8* msg = lua_tostring ( this->mState, -1 );
 
 					MOAILuaState state ( this->mState );
+
+#if (MOAI_WITH_LUAJIT)
+					//luajit has assertions on lua_call if the thread has crashed due to runtime error
+					//this means we can't run our custom stacktrace using this state. we will just bail instead
+					if ( msg ) {
+						ZLLog::Print ( "%s\n", msg );
+					}
+					state.PrintStackTrace ( ZLLog::CONSOLE, 0 );
+#else
 					MOAILuaRuntime::Get ().PushTraceback ( state );
 					state.Push ( msg );
+					
 					lua_call ( this->mState, 1, 0 );
+#endif
 					lua_pop ( this->mState, 1 );
 				}
 				this->Stop ();


### PR DESCRIPTION
...g functions

a runtime error in a coroutine sets the threads lua_state status field to 2. In luajit in debug mode there is an assert before each pcall that checks the current thread status. This causes our error handler to assert and crash project instead of printing stacktrace. I have written a patch that lets it just dump the stacktrace (the default method of handling errors) when running under luajit.
