### PR TITLE
curl: Fix test for PPC

### DIFF
--- a/3rdparty/curl-7.19.7/include/curl/curlbuild.h
+++ b/3rdparty/curl-7.19.7/include/curl/curlbuild.h
@@ -528,7 +528,7 @@
 /* ===================================== */
 
 #elif defined(__GNUC__)
-#  if defined(__i386__) || defined(__ppc__)
+#  if defined(__i386__) || defined(__ppc__) || (defined(__powerpc__) && !defined(__powerpc64__))
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
@@ -537,7 +537,7 @@
 #    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
-#  elif defined(__x86_64__) || defined(__ppc64__)
+#  elif defined(__x86_64__) || defined(__ppc64__) || defined(__powerpc64__)
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"


### PR DESCRIPTION
The tests for PowerPC in `3rdparty/curl-7.19.7/include/curl/curlbuild.h` use preprocessor symbols (`__ppc__` and `__ppc64__`) which are obsolete.  This results in a FTBFS.

The symbols defined by current gcc are `__powerpc__` and `__powerpc64__`.  Note that both are defined on a 64-bit system.
