### PR TITLE
Bug fixes MOAIStretchPatch2D.

### DIFF
--- a/src/moai-sim/MOAIStretchPatch2D.cpp
+++ b/src/moai-sim/MOAIStretchPatch2D.cpp
@@ -223,8 +223,8 @@ void MOAIStretchPatch2D::DrawStretch ( u32 idx, float xStretch, float yStretch )
 	float nativeHeight = this->mRect.Height ();
 	
 	// TODO: make optional
-	xStretch /= nativeWidth;
-	yStretch /= nativeHeight;
+	// xStretch /= nativeWidth;
+	// yStretch /= nativeHeight;
 	
 	float rectWidth = nativeWidth * xStretch;
 	float rectHeight = nativeHeight * yStretch;


### PR DESCRIPTION
MOAIStretchPatch2D becomes considerably smaller.
Fixed to the same behavior as before V1.5.

See #996
