### PR TITLE
Clone instructions didn't work for me

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You can work in Lua or C++, and Moai SDK runs on multiple platforms including iO
 ## Download
 Please clones the source in the following way.
 
-    git clone git@github.com:moai/moai-dev.git
+    git clone https://github.com/moai/moai-dev.git
+    cd moai-dev
     git submodule init
     git submodule update
 


### PR DESCRIPTION
Cloning the .git failed like so:

```
$ git clone git@github.com:moai/moai-dev.git
Cloning into 'moai-dev'...
Warning: Permanently added the RSA host key for IP address '192.30.252.123' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

And I added the `cd` so it can actually all be copy-pasted and would just work.
