### PR TITLE
Make zl-vfs able to load an archive that has had data prepended to it

### DIFF
--- a/src/zl-vfs/ZLVfsZipArchive.h
+++ b/src/zl-vfs/ZLVfsZipArchive.h
@@ -20,7 +20,9 @@ public:
 	u32	mCDSize;			// 4 Size of central directory in bytes
 	u32	mCDAddr;			// 4 Offset of start of central directory, relative to start of archive
 	u16	mCommentLength;		// 2 ZIP file comment length
-	
+
+	u32 mDataOffset;		// amount of junk before the central directory
+
 	//----------------------------------------------------------------//
 	int		FindAndRead		( FILE* file );
 };
@@ -50,7 +52,7 @@ public:
 	u32	mFileHeaderAddr;		// 4 Relative offset of file header
 	
 	//----------------------------------------------------------------//
-	int		Read	( FILE* file );
+	int		Read	( FILE* file, u32 dataOffset );
 };
 
 //================================================================//


### PR DESCRIPTION
This fix makes it so zl-vfs can load fused exes that have been created by running 'copy /b moai.exe+src.zip game.exe', rather than requiring a more complicated script ( http://getmoai.com/forums/demo-package-game-in-one-executable-file-t2614/ )

Comment from physfs, from which this approach was inspired:

>  For self-extracting archives, etc, there's crapola in the file
>  before the zipfile records; we calculate how much data there is
>  prepended by determining how far the central directory offset is
>  from where it is supposed to be (start of end-of-central-dir minus
>  sizeof central dir)...the difference in bytes is how much arbitrary
>  data is at the start of the physical file.
