### PR TITLE
Regression in font glyph (imagetexture) invalidation

### DIFF
--- a/src/moai-sim/MOAIImageTexture.cpp
+++ b/src/moai-sim/MOAIImageTexture.cpp
@@ -25,7 +25,7 @@
 */
 int MOAIImageTexture::_updateRegion ( lua_State* L ) {
 	MOAI_LUA_SETUP ( MOAIImageTexture, "U" )
-	
+
 	if ( state.GetTop () > 1 ) {
 		ZLIntRect rect = state.GetRect < int >( 2 );
 		self->UpdateRegion ( rect );
@@ -55,7 +55,7 @@ bool MOAIImageTexture::IsValid () {
 //----------------------------------------------------------------//
 MOAIImageTexture::MOAIImageTexture () :
 	mStatus ( INVALID ) {
-	
+
 	RTTI_BEGIN
 		RTTI_EXTEND ( MOAITextureBase )
 		RTTI_EXTEND ( MOAIImage )
@@ -77,12 +77,12 @@ void MOAIImageTexture::OnClear () {
 void MOAIImageTexture::OnCreate () {
 
 	if ( !this->IsOK ()) return;
-	
+
 	if ( !this->mGLTexID ) {
 		this->CreateTextureFromImage ( *this );
 	}
 	else if ( this->mStatus != VALID ) {
-		
+
 		ZLIntRect rect = this->mRegion;
 		if ( this->mStatus == INVALID ) {
 			rect = this->GetRect ();
@@ -96,13 +96,11 @@ void MOAIImageTexture::OnCreate () {
 void MOAIImageTexture::OnLoad () {
 }
 
-//----------------------------------------------------------------//
-void MOAIImageTexture::OnInvalidate () {
-}
+
 
 //----------------------------------------------------------------//
 void MOAIImageTexture::RegisterLuaClass ( MOAILuaState& state ) {
-	
+
 	MOAITextureBase::RegisterLuaClass ( state );
 	MOAIImage::RegisterLuaClass ( state );
 }
@@ -112,7 +110,7 @@ void MOAIImageTexture::RegisterLuaFuncs ( MOAILuaState& state ) {
 
 	MOAITextureBase::RegisterLuaFuncs ( state );
 	MOAIImage::RegisterLuaFuncs ( state );
-	
+
 	luaL_Reg regTable [] = {
 		{ "invalidate",					_updateRegion }, // TODO: deprecate
 		{ "updateRegion",				_updateRegion },
@@ -137,17 +135,16 @@ void MOAIImageTexture::UpdateRegion () {
 
 	//this->mStatus = INVALID;
  	//this->MOAIGfxResource::Load ();
-	
+
 	this->mRegion = this->GetRect ();
-	
+
 	this->mStatus = INVALID_REGION;
-	this->MOAIGfxResource::Invalidate ();
-	this->MOAIGfxResource::Load ();
+	this->MOAIGfxResource::InvalidateContents ();
 }
 
 //----------------------------------------------------------------//
 void MOAIImageTexture::UpdateRegion ( ZLIntRect rect ) {
-	
+
 	if ( this->mStatus != INVALID ) {
 
 		rect.Bless ();
@@ -160,8 +157,7 @@ void MOAIImageTexture::UpdateRegion ( ZLIntRect rect ) {
 			this->mRegion.Grow ( rect );
 		}
 	}
-	
+
 	this->mStatus = INVALID_REGION;
-	this->MOAIGfxResource::Invalidate ();
-	this->MOAIGfxResource::Load ();
+	this->MOAIGfxResource::InvalidateContents ();
 }

--- a/src/moai-sim/MOAIImageTexture.h
+++ b/src/moai-sim/MOAIImageTexture.h
@@ -39,14 +39,13 @@ private:
 	void			OnClear					();
 	void			OnCreate				();
 	void			OnLoad					();
-	void			OnInvalidate			();
 
 public:
-	
+
 	DECL_LUA_FACTORY ( MOAIImageTexture )
-	
+
 	static const u32 DEFAULT_TRANSFORM = MOAIImageTransform::TRUECOLOR | MOAIImageTransform::PREMULTIPLY_ALPHA;
-	
+
 	//----------------------------------------------------------------//
 					MOAIImageTexture		();
 					~MOAIImageTexture		();


### PR DESCRIPTION
fixes regression in image texture routines. 
To reproduce run hello moai on android. lock screen, unlock screen, fonts are trashed.

doing nothing on onInvalidate caused the glyphs to be trashed when android was suspended/unsuspended, 

calling load was causing a texture reload every glyph (leak), 

Instead use the invalidateContents method to put the texture in the correct state to load its image into gpu next call (and reuse the texture handle) and leave onInvalidate handling to manage the android suspend/resume

This was working in 1.5-stable
