### PR TITLE
Fix MOAITextBox.revealAll not updating spooler

### DIFF
--- a/src/moai-sim/MOAITextBox.cpp
+++ b/src/moai-sim/MOAITextBox.cpp
@@ -283,6 +283,7 @@ int MOAITextBox::_revealAll ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAITextBox, "U" )
 	
 	self->mReveal = REVEAL_ALL;
+	self->mSpool = ( float )self->mSprites.GetTop ();
 	
 	return 0;
 }


### PR DESCRIPTION
Fixed `MOAITextBox.revealAll` not updating the current spooler position, as
`setReveal` does.
