### PR TITLE
MOAITransformBase.getWorldRot() and .getWorldDir() are broken

### DIFF
--- a/src/zl-util/ZLAffine2D.h
+++ b/src/zl-util/ZLAffine2D.h
@@ -78,7 +78,7 @@ public:
 	//----------------------------------------------------------------//
 	TYPE GetRot () const {
 
-		float rot = ( TYPE )( atan2 ( m [ C0_R0 ], m [ C0_R1 ]) * R2D );
+		float rot = ( TYPE )( atan2 ( m [ C0_R1 ], m [ C0_R0 ]) * R2D );
 		return rot;
 	}
 

--- a/src/zl-util/ZLAffine3D.h
+++ b/src/zl-util/ZLAffine3D.h
@@ -95,13 +95,14 @@ public:
 	}
 
 	//----------------------------------------------------------------//
+	// Rotates the vector (1, 0, 0) by the matrix, ignoring translation and scale
 	ZLMetaVec3D < TYPE > GetHeading () const {
 
 		ZLMetaVec3D < TYPE > heading;
 	
 		heading.mX = m [ C0_R0 ];
 		heading.mY = m [ C0_R1 ];
-		heading.mZ = m [ C0_R1 ];
+		heading.mZ = m [ C0_R2 ];
 
 		heading.NormSafe ();
 		

--- a/src/zl-util/ZLAffine3D.h
+++ b/src/zl-util/ZLAffine3D.h
@@ -111,7 +111,7 @@ public:
 	//----------------------------------------------------------------//
 	TYPE GetRot () const {
 
-		float rot = ( TYPE )( atan2 ( m [ C0_R0 ], m [ C0_R1 ]) * R2D );
+		float rot = ( TYPE )( atan2 ( m [ C0_R1 ], m [ C0_R0 ]) * R2D );
 		return rot;
 	}
 


### PR DESCRIPTION
`ZLMetaAffine2D/3D.GetRot()` pass their arguments to `atan2()` in the wrong order. Consequently, their results are always inverted and offset by 90°.

`ZLAffine3D.GetHeading()` should apparently return the vector (1, 0, 0), rotated by the rotation part of the transform. In what appears to be a copy-and-paste error from the same method in `ZLAffine2D`, the z coordinate is given the same value as the y coordinate, yielding strange results.
