### PR TITLE
Fix for MOAIHashWriter if no backing stream

### DIFF
--- a/samples/util-hash-file/main.lua
+++ b/samples/util-hash-file/main.lua
@@ -1,0 +1,35 @@
+
+----------------------------------------------------------------
+hashFile1 = function ( filename )
+	
+	local file = MOAIFileStream.new ()
+	file:open ( filename )
+	local data = file:read ()
+	file:close ()
+	
+	local writer = MOAIHashWriter.new ()
+	writer:openMD5 ()
+	writer:write ( data )
+	writer:close ()
+	
+	return writer:getHashHex ()
+end
+
+----------------------------------------------------------------
+hashFile2 = function ( filename )
+	
+	local file = MOAIFileStream.new ()
+	file:open ( filename )
+
+	local writer = MOAIHashWriter.new ()
+	writer:openMD5 ()
+	writer:writeStream ( file )
+	writer:close ()
+	file:close ()
+	
+	return writer:getHashHex ()
+end
+
+print ( hashFile1 ( 'test.txt' ))
+print ( hashFile2 ( 'test.txt' ))
+print ( 'd174ab98d277d9f5a5611c2c9f419d9f' )

--- a/samples/util-hash-file/run.bat
+++ b/samples/util-hash-file/run.bat
@@ -1,0 +1,24 @@
+::----------------------------------------------------------------::
+:: Copyright (c) 2010-2011 Zipline Games, Inc.
+:: All Rights Reserved.
+:: http://getmoai.com
+::----------------------------------------------------------------::
+
+@echo off
+
+:: verify paths
+if not exist "%MOAI_BIN%\moai.exe" (
+	echo.
+	echo --------------------------------------------------------------------------------
+	echo ERROR: The MOAI_BIN environment variable either doesn't exist or it's pointing
+	echo to an invalid path. Please point it at a folder containing moai.exe.
+	echo --------------------------------------------------------------------------------
+	echo.
+	goto end
+)
+
+:: run moai
+"%MOAI_BIN%\moai" "main.lua"
+
+:end
+pause

--- a/samples/util-hash-file/run.sh
+++ b/samples/util-hash-file/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#--------------------------------------------------------------------------------------
+# Copyright (c) 2010-2013 Zipline Games, Inc.
+# All Rights Reserved.
+# http://getmoai.com
+#--------------------------------------------------------------------------------------
+
+cd `dirname $0`
+
+# Verify paths
+if [ ! -f "$MOAI_BIN/moai" ]; then
+    echo "---------------------------------------------------------------------------"
+    echo "Error: The MOAI_BIN environment variable doesn't exist or its pointing to an"
+    echo "invalid path.  Please point it at a folder containing moai executable"
+    echo "---------------------------------------------------------------------------"
+    exit 1
+fi
+
+# Run moai
+$MOAI_BIN/moai main.lua

--- a/samples/util-hash-file/test.txt
+++ b/samples/util-hash-file/test.txt
@@ -1,0 +1,1 @@
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789

--- a/src/moai-crypto/MOAIHashWriterCrypto.h
+++ b/src/moai-crypto/MOAIHashWriterCrypto.h
@@ -10,7 +10,7 @@
 /**	@lua	MOAIHashWriterCrypto
 	@text	MOAIHashWriterCrypto may be attached to another stream for the
 			purpose of computing a hash while writing data to the other
-			stream. Currently only MD5 and SHA256 are available. 
+			stream. Currently only MD5 and SHA are available. 
 */
 class MOAIHashWriterCrypto :
 	public MOAIHashWriter {

--- a/src/zl-util/ZLHashWriter.cpp
+++ b/src/zl-util/ZLHashWriter.cpp
@@ -11,7 +11,7 @@
 //----------------------------------------------------------------//
 u32 ZLHashWriter::GetCaps () {
 
-	return this->mProxiedStream ? CAN_WRITE : 0;
+	return this->mProxiedStream ? this->mProxiedStream->GetCaps () | CAN_WRITE : CAN_WRITE;
 }
 
 //----------------------------------------------------------------//

--- a/xcode/osx/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
+++ b/xcode/osx/MoaiSample.xcodeproj/xcshareddata/xcschemes/moai.xcscheme
@@ -44,7 +44,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "YES"
-      customWorkingDirectory = "/Users/patrick/git/moai-dev/samples/box2d-squishy-swine"
+      customWorkingDirectory = "/Users/patrick/git/moai-dev/samples/util-hash-file"
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"


### PR DESCRIPTION
There was a bug where using writeStream with MOAIHashWriter wouldn't work unless there's also a backing stream.

This went undetected since usually we hash as we write to a file.
