### PR TITLE
MOAIFont crash fix, zl-gfx assert fix, and fix for silently failing to load the main script

### DIFF
--- a/src/moai-core/host.cpp
+++ b/src/moai-core/host.cpp
@@ -227,7 +227,11 @@ void AKURunData ( void* data, size_t size, int dataType, int compressed ) {
 //----------------------------------------------------------------//
 void AKURunScript ( const char* filename ) {
 
-	if ( !ZLFileSys::CheckFileExists ( filename )) return;
+	if ( !ZLFileSys::CheckFileExists ( filename ))
+	{
+		ZLLog::PrintFile ( ZLLog::CONSOLE, "Script does not exist: '%s'\n", filename );
+		return;
+	}
 
 	int status;
 	MOAIScopedLuaState state = MOAILuaRuntime::Get ().State ();

--- a/src/moai-sim/MOAIBitmapFontReader.cpp
+++ b/src/moai-sim/MOAIBitmapFontReader.cpp
@@ -253,8 +253,9 @@ MOAIBitmapFontReader::~MOAIBitmapFontReader () {
 }
 
 //----------------------------------------------------------------//
-void MOAIBitmapFontReader::OpenFont ( MOAIFont& font ) {
+bool MOAIBitmapFontReader::OpenFont ( MOAIFont& font ) {
 	UNUSED ( font );
+	return true;
 }
 
 //----------------------------------------------------------------//

--- a/src/moai-sim/MOAIBitmapFontReader.h
+++ b/src/moai-sim/MOAIBitmapFontReader.h
@@ -92,7 +92,7 @@ public:
 	bool			HasKerning					();
 					MOAIBitmapFontReader		();
 					~MOAIBitmapFontReader		();
-	void			OpenFont					( MOAIFont& font );
+	bool			OpenFont					( MOAIFont& font );
 	void			RegisterLuaClass			( MOAILuaState& state );
 	void			RegisterLuaFuncs			( MOAILuaState& state );
 	void			RenderGlyph					( MOAIFont& font, MOAIGlyph& glyph );

--- a/src/moai-sim/MOAIFontReader.h
+++ b/src/moai-sim/MOAIFontReader.h
@@ -23,7 +23,7 @@ public:
 	virtual bool		HasKerning				() = 0;
 						MOAIFontReader			();
 						~MOAIFontReader			();
-	virtual void		OpenFont				( MOAIFont& font ) = 0;
+	virtual bool		OpenFont				( MOAIFont& font ) = 0;
 	virtual void		RenderGlyph				( MOAIFont& font, MOAIGlyph& glyph ) = 0;
 	virtual void		SetFaceSize				( float size ) = 0;
 };

--- a/src/moai-sim/MOAIFreeTypeFontReader.h
+++ b/src/moai-sim/MOAIFreeTypeFontReader.h
@@ -39,7 +39,7 @@ public:
 	bool			HasKerning					();
 					MOAIFreeTypeFontReader		();
 					~MOAIFreeTypeFontReader		();
-	void			OpenFont					( MOAIFont& font );
+	bool			OpenFont					( MOAIFont& font );
 	void			RegisterLuaClass			( MOAILuaState& state );
 	void			RegisterLuaFuncs			( MOAILuaState& state );
 	void			RenderGlyph					( MOAIFont& font, MOAIGlyph& glyph );

--- a/src/moai-sim/MOAITextDesigner.cpp
+++ b/src/moai-sim/MOAITextDesigner.cpp
@@ -179,6 +179,7 @@ void MOAITextDesigner::BuildLayout () {
 			MOAIGlyph* glyph = this->mDeck->GetGlyph ( c );
 			if ( !glyph ) continue;
 			if ( glyph->mCode == MOAIGlyph::NULL_CODE_ID ) continue;
+			if ( glyph->mPageID == MOAIGlyph::NULL_PAGE_ID ) continue;
 			
 			// apply kerning
 			if ( this->mPrevGlyph ) {

--- a/src/zl-gfx/zl_gfx_opengl.cpp
+++ b/src/zl-gfx/zl_gfx_opengl.cpp
@@ -7,6 +7,7 @@
 SUPPRESS_EMPTY_FILE_WARNING
 #if MOAI_GFX_OPENGL
 
+#include <algorithm>
 #include <string>
 using namespace std;
 
@@ -428,9 +429,10 @@ void zglInitialize () {
 	#endif
 
 	string version = zglGetString ( ZGL_STRING_VERSION );
-	for ( u32 i = 0; version [ i ]; i++ ) {
-		version [ i ] = ( char )tolower ( version [ i ]);
-	}
+	std::transform(version.begin(),
+		version.end(),
+		version.begin(),
+		::tolower);
 	
 	string gles = "opengl es";
 	


### PR DESCRIPTION
Fixes  moai.exe crashes when attempting to use an unloaded font ( #978 )
Fixes a debug-only assert in zl-gfx due to improper use of an std::string
Makes the moai.exe host log an error when the main script couldn't be loaded instead of silently failing
