### PR TITLE
Update build instructions for os x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Please build according to the following procedure.
 
 	# Build
 	cd moai-dev
-	./bin/build-osx-sdl.sh
+	./bin/build-osx.sh
 	
 	# Run
 	cd <sample_directory>


### PR DESCRIPTION
Just noticed that the README says to run `./bin/build-osx-sdl.sh` which does not exist anymore. So here is a PR with the minor updated instruction to run `./bin/build-osx.sh` instead (which does exist) :)
