### PR TITLE
fix sounds never stopping in untz

### DIFF
--- a/3rdparty/untz/src/AudioMixer.cpp
+++ b/3rdparty/untz/src/AudioMixer.cpp
@@ -112,7 +112,7 @@ int AudioMixer::process(UInt32 numInputChannels, float* inputBuffer, UInt32 numO
 			}
 			while(framesRead > 0 && totalFramesRead < numFrames);
             
-			if(framesRead == -1)
+			if(framesRead == 0)
             {
                 if ( ! s->isLooping() )
                 {


### PR DESCRIPTION
audio sources return 0 for frames read, not -1, the .stop code was never called.
