### PR TITLE
Fixed addRopeJoint interpreting parameters as local anchors

### DIFF
--- a/src/moai-box2d/MOAIBox2DWorld.cpp
+++ b/src/moai-box2d/MOAIBox2DWorld.cpp
@@ -502,18 +502,23 @@ int	MOAIBox2DWorld::_addRopeJoint ( lua_State* L ) {
 	if ( !( bodyA && bodyB )) return 0;
 	
 	float maxLength = state.GetValue < float >( 4, 1 ) * self->mUnitsToMeters;
-	
+
+	b2Vec2 anchorA;
+	anchorA.x	= state.GetValue < float >( 5, 0 ) * self->mUnitsToMeters;
+	anchorA.y	= state.GetValue < float >( 6, 0 ) * self->mUnitsToMeters;
+
+	b2Vec2 anchorB;
+	anchorB.x	= state.GetValue < float >( 7, 0 ) * self->mUnitsToMeters;
+	anchorB.y	= state.GetValue < float >( 8, 0 ) * self->mUnitsToMeters;
+
+	bool collideConnected = state.GetValue < bool >( 9, false );
+
 	b2RopeJointDef jointDef;
-	jointDef.localAnchorA.x	= state.GetValue < float >( 5, 0 ) * self->mUnitsToMeters;
-	jointDef.localAnchorA.y	= state.GetValue < float >( 6, 0 ) * self->mUnitsToMeters;
-
-	jointDef.localAnchorB.x	= state.GetValue < float >( 7, 0 ) * self->mUnitsToMeters;
-	jointDef.localAnchorB.y	= state.GetValue < float >( 8, 0 ) * self->mUnitsToMeters;
-
-	jointDef.collideConnected = state.GetValue < bool >( 9, false );
-	
 	jointDef.bodyA = bodyA->mBody;
 	jointDef.bodyB = bodyB->mBody;
+	jointDef.collideConnected = collideConnected;
+	jointDef.localAnchorA = bodyA->mBody->GetLocalPoint(anchorA);
+	jointDef.localAnchorB = bodyB->mBody->GetLocalPoint(anchorB);
 	jointDef.maxLength = maxLength;
 	
 	MOAIBox2DRopeJoint* joint = new MOAIBox2DRopeJoint ();


### PR DESCRIPTION
This makes MOAIBox2dWorld.addRopeJoint's interface match all the other joints, and makes it match its own documentation as well.

( fixing https://github.com/moai/moai-dev/issues/981 )
