### PR TITLE
Added MOAIBox2DWorld:addRevoluteJointLocal

### DIFF
--- a/src/moai-box2d/MOAIBox2DWorld.cpp
+++ b/src/moai-box2d/MOAIBox2DWorld.cpp
@@ -474,6 +474,55 @@ int	MOAIBox2DWorld::_addRevoluteJoint ( lua_State* L ) {
 }
 
 //----------------------------------------------------------------//
+/**	@name	addRevoluteJointLocal
+	@text	Create and add a joint to the world, using local anchors. See Box2D documentation.
+	
+	@in		MOAIBox2DWorld self
+	@in		MOAIBox2DBody bodyA
+	@in		MOAIBox2DBody bodyB
+	@in		number anchorA_X	in units, in world coordinates, converted to meters
+	@in		number anchorA_Y	in units, in world coordinates, converted to meters
+	@in		number anchorB_X	in units, in world coordinates, converted to meters
+	@in		number anchorB_Y	in units, in world coordinates, converted to meters
+	@out	MOAIBox2DJoint joint
+*/
+int	MOAIBox2DWorld::_addRevoluteJointLocal( lua_State* L ) {
+	MOAI_LUA_SETUP ( MOAIBox2DWorld, "UUUNNNN" )
+	
+	if ( self->IsLocked ()) {
+		MOAILog ( state, MOAILogMessages::MOAIBox2DWorld_IsLocked );
+		return 0;
+	}
+	
+	MOAIBox2DBody* bodyA = state.GetLuaObject < MOAIBox2DBody >( 2, true );
+	MOAIBox2DBody* bodyB = state.GetLuaObject < MOAIBox2DBody >( 3, true );
+	
+	if ( !( bodyA && bodyB )) return 0;
+		
+	b2RevoluteJointDef jointDef;
+	jointDef.bodyA = bodyA->mBody;
+	jointDef.bodyB = bodyB->mBody;
+	
+	jointDef.localAnchorA.Set(
+		state.GetValue < float >( 4, 0 ) * self->mUnitsToMeters, 
+		state.GetValue < float >( 5, 0 ) * self->mUnitsToMeters);
+		
+	jointDef.localAnchorB.Set(
+		state.GetValue < float >( 6, 0 ) * self->mUnitsToMeters, 
+		state.GetValue < float >( 7, 0 ) * self->mUnitsToMeters);
+		
+	MOAIBox2DRevoluteJoint* joint = new MOAIBox2DRevoluteJoint ();
+	joint->SetJoint ( self->mWorld->CreateJoint ( &jointDef ));
+	joint->SetWorld ( self );
+	joint->LuaRetain ( bodyA );
+	joint->LuaRetain ( bodyB );
+	self->LuaRetain ( joint );
+	
+	joint->PushLuaUserdata ( state );
+	return 1;
+}
+
+//----------------------------------------------------------------//
 /**	@name	addRopeJoint
  @text	Create and add a rope joint to the world. See Box2D documentation.
  
@@ -1034,6 +1083,7 @@ void MOAIBox2DWorld::RegisterLuaFuncs ( MOAILuaState& state ) {
 		{ "addPrismaticJoint",			_addPrismaticJoint },
 		{ "addPulleyJoint",				_addPulleyJoint },
 		{ "addRevoluteJoint",			_addRevoluteJoint },
+		{ "addRevoluteJointLocal",		_addRevoluteJointLocal },
 		{ "addRopeJoint",				_addRopeJoint },
 		{ "addWeldJoint",				_addWeldJoint },
 		{ "addWheelJoint",				_addWheelJoint },

--- a/src/moai-box2d/MOAIBox2DWorld.h
+++ b/src/moai-box2d/MOAIBox2DWorld.h
@@ -90,6 +90,7 @@ private:
 	static int		_addPrismaticJoint			( lua_State* L );
 	static int		_addPulleyJoint				( lua_State* L );
 	static int		_addRevoluteJoint			( lua_State* L );
+	static int		_addRevoluteJointLocal		( lua_State* L );
 	static int		_addRopeJoint				( lua_State* L );
 	static int		_addWeldJoint				( lua_State* L );
 	static int		_addWheelJoint				( lua_State* L );


### PR DESCRIPTION
As discussed on the getmoai.com/forums. Adds a variant function to MOAIBox2DWorld that adds a revolute joint build on local anchors to the relevant A & B bodies, instead of a single, world based anchor as per existing addRevoluteJoint. 
