### PR TITLE
Always run with pcall, and only print stack trace if no user trace back is set

### DIFF
--- a/src/moai-core/MOAILuaRuntime.cpp
+++ b/src/moai-core/MOAILuaRuntime.cpp
@@ -276,14 +276,19 @@ int MOAILuaRuntime::_traceback ( lua_State *L ) {
 			if ( result ) {
 				ZLLog::Print ( "error in user supplied traceback func\n" );
 				ZLLog::Print ( "falling back on default error handler:\n" );
+
+				if ( msg ) {
+					ZLLog::Print ( "%s\n", msg );
+				}
+				state.PrintStackTrace ( ZLLog::CONSOLE, 0 );
 			}
 		}
+	} else {
+		if ( msg ) {
+			ZLLog::Print ( "%s\n", msg );
+		}
+		state.PrintStackTrace ( ZLLog::CONSOLE, 0 );
 	}
-
-	if ( msg ) {
-		ZLLog::Print ( "%s\n", msg );
-	}
-	state.PrintStackTrace ( ZLLog::CONSOLE, 0 );
 
 	return 0;
 }

--- a/src/moai-core/MOAILuaState.cpp
+++ b/src/moai-core/MOAILuaState.cpp
@@ -168,27 +168,20 @@ int MOAILuaState::DebugCall ( int nArgs, int nResults ) {
 	
 	int status;
 	
-	if ( MOAILuaRuntime::Get ().mTracebackRef ) {
-	
-		int errIdx = this->AbsIndex ( -( nArgs + 1 ));
+	int errIdx = this->AbsIndex ( -( nArgs + 1 ));
 		
-		MOAILuaRuntime::Get ().PushTraceback ( *this );
-		lua_insert ( this->mState, errIdx );
+	MOAILuaRuntime::Get ().PushTraceback ( *this );
+	lua_insert ( this->mState, errIdx );
 
-		status = lua_pcall ( this->mState, nArgs, nResults, errIdx );
+	status = lua_pcall ( this->mState, nArgs, nResults, errIdx );
 
-		if ( status ) {
-			lua_settop ( this->mState, errIdx - 1 );
-		}
-		else {
-			lua_remove ( this->mState, errIdx );
-		}
+	if ( status ) {
+		lua_settop ( this->mState, errIdx - 1 );
 	}
 	else {
-	
-		lua_call ( this->mState, nArgs, nResults );
-		status = 0;
+		lua_remove ( this->mState, errIdx );
 	}
+
 	return status;
 }
 


### PR DESCRIPTION
See a discussion of this here: http://getmoai.com/forums/in-moai-1-5-lua-errors-no-longer-display-the-lua-stack-t2497/

Basicly now Moai doesnt run with pcall if the user has not set a trace back. If the user has set a trace back, it does run with pcall, but no matter what the user traceback does it still prints its own stack trace as well. So you get a double stack trace.

I cant see a situation where you would not want a stack trace so I made it always use pcall, and only print stack trace when there is not user traceback set.
