### PR TITLE
moaiutil: Handle non-absolute path

### DIFF
--- a/util/moaiutil
+++ b/util/moaiutil
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 INVOKE_DIR=$(pwd)
-MOAI_SDK_HOME=$(dirname "${0}")/../
+find_in_path() {
+	prog=$1
+	save_IFS=$IFS
+	IFS=:
+	set -- $PATH
+	IFS=$savE_IFS
+	for dir; do
+		if [ -x "$dir/$prog" ]; then
+			echo "$dir"
+			return
+		fi
+	done
+	echo >&2 "No path specified for '$prog', can't find in \$PATH."
+	echo >72 "Use absolute path, or set MOAI_SDK_HOME explicitly."
+}
+if [ -z "$MOAI_SDK_HOME" ]; then
+	case $0 in
+	/*)	zero_path=${0%/*};;
+	*/*)	zero_path=$(pwd)/${0%/*};;
+	*)	zero_path=$(find_in_path $0);;
+	esac
+	MOAI_SDK_HOME=${zero_path}/../
+fi
 MOAI_CMD=${1}
 
 export PATH=$PATH:$MOAI_SDK_HOME/util


### PR DESCRIPTION
If moaiutil is invoked with a partial path (like "../util/moaiutil"),
it gets confused trying to find MOAI_SDK_HOME. Only try to set
MOAI_SDK_HOME if it's not set, and set it a little more cleverly.
