### PR TITLE
Fix issue with build docs script giving a "too many arguments" error

### DIFF
--- a/bin/build-docs.sh
+++ b/bin/build-docs.sh
@@ -7,27 +7,27 @@ DOXYGEN=`which doxygen`
 MOAI=`which moai`
 DOT=`which dot`
 
-if [ -z $RUBY ]; then
+if [[ -z $RUBY ]]; then
   echo "You need to have Ruby 1.9+ installed. Check http://www.ruby-lang.org/";
   exit 1;
 fi
 
-if [ -z $BUNDLE ]; then
+if [[ -z $BUNDLE ]]; then
   echo "You need to have bundler installed. Check http://gembundler.com/"
   exit 1
 fi
 
-if [ -z $DOXYGEN ]; then
+if [[ -z $DOXYGEN ]]; then
   echo "You need to have Doxygen installed.";
   exit 1;
 fi
 
-if [ -z $DOT ]; then
+if [[ -z $DOT ]]; then
   echo "You need to have graphviz (and dot command on PATH) installed.";
   exit 1;
 fi
 
-if [ -z $MOAI ]; then
+if [[ -z $MOAI ]]; then
   echo "You need to have moai in your PATH.";
   exit 1;
 fi


### PR DESCRIPTION
This was occurring if any of the required exes' path had a space in
it because it would be interpreted as separate words rather than one
string.
