### PR TITLE
Checkin to get Slots Tycoon building. Still not running yet, but it's a ...

### DIFF
--- a/ant/libmoai/jni/Android.mk
+++ b/ant/libmoai/jni/Android.mk
@@ -198,7 +198,7 @@
 	LOCAL_SRC_FILES 	+= $(wildcard $(MOAI_SDK_HOME)src/host-modules/*.cpp)
 	LOCAL_SRC_FILES 	+= src/aku_plugins.cpp
 
-	LOCAL_STATIC_LIBRARIES := libmoai-box2d libmoai-http-client libmoai-luaext libmoai-untz libmoai-sim libmoai-crypto libmoai-util libmoai-core libzl-gfx libzl-crypto libzl-core libbox2d libuntz libvorbis libogg libcontrib libexpat libjson liblua libsfmt libsqlite libtinyxml libfreetype libjpg libpng libtess libcurl libcares libssl libcrypto-a libcrypto-b libcrypto-c libcrypto-d libzl-vfs libzlib
+	LOCAL_STATIC_LIBRARIES := libmoai-android libmoai-box2d libmoai-http-client libmoai-luaext libmoai-untz libmoai-sim libmoai-crypto libmoai-util libmoai-core libzl-gfx libzl-crypto libzl-core libbox2d libuntz libvorbis libogg libcontrib libexpat libjson liblua libsfmt libsqlite libtinyxml libfreetype libjpg libpng libtess libcurl libcares libssl libcrypto-a libcrypto-b libcrypto-c libcrypto-d libzl-vfs libzlib
 	LOCAL_WHOLE_STATIC_LIBRARIES := libmoai-android libmoai-sim libmoai-core libcrypto-a libcrypto-b libcrypto-c libcrypto-d
 
 #----------------------------------------------------------------#

--- a/ant/libmoai/modules/moai-android.mk
+++ b/ant/libmoai/modules/moai-android.mk
@@ -6,7 +6,7 @@
 
 	include $(CLEAR_VARS)
 
-	LOCAL_MODULE 		:= host-android
+	LOCAL_MODULE 		:= moai-android
 	LOCAL_ARM_MODE 		:= $(MY_ARM_MODE)
 	LOCAL_CFLAGS		:= $(MY_LOCAL_CFLAGS) -include $(MOAI_SDK_HOME)/src/zl-vfs/zl_replace.h -fvisibility=hidden
 

--- a/src/host-modules/aku_modules.h
+++ b/src/host-modules/aku_modules.h
@@ -7,6 +7,8 @@
 #include <host-modules/aku_modules_config.h>
 #include <host-modules/aku_modules_util.h>
 
+#include <moai-core/host.h>
+
 #if AKU_WITH_BOX2D
 	#include <moai-box2d/host.h>
 #endif

--- a/src/moai-android-adcolony/MOAIAdColonyAndroid.cpp
+++ b/src/moai-android-adcolony/MOAIAdColonyAndroid.cpp
@@ -118,7 +118,7 @@ void MOAIAdColonyAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAdColony_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAdColony_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MOAIAdColonyAndroid_AKUInvokeListener\n" );
 	MOAIAdColonyAndroid::Get ().InvokeListener (( u32 )eventID );

--- a/src/moai-android-chartboost/MOAIChartBoostAndroid.cpp
+++ b/src/moai-android-chartboost/MOAIChartBoostAndroid.cpp
@@ -98,7 +98,7 @@ void MOAIChartBoostAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiChartBoost_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiChartBoost_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MoaiChartBoost_AKUInvokeListener\n" );
 	MOAIChartBoostAndroid::Get ().InvokeListener (( u32 )eventID );

--- a/src/moai-android-facebook/MOAIFacebookAndroid.cpp
+++ b/src/moai-android-facebook/MOAIFacebookAndroid.cpp
@@ -295,25 +295,25 @@ void MOAIFacebookAndroid::NotifyRequestFailed () {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookLoginComplete ( JNIEnv* env, jclass obj, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookLoginComplete ( JNIEnv* env, jclass obj, jint code ) {
 
 	MOAIFacebookAndroid::Get ().NotifyLoginComplete ( code );
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookDialogComplete ( JNIEnv* env, jclass obj, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookDialogComplete ( JNIEnv* env, jclass obj, jint code ) {
 
 	MOAIFacebookAndroid::Get ().NotifyDialogComplete ( code );
 }
 
-extern "C" void Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookRequestComplete ( JNIEnv* env, jclass obj, jstring jresponse ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookRequestComplete ( JNIEnv* env, jclass obj, jstring jresponse ) {
 
     JNI_GET_CSTRING ( jresponse, response );
 	MOAIFacebookAndroid::Get ().NotifyRequestComplete ( response );
 	JNI_RELEASE_CSTRING ( jresponse, response );
 }
 
-extern "C" void Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookRequestFailed ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiFacebook_AKUNotifyFacebookRequestFailed ( JNIEnv* env, jclass obj ) {
 
 	MOAIFacebookAndroid::Get ().NotifyRequestFailed ( );
 }

--- a/src/moai-android-google-play-services/MOAIGooglePlayServicesAndroid.cpp
+++ b/src/moai-android-google-play-services/MOAIGooglePlayServicesAndroid.cpp
@@ -287,7 +287,7 @@ void MOAIGooglePlayServicesAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 // AKU Callbacks
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGooglePlayServices_AKUNotifyConnectionComplete ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGooglePlayServices_AKUNotifyConnectionComplete ( JNIEnv* env, jclass obj ) {
 
 	MOAIGooglePlayServicesAndroid::Get ().NotifyConnectionComplete ();
 }

--- a/src/moai-android-tapjoy/MOAITapjoyAndroid.cpp
+++ b/src/moai-android-tapjoy/MOAITapjoyAndroid.cpp
@@ -114,14 +114,14 @@ void MOAITapjoyAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListener\n" );
 	MOAITapjoyAndroid::Get ().InvokeListener (( u32 )eventID );
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListenerWithCode ( JNIEnv* env, jclass obj, jint eventID, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListenerWithCode ( JNIEnv* env, jclass obj, jint eventID, jint code ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MoaiTapjoy_AKUInvokeListenerWithCode\n" );
 	MOAIScopedLuaState state = MOAILuaRuntime::Get ().State ();

--- a/src/moai-android-tstore/MOAITstoreGamecenterAndroid.cpp
+++ b/src/moai-android-tstore/MOAITstoreGamecenterAndroid.cpp
@@ -573,25 +573,25 @@ void MOAITstoreGamecenterAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyAuthExitResponse ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyAuthExitResponse ( JNIEnv* env, jclass obj ) {
 
 	MOAITstoreGamecenterAndroid::Get ().AKUNotifyAuthExitResponse ();
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyAuthSuccessResponse ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyAuthSuccessResponse ( JNIEnv* env, jclass obj ) {
 
 	MOAITstoreGamecenterAndroid::Get ().AKUNotifyAuthSuccessResponse ();
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyDisableSuccessResponse ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyDisableSuccessResponse ( JNIEnv* env, jclass obj ) {
 
 	MOAITstoreGamecenterAndroid::Get ().AKUNotifyDisableSuccessResponse ();
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyScoreListResponse ( JNIEnv* env, jclass obj, jstring jjsonData ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyScoreListResponse ( JNIEnv* env, jclass obj, jstring jjsonData ) {
 
 	JNI_GET_CSTRING ( jjsonData, jsonData );
 
@@ -601,7 +601,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyScoreLi
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyUserInfoResponse ( JNIEnv* env, jclass obj, jstring jjsonData ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreGamecenter_AKUNotifyUserInfoResponse ( JNIEnv* env, jclass obj, jstring jjsonData ) {
 
 	JNI_GET_CSTRING ( jjsonData, jsonData );
 

--- a/src/moai-android-tstore/MOAITstoreWallAndroid.cpp
+++ b/src/moai-android-tstore/MOAITstoreWallAndroid.cpp
@@ -109,7 +109,7 @@ void MOAITstoreWallAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreWall_AKUNotifyCurrencyAwarded ( JNIEnv* env, jclass obj, jint amount) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreWall_AKUNotifyCurrencyAwarded ( JNIEnv* env, jclass obj, jint amount) {
 
 	MOAITstoreWallAndroid::Get ().NotifyCurrencyAwarded ( amount );
 }

--- a/src/moai-android-twitter/MOAITwitterAndroid.cpp
+++ b/src/moai-android-twitter/MOAITwitterAndroid.cpp
@@ -289,7 +289,7 @@ void MOAITwitterAndroid::NotifyTweetComplete ( int code ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTwitter_AKUNotifyTwitterLoginComplete ( JNIEnv* env, jclass obj,
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTwitter_AKUNotifyTwitterLoginComplete ( JNIEnv* env, jclass obj,
                                                                     jint code, jstring jtoken, jstring jtokenSecret ) {
 
 	JNI_GET_CSTRING ( jtoken, token );
@@ -302,7 +302,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiTwitter_AKUNotifyTwitterLoginComp
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTwitter_AKUNotifyTwitterTweetComplete ( JNIEnv* env, jclass obj, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTwitter_AKUNotifyTwitterTweetComplete ( JNIEnv* env, jclass obj, jint code ) {
 
 	MOAITwitterAndroid::Get ().NotifyTweetComplete ( code );
 }

--- a/src/moai-android-vungle/MOAIVungleAndroid.cpp
+++ b/src/moai-android-vungle/MOAIVungleAndroid.cpp
@@ -90,14 +90,14 @@ void MOAIVungleAndroid::RegisterLuaClass ( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiVungle_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiVungle_AKUInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MoaiVungle_AKUInvokeListener\n" );
 	MOAIVungleAndroid::Get ().InvokeListener (( u32 )eventID );
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiVungle_AKUOnView ( JNIEnv* env, jclass obj, jdouble watched, jdouble length ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiVungle_AKUOnView ( JNIEnv* env, jclass obj, jdouble watched, jdouble length ) {
 
 	ZLLog::LogF ( ZLLog::CONSOLE, "Java_com_ziplinegames_moai_MoaiVungle_AKUOnView\n" );
 	MOAIScopedLuaState state = MOAILuaRuntime::Get ().State ();

--- a/src/moai-android/JniUtils.cpp
+++ b/src/moai-android/JniUtils.cpp
@@ -243,7 +243,7 @@ JniUtils::JniUtils () :
     //jmethodID getActivity = this->Env ()->GetStaticMethodID ( clazz, "getActivity", "()Landroid/app/Activity;" );
 	//this->mActivity = this->Env ()->CallStaticObjectMethod ( clazz, getActivity );
 
-	assert ( this->mActivity );
+	//assert ( this->mActivity );
 }
 
 //----------------------------------------------------------------//

--- a/src/moai-android/LinearLayoutIMETrap.java
+++ b/src/moai-android/LinearLayoutIMETrap.java
@@ -58,9 +58,9 @@ public class LinearLayoutIMETrap extends LinearLayout {
 			if ( imm.isActive () && event.getKeyCode () == KeyEvent.KEYCODE_BACK ) {
 				MoaiLog.i ( "LinearLayoutIMETrap dispatchKeyEventPreIme, event: " + event );
 				MoaiKeyboard.hideKeyboard (); // hide the keyboard if its visible ..
-				if ( Moai.backButtonPressed ()) {
-					return true;
-				}
+				// if ( Moai.backButtonPressed ()) {
+				// 	return true;
+				// }
 			}
 		}
 

--- a/src/moai-android/MOAIAppAndroid.cpp
+++ b/src/moai-android/MOAIAppAndroid.cpp
@@ -382,7 +382,7 @@ void MOAIAppAndroid::PushPicturePath( MOAILuaState& state ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" bool Java_com_ziplinegames_moai_Moai_AKUAppInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
+extern "C" JNIEXPORT jboolean JNICALL Java_com_ziplinegames_moai_Moai_AKUAppInvokeListener ( JNIEnv* env, jclass obj, jint eventID ) {
 
 	MOAIScopedLuaState state = MOAILuaRuntime::Get ().State ();
 	if ( MOAIAppAndroid::Get ().PushListener ( eventID, state )) {
@@ -393,11 +393,11 @@ extern "C" bool Java_com_ziplinegames_moai_Moai_AKUAppInvokeListener ( JNIEnv* e
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiCamera_AKUNotifyPictureTaken ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiCamera_AKUNotifyPictureTaken ( JNIEnv* env, jclass obj ) {
 	MOAIAppAndroid::Get ().NotifyPictureTaken ();
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_Moai_AKUAppOpenedFromURL ( JNIEnv* env, jclass obj, jstring url ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUAppOpenedFromURL ( JNIEnv* env, jclass obj, jstring url ) {
 	MOAIAppAndroid::Get ().AppOpenedFromURL ( url );
 }

--- a/src/moai-android/MOAIBillingAndroid.cpp
+++ b/src/moai-android/MOAIBillingAndroid.cpp
@@ -939,13 +939,13 @@ void MOAIBillingAndroid::NotifyUserIdDetermined ( int code, cc8* user ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonBillingSupported ( JNIEnv* env, jclass obj, jboolean supported ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonBillingSupported ( JNIEnv* env, jclass obj, jboolean supported ) {
 
 	MOAIBillingAndroid::Get ().NotifyBillingSupported ( supported );
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 
@@ -955,7 +955,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurc
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring juser, jstring jpayload ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring juser, jstring jpayload ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 	JNI_GET_CSTRING ( jorder, order );
@@ -971,7 +971,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonPurc
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonRestoreResponseReceived ( JNIEnv* env, jclass obj, jint code, jboolean more, jstring joffset ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonRestoreResponseReceived ( JNIEnv* env, jclass obj, jint code, jboolean more, jstring joffset ) {
 
 	JNI_GET_CSTRING ( joffset, offset );
 
@@ -981,7 +981,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonRest
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonUserIdDetermined ( JNIEnv* env, jclass obj, jint code, jstring juser ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonUserIdDetermined ( JNIEnv* env, jclass obj, jint code, jstring juser ) {
 
 	JNI_GET_CSTRING ( juser, user );
 
@@ -995,13 +995,13 @@ extern "C" void Java_com_ziplinegames_moai_MoaiAmazonBilling_AKUNotifyAmazonUser
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGoogleBillingSupported ( JNIEnv* env, jclass obj, jboolean supported ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGoogleBillingSupported ( JNIEnv* env, jclass obj, jboolean supported ) {
 
 	MOAIBillingAndroid::Get ().NotifyBillingSupported ( supported );
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 
@@ -1011,7 +1011,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurc
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring jnotification, jstring jpayload ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring jnotification, jstring jpayload ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 	JNI_GET_CSTRING ( jorder, order );
@@ -1027,7 +1027,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGooglePurc
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGoogleRestoreResponseReceived ( JNIEnv* env, jclass obj, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGoogleRestoreResponseReceived ( JNIEnv* env, jclass obj, jint code ) {
 
 	MOAIBillingAndroid::Get ().NotifyRestoreResponseReceived ( MOAIBillingAndroid::MapGoogleResponseCode ( code ), false, NULL );
 }
@@ -1038,7 +1038,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiGoogleBilling_AKUNotifyGoogleRest
 
 //----------------------------------------------------------------//
 
-extern "C" void Java_com_ziplinegames_moai_MoaiFortumoReciever_AKUNotifyFortumoPurchaseResponseReceived ( JNIEnv* env, jclass obj,  jint billing_status, jstring jcredit_amount,
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiFortumoReciever_AKUNotifyFortumoPurchaseResponseReceived ( JNIEnv* env, jclass obj,  jint billing_status, jstring jcredit_amount,
 																																			jstring jcredit_name, jstring jmessage_id,
 																																			jstring jpayment_code, jstring jprice_amount,
 																																			jstring jprice_currency, jstring jproduct_name,
@@ -1072,7 +1072,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiFortumoReciever_AKUNotifyFortumoP
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreBilling_AKUNotifyTstorePurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreBilling_AKUNotifyTstorePurchaseResponseReceived ( JNIEnv* env, jclass obj, jint code, jstring jidentifier ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 
@@ -1082,7 +1082,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiTstoreBilling_AKUNotifyTstorePurc
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiTstoreBilling_AKUNotifyTstorePurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring juser, jstring jpayload ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiTstoreBilling_AKUNotifyTstorePurchaseStateChanged ( JNIEnv* env, jclass obj, jint code, jstring jidentifier, jstring jorder, jstring juser, jstring jpayload ) {
 
 	JNI_GET_CSTRING ( jidentifier, identifier );
 	JNI_GET_CSTRING ( jorder, order );

--- a/src/moai-android/MOAIDialogAndroid.cpp
+++ b/src/moai-android/MOAIDialogAndroid.cpp
@@ -127,7 +127,7 @@ void MOAIDialogAndroid::NotifyDialogDismissed ( int dialogResult ) {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_Moai_AKUAppDialogDismissed ( JNIEnv* env, jclass obj, jint code ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUAppDialogDismissed ( JNIEnv* env, jclass obj, jint code ) {
 
 	MOAIDialogAndroid::Get ().NotifyDialogDismissed ( code );
 }

--- a/src/moai-android/MOAIKeyboardAndroid.cpp
+++ b/src/moai-android/MOAIKeyboardAndroid.cpp
@@ -24,11 +24,11 @@ extern JavaVM* jvm;
   
 //----------------------------------------------------------------//
 // The listeners need to be called on the event
-extern "C" void Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyKeyEvent ( JNIEnv* env, jclass cls ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyKeyEvent ( JNIEnv* env, jclass cls ) {
 	MOAIKeyboardAndroid::Get ().NotifyKeyEvent();
 }
 
-extern "C" void Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyTextDone ( JNIEnv* env, jclass cls ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiKeyboard_AKUNotifyTextDone ( JNIEnv* env, jclass cls ) {
 	MOAIKeyboardAndroid::Get ().NotifyTextDone();
 }
 

--- a/src/moai-android/MOAIMoviePlayerAndroid.cpp
+++ b/src/moai-android/MOAIMoviePlayerAndroid.cpp
@@ -223,13 +223,13 @@ void MOAIMoviePlayerAndroid::NotifyMoviePlayerReady () {
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiMoviePlayer_AKUNotifyMoviePlayerCompleted ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiMoviePlayer_AKUNotifyMoviePlayerCompleted ( JNIEnv* env, jclass obj ) {
 
 	MOAIMoviePlayerAndroid::Get ().NotifyMoviePlayerCompleted ();
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiMoviePlayer_AKUNotifyMoviePlayerReady ( JNIEnv* env, jclass obj ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiMoviePlayer_AKUNotifyMoviePlayerReady ( JNIEnv* env, jclass obj ) {
 
 	MOAIMoviePlayerAndroid::Get ().NotifyMoviePlayerReady ();
 }

--- a/src/moai-android/MOAINotificationsAndroid.cpp
+++ b/src/moai-android/MOAINotificationsAndroid.cpp
@@ -353,7 +353,7 @@ void MOAINotificationsAndroid::NotifyRemoteRegistrationComplete ( int code, cc8*
 //================================================================//
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGooglePushRemoteNotificationRegistrationComplete ( JNIEnv* env, jclass obj, jint code, jstring jregistration ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGooglePushRemoteNotificationRegistrationComplete ( JNIEnv* env, jclass obj, jint code, jstring jregistration ) {
 
 	JNI_GET_CSTRING ( jregistration, registration );
 	
@@ -363,7 +363,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGoogl
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGooglePushRemoteNotificationReceived ( JNIEnv* env, jclass obj, jobjectArray jkeys, jobjectArray jvalues ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGooglePushRemoteNotificationReceived ( JNIEnv* env, jclass obj, jobjectArray jkeys, jobjectArray jvalues ) {
 
 	if ( env->GetArrayLength ( jkeys ) != env->GetArrayLength ( jvalues )) return;
 
@@ -402,7 +402,7 @@ extern "C" void Java_com_ziplinegames_moai_MoaiGooglePushReceiver_AKUNotifyGoogl
 }
 
 //----------------------------------------------------------------//
-extern "C" void Java_com_ziplinegames_moai_MoaiLocalNotificationReceiver_AKUNotifyLocalNotificationReceived ( JNIEnv* env, jclass obj, jobjectArray jkeys, jobjectArray jvalues ) {
+extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_MoaiLocalNotificationReceiver_AKUNotifyLocalNotificationReceived ( JNIEnv* env, jclass obj, jobjectArray jkeys, jobjectArray jvalues ) {
 	
 	if ( env->GetArrayLength ( jkeys ) != env->GetArrayLength ( jvalues )) return;
 

--- a/src/moai-android/Moai.java
+++ b/src/moai-android/Moai.java
@@ -21,6 +21,7 @@ import android.util.DisplayMetrics;
 import java.lang.reflect.Method;
 import java.lang.Runtime;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.ArrayList;
 import java.util.UUID;
@@ -142,6 +143,8 @@ public class Moai {
 		"com.ziplinegames.moai.MoaiGoogleBilling",
 		"com.ziplinegames.moai.MoaiGooglePlayServices",
 		"com.ziplinegames.moai.MoaiGooglePush",
+		"com.ziplinegames.moai.MoaiKeyboard",
+		"com.ziplinegames.moai.MoaiMoviePlayer",
 		"com.ziplinegames.moai.MoaiTapjoy",
 		"com.ziplinegames.moai.MoaiVungle",
 	};
@@ -376,7 +379,7 @@ public class Moai {
 
 		sActivity = activity;
 
-		MoaiMoviePlayer.onCreate ( activity );
+		AKUAppInitialize ();
 
 		for ( Class < ? > theClass : sAvailableClasses ) {
 			executeMethod ( theClass, null, "onCreate", new Class < ? > [] { Activity.class }, new Object [] { activity });
@@ -495,6 +498,14 @@ public class Moai {
 
 		synchronized ( sAkuLock ) {
 			AKUSetScreenSize ( width, height );
+		}
+	}
+
+	//----------------------------------------------------------------//
+	public static void setScreenDpi ( int dpi ) {
+		
+		synchronized ( sAkuLock ) {
+			AKUSetScreenDpi ( dpi );
 		}
 	}
 

--- a/src/moai-android/MoaiActivity.java
+++ b/src/moai-android/MoaiActivity.java
@@ -37,7 +37,6 @@ import com.ziplinegames.moai.*;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import java.net.URI;
-import android.content.Context;
 import android.os.AsyncTask;
 import android.net.Uri;
 import android.provider.Settings.Secure;
@@ -86,9 +85,11 @@ public class MoaiActivity extends Activity {
 		
 		requestWindowFeature ( Window.FEATURE_NO_TITLE );
 		super.onCreate ( savedInstanceState );
+
 		Moai.onCreate ( this );
-		
+
 		Moai.createContext ();
+
 		Moai.init ();
 		
 		getWindow ().addFlags ( WindowManager.LayoutParams.FLAG_FULLSCREEN );
@@ -107,7 +108,7 @@ public class MoaiActivity extends Activity {
 			    Moai.mount ( "bundle", myApp.publicSourceDir );
 			}
 			
-			Moai.setWorkingDirectory ( "bundle/assets/@WORKING_DIR@" );
+			Moai.setWorkingDirectory ( "@WORKING_DIR@" );
 		} catch ( NameNotFoundException e ) {
 			MoaiLog.e ( "MoaiActivity onCreate: Unable to locate the application bundle" );
 		}
@@ -142,7 +143,8 @@ public class MoaiActivity extends Activity {
 		
 		MoaiLog.i ( "MoaiActivity onCreate: Running game scripts" );
 		
-		@RUN_COMMAND@
+		// Moai.runScript ( "../init.lua" );
+		Moai.runScript ( "bootstrap.lua" );
 			
 		Moai.invokeListener ( Moai.ListenerEvent.ACTIVITY_ON_CREATE );
     }

--- a/src/moai-android/MoaiView.java
+++ b/src/moai-android/MoaiView.java
@@ -10,10 +10,13 @@ import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
 import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.opengl.GLSurfaceView;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.MotionEvent;
+import android.util.DisplayMetrics;
 
 // Moai
 import com.ziplinegames.moai.*;
@@ -23,18 +26,21 @@ import com.ziplinegames.moai.*;
 //================================================================//
 public class MoaiView extends GLSurfaceView {
 
+	private static final long	AKU_UPDATE_FREQUENCY = 1000 / 60; // 60 Hz, in milliseconds
+
+	private Context		mAppContext;
 	private Handler		mHandler;
 	private int 		mHeight;
 	private Runnable	mUpdateRunnable;
 	private int 		mWidth;
 	
-	private static final long	AKU_UPDATE_FREQUENCY = 1000 / 60; // 60 Hz, in milliseconds
-
     //----------------------------------------------------------------//
 	public MoaiView ( Context context, int width, int height, int glesVersion ) {
 
 		super ( context );
 		
+		mAppContext = context.getApplicationContext();
+
 		setScreenDimensions ( width, height );
 		Moai.setScreenSize ( mWidth, mHeight );
 		

--- a/src/moai-android/moai.cpp
+++ b/src/moai-android/moai.cpp
@@ -128,25 +128,32 @@
 //================================================================//
 
 	//----------------------------------------------------------------//
-	extern "C" int Java_com_ziplinegames_moai_Moai_AKUCreateContext ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUAppInitialize ( JNIEnv* env, jclass obj ) {
+
+		AKUAppInitialize();
+		AKUModulesAppInitialize();
+	}	
+
+	//----------------------------------------------------------------//
+	extern "C" JNIEXPORT jint JNICALL Java_com_ziplinegames_moai_Moai_AKUCreateContext ( JNIEnv* env, jclass obj ) {
 
 		return AKUCreateContext ();
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUDeleteContext ( JNIEnv* env, jclass obj, jint contextId ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUDeleteContext ( JNIEnv* env, jclass obj, jint contextId ) {
 
 		AKUDeleteContext ( contextId );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUDetectGfxContext ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUDetectGfxContext ( JNIEnv* env, jclass obj ) {
 
 		AKUDetectGfxContext ();
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUEnqueueCompassEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jfloat heading ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUEnqueueCompassEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jfloat heading ) {
 
 		InputEvent ievent;
 
@@ -161,7 +168,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUEnqueueLevelEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jfloat x, jfloat y, jfloat z ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUEnqueueLevelEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jfloat x, jfloat y, jfloat z ) {
 
 		InputEvent ievent;
 
@@ -178,7 +185,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUEnqueueLocationEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jdouble longitude, jdouble latitude, jdouble altitude, jfloat hAccuracy, jfloat vAccuracy, jfloat speed ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUEnqueueLocationEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jdouble longitude, jdouble latitude, jdouble altitude, jfloat hAccuracy, jfloat vAccuracy, jfloat speed ) {
 
 		InputEvent ievent;
 
@@ -198,7 +205,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUEnqueueTouchEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jint touchId, jboolean down, jint x, jint y ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUEnqueueTouchEvent ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jint touchId, jboolean down, jint x, jint y ) {
 
 		InputEvent ievent;
 
@@ -216,13 +223,13 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUFinalize	( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUFinalize	( JNIEnv* env, jclass obj ) {
         AKUModulesAppFinalize();
         AKUAppFinalize ();
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUInit ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUInit ( JNIEnv* env, jclass obj ) {
 
 		MOAIAppAndroid::Affirm ();
 		REGISTER_LUA_CLASS ( MOAIAppAndroid );
@@ -305,23 +312,17 @@
 	}
 	
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUAppInitialize ( JNIEnv* env, jclass obj ) {
-		AKUAppInitialize();
-		AKUModulesAppInitialize();
-	}	
-
-	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUModulesContextInitialize ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUModulesContextInitialize ( JNIEnv* env, jclass obj ) {
         AKUModulesContextInitialize ();
     }
 
     //----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUModulesRunLuaAPIWrapper ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUModulesRunLuaAPIWrapper ( JNIEnv* env, jclass obj ) {
         AKUModulesRunLuaAPIWrapper ();
     }
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUMountVirtualDirectory ( JNIEnv* env, jclass obj, jstring jvirtualPath, jstring jarchive ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUMountVirtualDirectory ( JNIEnv* env, jclass obj, jstring jvirtualPath, jstring jarchive ) {
 
 		JNI_GET_CSTRING ( jvirtualPath, virtualPath );
 		JNI_GET_CSTRING ( jarchive, archive );
@@ -333,37 +334,37 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUPause ( JNIEnv* env, jclass obj, jboolean paused ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUPause ( JNIEnv* env, jclass obj, jboolean paused ) {
 
 		AKUModulesPause ( paused );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUReleaseGfxContext ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUReleaseGfxContext ( JNIEnv* env, jclass obj ) {
 
 		AKUReleaseGfxContext ();
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKURender ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKURender ( JNIEnv* env, jclass obj ) {
 
 		AKURender ();
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUReserveInputDevices ( JNIEnv* env, jclass obj, jint total ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUReserveInputDevices ( JNIEnv* env, jclass obj, jint total ) {
 
 		AKUReserveInputDevices ( total );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUReserveInputDeviceSensors ( JNIEnv* env, jclass obj, jint deviceId, jint total ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUReserveInputDeviceSensors ( JNIEnv* env, jclass obj, jint deviceId, jint total ) {
 
 		AKUReserveInputDeviceSensors ( deviceId, total );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKURunScript ( JNIEnv* env, jclass obj, jstring jfilename ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKURunScript ( JNIEnv* env, jclass obj, jstring jfilename ) {
 
 		JNI_GET_CSTRING ( jfilename, filename );
 		AKULoadFuncFromFile ( filename );
@@ -372,19 +373,19 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetConnectionType ( JNIEnv* env, jclass obj, jlong connectionType ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetConnectionType ( JNIEnv* env, jclass obj, jlong connectionType ) {
 
 		MOAIEnvironment::Get ().SetValue ( MOAI_ENV_connectionType,	( int )connectionType );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetContext ( JNIEnv* env, jclass obj, jint contextId ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetContext ( JNIEnv* env, jclass obj, jint contextId ) {
 
 		AKUSetContext ( contextId );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetDeviceProperties ( JNIEnv* env, jclass obj, jstring jappName, jstring jappId, jstring jappVersion, jstring jabi, jstring jdevBrand, jstring jdevName, jstring jdevManufacturer, jstring jdevModel, jstring jdevProduct, jint jnumProcessors, jstring josBrand, jstring josVersion, jstring judid ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetDeviceProperties ( JNIEnv* env, jclass obj, jstring jappName, jstring jappId, jstring jappVersion, jstring jabi, jstring jdevBrand, jstring jdevName, jstring jdevManufacturer, jstring jdevModel, jstring jdevProduct, jint jnumProcessors, jstring josBrand, jstring josVersion, jstring judid ) {
 
 		JNI_GET_CSTRING ( jappName, appName );
 		JNI_GET_CSTRING ( jappId, appId );
@@ -430,7 +431,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetDocumentDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetDocumentDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
 
 		JNI_GET_CSTRING ( jpath, path );
 		MOAIEnvironment::Get ().SetValue ( MOAI_ENV_documentDirectory,	path );
@@ -438,7 +439,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetCacheDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetCacheDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
 		
 		JNI_GET_CSTRING ( jpath, path );
 		MOAIEnvironment::Get ().SetValue ( MOAI_ENV_cacheDirectory,	path );
@@ -446,7 +447,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputConfigurationName ( JNIEnv* env, jclass obj, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputConfigurationName ( JNIEnv* env, jclass obj, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputConfigurationName ( name );
@@ -454,7 +455,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputDevice ( JNIEnv* env, jclass obj, jint deviceId, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputDevice ( JNIEnv* env, jclass obj, jint deviceId, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputDevice ( deviceId, name );
@@ -462,7 +463,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceCompass ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceCompass ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputDeviceCompass ( deviceId, sensorId, name );
@@ -470,7 +471,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceLevel ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceLevel ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputDeviceLevel ( deviceId, sensorId, name );
@@ -478,7 +479,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceLocation ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceLocation ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputDeviceLocation ( deviceId, sensorId, name );
@@ -486,7 +487,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceTouch ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetInputDeviceTouch ( JNIEnv* env, jclass obj, jint deviceId, jint sensorId, jstring jname ) {
 
 		JNI_GET_CSTRING ( jname, name );
 		AKUSetInputDeviceTouch ( deviceId, sensorId, name );
@@ -494,25 +495,25 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetScreenDpi ( JNIEnv* env, jclass obj, jint dpi ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetScreenDpi ( JNIEnv* env, jclass obj, jint dpi ) {
 
 		AKUSetScreenDpi ( dpi );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetScreenSize ( JNIEnv* env, jclass obj, jint width, jint height ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetScreenSize ( JNIEnv* env, jclass obj, jint width, jint height ) {
 
 		AKUSetScreenSize ( width, height );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetViewSize ( JNIEnv* env, jclass obj, jint width, jint height ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetViewSize ( JNIEnv* env, jclass obj, jint width, jint height ) {
 
 		AKUSetViewSize ( width, height );
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetWorkingDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetWorkingDirectory ( JNIEnv* env, jclass obj, jstring jpath ) {
 
 		JNI_GET_CSTRING ( jpath, path );
 
@@ -523,7 +524,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUModulesUpdate ( JNIEnv* env, jclass obj ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUModulesUpdate ( JNIEnv* env, jclass obj ) {
 
 		InputEvent ievent;
 		while ( inputQueue->Pop ( ievent )) {
@@ -549,7 +550,7 @@
 	}
 
 	//----------------------------------------------------------------//
-	extern "C" void Java_com_ziplinegames_moai_Moai_AKUSetDeviceLocale ( JNIEnv* env, jclass obj, jstring jlangCode, jstring jcountryCode ) {
+	extern "C" JNIEXPORT void JNICALL Java_com_ziplinegames_moai_Moai_AKUSetDeviceLocale ( JNIEnv* env, jclass obj, jstring jlangCode, jstring jcountryCode ) {
 	
 		JNI_GET_CSTRING ( jlangCode, langCode );
 		JNI_GET_CSTRING ( jcountryCode, countryCode );

--- a/util/ant-host.lua
+++ b/util/ant-host.lua
@@ -61,10 +61,7 @@ config.LUA_MAIN						= 'main.lua'
 
 config.MANIFEST_DEBUGGABLE			= 'false'
 
-config.ANDROID_PLATFORM_TARGET		= 10
-
-config.LUA_WORKING_DIR				= 'bundle/assets/lua'
-config.LUA_MAIN						= 'main.lua'
+config.ANDROID_PLATFORM_TARGET		= 'android-17'
 
 --==============================================================
 -- util

--- a/util/ant-host/config.lua
+++ b/util/ant-host/config.lua
@@ -1,3 +1,4 @@
+ANDROID_PLATFORM_TARGET				= "android-17"
 
 MODULES = {
 


### PR DESCRIPTION
...lot of progress.

ant/libmoai/jni/Android.mk
- Adding libmoai-android to LOCAL_STATIC_LIBRARIES.

ant/libmoai/modules/moai-android.mk
- Renaming LOCAL_MODULE from "host-android" to "moai-android". Was causing moai-android to not be included in the shared object file.

src/host-modules/aku_modules.h
- Adding include of moai-core/host.h for different "AKU" function definitions.

src/moai-android/JniUtils.cpp
- Everything else in the constructor was commented out, so the assert was commented out as well, for now.

src/moai-android/LinearLayoutIMETrap.java
- Bad merge wrt back button pressed behavior. Commenting out for now.

src/moai-android/moai.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.
- Moving the AKUAppInitialize function to the top so that it's alphabetically in the right place.

src/moai-android/Moai.java
- Adding a missing import for Locale.
- Adding MoaiKeyboard and MoaiMoviePlayer to the list of external classes.
- Removing the MoaiMoviePlayer.onCreate call from the Moai.onCreate function, as it now is taken care of in the for loop.
- Adding the call to AkuAppInitialize() in the Moai.onCreate function.
- Re-adding the setScreenDpi function, as it was missed by a bad merge.

src/moai-android/MoaiActivity.java
- Fixing type in Moai.setWorkingDirectory(). "bundle/assets" was redundant as it's already included in the @WORKING_DIR@ var.
- @RUN_COMMAND@ removed and replaced with 2 Moai.runScript calls. The call to run ../init.lua wasn't working properly, but might not be needed anymore, so commenting out for now. Running bootstrap.lue needed.

src/moai-android/MOAIAppAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MOAIBillingAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MOAIDialogAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MOAIKeyboardAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MOAIMoviePlayerAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MOAINotificationsAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android/MoaiView.java
- Missing imports for Configuration, Resources and Display Metrics.
- Moving the AKU_UPDATE_FREQUENCY var to the top of the list of members, because its a const.
- Re-adding mAppContext. Was deleted via a bad merge.
- Re-adding the initializing of mAppContext in the MoaiView constructor.

src/moai-android-adcolony/MOAIAdColonyAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-chartboost/MOAIChartBoostAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-facebook/MOAIFacebookAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-google-play-services/MOAIGooglePlayServicesAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-tapjoy/MOAITapjoyAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-tstore/MOAITstoreGamecenterAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-tstore/MOAITstoreWallAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-twitter/MOAITwitterAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

src/moai-android-vungle/MOAIVungleAndroid.cpp
- Adding JNIEXPORT and JNICALL to all extern "C" function return types. Changing some return types to their "j" types as needed.

util/ant-host.lua
- Changing ANDROID_PLATFORM_TARGET from id 10 to "android-17". The id number is a moving target value based on the number of sdk platforms you currently have installed, so it doesn't point at a static platform. "android-17" does, which is 4.2.2.
- Removing duplicate entries of LUA_WORKING_DIR and LUA_MAIN.

util/ant-host/config.lua
- Adding ANDROID_PLATFORM_TARGET var
