### PR TITLE
moai_api_parser.rb: Support split-out moai_version_*.h

### DIFF
--- a/bin/api-reference-parser/lib/moai_api_parser.rb
+++ b/bin/api-reference-parser/lib/moai_api_parser.rb
@@ -122,18 +122,24 @@ class MoaiAPIParser
   end
 
   def parse_version
-    file = File.open ( destination + "src/config-default/moai_version.h" )
-    data = file.read
+    File.open ( destination + "src/config-default/moai_version_major.h" ) do |file|
+      data = file.read
 
-    data.match ( /MOAI_SDK_VERSION_MAJOR_MINOR\s(\S*)\s*/ )
-    self.version_major = $1
+      data.match ( /MOAI_SDK_VERSION_MAJOR_MINOR\s(\S*)\s*/ )
+      self.version_major = $1
+    end
+    File.open ( destination + "src/config-default/moai_version_minor.h" ) do |file|
+      data = file.read
 
-    data.match ( /MOAI_SDK_VERSION_REVISION\s(\S*)\s*/ )
-    self.version_revision = $1
+      data.match ( /MOAI_SDK_VERSION_REVISION\s(\S*)\s*/ )
+      self.version_revision = $1
+    end
+    File.open ( destination + "src/config-default/moai_version_author.h" ) do |file|
+      data = file.read
 
-    data.match ( /MOAI_SDK_VERSION_AUTHOR\s\"(.*)\"\s*/ )
-    self.version_author = $1    
-
+      data.match ( /MOAI_SDK_VERSION_AUTHOR\s\"(.*)\"\s*/ )
+      self.version_author = $1    
+    end
   end
 
   def full_version


### PR DESCRIPTION
moai_api_parser.rb assumed that there was a single moai_version.h,
there isn't anymore. Tweaked.

(This fixes doc builds and allowed me to build a complete current doc set.)
