### PR TITLE
moaiutil is now called pito

### DIFF
--- a/ant/host-clean.sh
+++ b/ant/host-clean.sh
@@ -1,4 +1,4 @@
 #rm -rf libmoai/obj
 #rm -rf libmoai/libs
 
-../util/moaiutil ant-host
+../util/pito ant-host

--- a/ant/host-reset.sh
+++ b/ant/host-reset.sh
@@ -1,1 +1,1 @@
-../util/moaiutil ant-host
+../util/pito ant-host

--- a/ant/libmoai-clean.sh
+++ b/ant/libmoai-clean.sh
@@ -3,4 +3,4 @@ set -e # exit on error
 rm -rf libmoai/obj
 rm -rf libmoai/libs
 
-../util/moaiutil ant-libmoai
+../util/pito ant-libmoai

--- a/bin/build-all-linux.sh
+++ b/bin/build-all-linux.sh
@@ -14,7 +14,7 @@ echo "Linux Libs complete"
 
 echo "Creating linux host"
 
-moaiutil host-linux
+pito host-linux
 
 echo "Linux host Complete"
 
@@ -26,7 +26,7 @@ echo "Android libs complete"
 
 echo "Creating android host"
 
-moaiutil host-android-gradle
+pito host-android-gradle
 
 echo "Android host Complete"
 

--- a/bin/build-all-windows.bat
+++ b/bin/build-all-windows.bat
@@ -10,7 +10,7 @@ echo "windows lib complete"
 
 echo "Creating windows host"
 
-call moaiutil.bat host-windows-vs2013 || goto :error
+call pito.bat host-windows-vs2013 || goto :error
 
 echo "Windows host Complete"
 
@@ -22,7 +22,7 @@ echo "Android lib complete"
 
 echo "Creating android host"
 
-call moaiutil.bat host-android-gradle || goto :error
+call pito.bat host-android-gradle || goto :error
 
 echo "android host Complete"
 

--- a/bin/ci-android.sh
+++ b/bin/ci-android.sh
@@ -1,4 +1,4 @@
-echo "Setting up MoaiUtil path..."
+echo "Setting up pito path..."
 
 UTIL_PATH=$(dirname "${BASH_SOURCE[0]}")
 UTIL_PATH=$(cd $UTIL_PATH/../util; pwd)
@@ -32,13 +32,13 @@ popd
 
 echo Creating and building android host
 sudo chmod a+x util/moai
-sudo chmod a+x util/moaiutil
+sudo chmod a+x util/pito
 
 export MOAI_ROOT=$(pwd)
 pushd ~
 mkdir testhost
 cd testhost
 cp -R $MOAI_ROOT/samples/hello-moai src/
-moaiutil host init
-moaiutil host build android-gradle
+pito host init
+pito host build android-gradle
 popd

--- a/bin/ci-linux.sh
+++ b/bin/ci-linux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Setting up MoaiUtil path..."
+echo "Setting up pito path..."
 
 UTIL_PATH=$(dirname "${BASH_SOURCE[0]}")
 UTIL_PATH=$(cd $UTIL_PATH/../util; pwd)

--- a/bin/ci-osx.sh
+++ b/bin/ci-osx.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Setting up MoaiUtil path..."
+echo "Setting up pito path..."
 
 UTIL_PATH=$(dirname "${BASH_SOURCE[0]}")
 UTIL_PATH=$(cd $UTIL_PATH/../util; pwd)
@@ -32,7 +32,7 @@ popd
 
 pushd `dirname $0`/..
 sudo chmod a+x util/moai
-sudo chmod a+x util/moaiutil
+sudo chmod a+x util/pito
 export MOAI_ROOT=$(pwd)
 popd
 
@@ -42,13 +42,13 @@ echo Creating test project
 mkdir testhost
 cd testhost
 cp -R $MOAI_ROOT/samples/hello-moai src/
-moaiutil host init
+pito host init
 
 echo Creating and building ios host
-moaiutil host build ios
+pito host build ios
 
 echo Creating and building osx host
-moaiutil host build osx
+pito host build osx
 
 popd
 

--- a/bin/ci-windows.bat
+++ b/bin/ci-windows.bat
@@ -22,7 +22,7 @@ call bin\build-windows.bat
 echo Creating Windows Host
 mkdir hosttest
 cd hosttest
-moaiutil host init
-moaiutil host build windows
+pito host init
+pito host build windows
 
 popd

--- a/bin/create-host-ios.sh
+++ b/bin/create-host-ios.sh
@@ -4,4 +4,4 @@ cd `dirname $0`/..
 mkdir hosts
 
 cd util
-moaiutil host-ios -o ../hosts/ios/ $@
+pito host-ios -o ../hosts/ios/ $@

--- a/bin/create-host-osx.sh
+++ b/bin/create-host-osx.sh
@@ -4,4 +4,4 @@ cd `dirname $0`/..
 mkdir hosts
 
 cd util
-moaiutil host-osx-app -o ../hosts/osx/ $@
+pito host-osx-app -o ../hosts/osx/ $@

--- a/bin/env-linux.sh
+++ b/bin/env-linux.sh
@@ -39,7 +39,7 @@ cd $EMSDK_PATH
 . ./emsdk_set_env.sh
 popd > /dev/null
 
-echo "Setting up MoaiUtil path..."
+echo "Setting up pito path..."
 
 UTIL_PATH=$(dirname "${BASH_SOURCE[0]}")
 UTIL_PATH=$(cd $UTIL_PATH/../util; pwd)

--- a/bin/env-osx.sh
+++ b/bin/env-osx.sh
@@ -39,7 +39,7 @@ cd $EMSDK_PATH
 . ./emsdk_set_env.sh
 popd > /dev/null
 
-echo "Setting up MoaiUtil path..."
+echo "Setting up pito path..."
 
 UTIL_PATH=$(dirname "${BASH_SOURCE[0]}")
 UTIL_PATH=$(cd $UTIL_PATH/../util; pwd)

--- a/docs/building/On Windows.md
+++ b/docs/building/On Windows.md
@@ -13,7 +13,7 @@ Edit the bin\env-win.bat file and change the CMAKE_PATH to point to your cmake i
 
 From the SDK folder, run `bin\env-win.bat` to set the paths
 
-From the SDK folder, run `bin\build-windows.bat vs2013`. This will create a `lib\windows\vs2013\Distribute` folder inside your SDK folder which contains the includes and the libs needed to use libmoai in a custom host. It also includes a bin folder with the compiled bundled SDL host. This can be used to run any of the samples. This also adds moai.exe to the SDK_PATH/util folder in order for moaiutil scripts to run.
+From the SDK folder, run `bin\build-windows.bat vs2013`. This will create a `lib\windows\vs2013\Distribute` folder inside your SDK folder which contains the includes and the libs needed to use libmoai in a custom host. It also includes a bin folder with the compiled bundled SDL host. This can be used to run any of the samples. This also adds moai.exe to the SDK_PATH/util folder in order for pito scripts to run.
 
 ## Building Android Lib (using cmake)
 
@@ -50,11 +50,11 @@ From the SDK folder, run `bin\build-html.bat`. This will create the `lib\html\mo
 
 A Moai host is a project that links against the moai libraries. There is usually one host per project and setting up a host may involve pointing it to your lua source, editing the author and product names, changing the icon, and linking against different host modules. 
 
-To generate a host for your lua project, you use `moaiutil.bat` found in the util folder. `moaiutil.bat` requires a recent copy of moai.exe either in the util path or on your system path.
+To generate a host for your lua project, you use `pito.bat` found in the util folder. `pito.bat` requires a recent copy of moai.exe either in the util path or on your system path.
 
 Hosts will be generated under the `SDK_ROOT\hosts` folder by default but this can be changed by passing `-o [output dir]` .
 
-Hosts will also take a copy of the compiled libs they need from `SDK_ROOT\lib\[platform]` folder. The lib source can be changed with `-l [lib dir]`. Instead of a copy, a symlink to the lib can be created instead with `-s`. This only works if the moaiutil script is run in an administrator cmd window. This is useful if you are updating your libs and want all of your projects to get the update (instead of manually copying the libs to each project after building).
+Hosts will also take a copy of the compiled libs they need from `SDK_ROOT\lib\[platform]` folder. The lib source can be changed with `-l [lib dir]`. Instead of a copy, a symlink to the lib can be created instead with `-s`. This only works if the pito script is run in an administrator cmd window. This is useful if you are updating your libs and want all of your projects to get the update (instead of manually copying the libs to each project after building).
 
 Each host includes a `readme.md` file in the root of the host output that describes what steps are needed to customize and build the host.
 
@@ -62,21 +62,21 @@ Each host includes a `readme.md` file in the root of the host output that descri
 
 Generates a vs2013 solution that contains the sdl host sources and is preconfigured with a resource file for versioning and branding and an application and taskbar icon.
 
-`moaiutil host-windows-vs2013`  generates a host under `SDK_ROOT\hosts\windows\vs2013`
+`pito host-windows-vs2013`  generates a host under `SDK_ROOT\hosts\windows\vs2013`
 
-`moaiutil host-windows-vs2013 -s -l c:\moai\1.5-stable\lib\windows\vs2013 -o c:\projects\mygame\hosts\vs2013` generates a host using a symlink to the libs in `c:\moai\1.5-stable\lib\windows\vs2013` and places it at `c:\projects\mygame\hosts\vs2013`
+`pito host-windows-vs2013 -s -l c:\moai\1.5-stable\lib\windows\vs2013 -o c:\projects\mygame\hosts\vs2013` generates a host using a symlink to the libs in `c:\moai\1.5-stable\lib\windows\vs2013` and places it at `c:\projects\mygame\hosts\vs2013`
 
 ### Android Studio Host
 
 Generates a android studio (Google's new default IDE for android projects) compatible gradle project.
 
-`moaiutil host-android-gradle` generates a host under `SDK_ROOT\hosts\android-studio`
+`pito host-android-gradle` generates a host under `SDK_ROOT\hosts\android-studio`
 
 ### HTML/JS Host
 
 Generates a html site template containing a moai player that will play your moai lua in the browser.
 
-`moaiutil host-html` generates a host under `SDK_ROOT\hosts\html`
+`pito host-html` generates a host under `SDK_ROOT\hosts\html`
 
 
 # Building all Windows compatible Libs and Hosts

--- a/host-templates/html/README.md
+++ b/host-templates/html/README.md
@@ -16,7 +16,7 @@ Now, create a directory that you want to use as output directory. This is where 
 
 Now navigate into the `util` directory and execute the following command:
 
-`moaiutil.bat host-html --use-symlink --output-dir <output directory>`
+`pito.bat host-html --use-symlink --output-dir <output directory>`
 
 Replace `<output directory>` with your output directory. Note that you can shorten `--use-symlink` to `-s` and `--output-dir` to -`o`.
 

--- a/host-templates/html/run.bat
+++ b/host-templates/html/run.bat
@@ -1,3 +1,3 @@
 pushd www
-moaiutil serve
+pito serve
 popd

--- a/host-templates/html/run.sh
+++ b/host-templates/html/run.sh
@@ -1,3 +1,3 @@
 pushd www
-moaiutil serve
+pito serve
 popd

--- a/util/ant-libmoai/config.lua
+++ b/util/ant-libmoai/config.lua
@@ -1,6 +1,6 @@
 CONFIG_NAME = 'MOAI_MODULES' -- this will create a variable in Android.mk containing the relative path to this config file
 
--- Additional config files maybe specified on the command line. moaiutil libmoai-ant will
+-- Additional config files maybe specified on the command line. pito libmoai-ant will
 -- also look in its invoke directory for a config file that will be applied before additional
 -- config's specified on the command line.
 

--- a/util/environment/main.lua
+++ b/util/environment/main.lua
@@ -1,5 +1,5 @@
 --==============================================================
--- setup environment for MOAI and moaiutil
+-- setup environment for MOAI and pito
 --==============================================================
 local envFileName = MOAI_SDK_HOME .. "env.sh"
 local envStr = string.format ( 'export MOAI_SDK_HOME=%s\n', MOAI_SDK_HOME ) ..

--- a/util/host-android-gradle/main.lua
+++ b/util/host-android-gradle/main.lua
@@ -259,7 +259,11 @@ configureHost = function()
     [ output .. 'local.properties' ] = {
       [ 'sdk.dir=[^\n]+' ]= "sdk.dir="..sdkdir,
       [ 'ndk.dir=[^\n]+' ]= "ndk.dir="..ndkdir
-    }
+    },
+    -- TODO: Set up ApplicationId
+    -- [ output..'app/build.gradle' ] = {
+    --   ['com.getmoai'] = hostconfig['ApplicationId'],
+    --   },
 	})
   
   print("copying icons")

--- a/util/host/create.lua
+++ b/util/host/create.lua
@@ -17,7 +17,7 @@ end
 
 --we get here if we don't exist and we are a valid host
 print("creating host: "..hostname)
-os.execute("moaiutil "..hosts[hostname].." -c hostconfig.lua -o "..hostsFolder..hostname)
+os.execute("pito "..hosts[hostname].." -c hostconfig.lua -o "..hostsFolder..hostname)
 print("\n Host created ")
 
   

--- a/util/host/main.lua
+++ b/util/host/main.lua
@@ -52,7 +52,7 @@ end
 
 function ensureHostConfig()
   if (not hasConfig()) then
-    command_error("this command must be run from a project folder containing hostconfig.lua\nYou can create one using moaiutil host init\n")
+    command_error("this command must be run from a project folder containing hostconfig.lua\nYou can create one using pito host init\n")
   end
 end
 

--- a/util/package-cmake-sdk/main.lua
+++ b/util/package-cmake-sdk/main.lua
@@ -89,4 +89,4 @@ for i, v in ipairs ( CLEAN_DIRS ) do
 	MOAIFileSystem.deleteDirectory ( OUTPUT_DIR .. v, true )
 end
 
-moaiexec ( 'moaiutil make-lua-docs -o "%sdocs/sdk-lua-reference"', OUTPUT_DIR )
+moaiexec ( 'pito make-lua-docs -o "%sdocs/sdk-lua-reference"', OUTPUT_DIR )

--- a/util/package-cmake-sdk/moai-sdk/Readme.md
+++ b/util/package-cmake-sdk/moai-sdk/Readme.md
@@ -12,17 +12,17 @@ You should try to  structure your moai projects so that there is a source direct
 
 While you can use the moai desktop binary provided to run your moai lua code, you will eventually want to build your own host. Building your own host is required to run and deploy your project on other platforms (android, ios, html) or to customize the desktop version with your own icon and customisations or in preparation for submission to an app store.
 
-Managing and building these per platform hosts can be a headache and repeating the process for each project can get annoying. Thankfully this sdk provides a set of utility scripts to help with building and creating moai projects called `moaiutil`.
+Managing and building these per platform hosts can be a headache and repeating the process for each project can get annoying. Thankfully this sdk provides a set of utility scripts to help with building and creating moai projects called `pito`.
 
-To use moaiutil you should first add `<sdk-path>\util` to your `PATH` environment variable (if you haven't already done so).
+To use pito you should first add `<sdk-path>\util` to your `PATH` environment variable (if you haven't already done so).
 
 You should also ensure you have the requirements installed for the platforms you wish to support. See [Requirements](Requirements) section below.
 
 ### Creating Host Config ###
 
-moaiutil uses a lua based config file `hostconfig.lua` to create host projects with the correct settings and correct lua src location. To create this config file for the first time on a project, ensure you are one level up from your lua src and run 
+pito uses a lua based config file `hostconfig.lua` to create host projects with the correct settings and correct lua src location. To create this config file for the first time on a project, ensure you are one level up from your lua src and run 
 ```bash
-moaiutil host init
+pito host init
 ```
 This will create the hostconfig.lua which contains default settings for each platform, and can be edited to setup the name, source location, icon etc for the project you wish to build.
 
@@ -30,12 +30,12 @@ This will create the hostconfig.lua which contains default settings for each pla
 
 Once there is a hostconfig.lua, you can create (or recreate) a host project for a particular platform by running 
 ```bash
-moaiutil host create <host-name>
+pito host create <host-name>
 ```
 
 where `host-name` is the name of the host you want to create (normally named after the target plaform). For a list of supported host-names run 
 ```bash
-moaiutil host list
+pito host list
 ```
 
 The created host will be in a subfolder called `hosts\<host-name>` in your current project. 
@@ -44,17 +44,17 @@ The created host will be in a subfolder called `hosts\<host-name>` in your curre
 
 To customize the created host, you can just edit the files in `hosts\<host-name>` using either the ide (xcode, visual studio, android studio) for the project, or just with a text editor. 
 
-A better option (when applicable) is to just update the `hostconfig.lua` with new values and run `moaiutil host create <host-name>` again. This will remove your old `hosts/<host-name>` folder and create a new host with new settings. The advantage of this method is that you can recreate your host projects after updating the moai sdk to get all the latest fixes or customisations you have made to the sdk.
+A better option (when applicable) is to just update the `hostconfig.lua` with new values and run `pito host create <host-name>` again. This will remove your old `hosts/<host-name>` folder and create a new host with new settings. The advantage of this method is that you can recreate your host projects after updating the moai sdk to get all the latest fixes or customisations you have made to the sdk.
 
 ### Building the created host projects ###
 
 To build the created hosts you can launch the created project in the relevant ide (xcode, visual studio, android studio) or you can run 
 ```bash
-moaiutil host build <host-name>
+pito host build <host-name>
 ```
 or 
 ```bash
-moaiutil host run <host-name>
+pito host run <host-name>
 ```
 
 These scripts will create the host if it doesn't exist, then build it using the build.sh|bat script in the host directory. The run command will also call the run.bat|sh script in the host directory (if available) to launch the build application.

--- a/util/package-cmake-sdk/moai-sdk/Readme.md
+++ b/util/package-cmake-sdk/moai-sdk/Readme.md
@@ -14,6 +14,8 @@ While you can use the moai desktop binary provided to run your moai lua code, yo
 
 Managing and building these per platform hosts can be a headache and repeating the process for each project can get annoying. Thankfully this sdk provides a set of utility scripts to help with building and creating moai projects called `pito`.
 
+    pito: https://en.wiktionary.org/wiki/pito
+
 To use pito you should first add `<sdk-path>\util` to your `PATH` environment variable (if you haven't already done so).
 
 You should also ensure you have the requirements installed for the platforms you wish to support. See [Requirements](Requirements) section below.

--- a/util/package-sdk/main.lua
+++ b/util/package-sdk/main.lua
@@ -86,7 +86,7 @@ for i, v in ipairs ( CLEAN_DIRS ) do
 	MOAIFileSystem.deleteDirectory ( PACKAGE_DIR .. v, true )
 end
 
-util.moaiexec ( 'moaiutil make-lua-docs -o "%sdocs/sdk-lua-reference"', PACKAGE_DIR )
+util.moaiexec ( 'pito make-lua-docs -o "%sdocs/sdk-lua-reference"', PACKAGE_DIR )
 util.moaiexec ( './test-build.sh %s', PACKAGE_DIR )
 
 --MOAIFileSystem.copy ( PACKAGE_DIR .. 'bin/osx/moai', MOAI_SDK_HOME .. 'bin/osx/moai' )

--- a/util/pito
+++ b/util/pito
@@ -39,14 +39,19 @@ then
     fi
 fi
 
+case ${1} in
+    wut*)
+        echo    "         MOAI SDK location: $MOAI_SDK_HOME"
+        echo    "      MOAI binary location: $MOAI_SDK_BIN"
+        echo -n "    pito toolbelt location: " && which pito 
+        echo
+        exit 0
+        ;;
+esac
+
 # call pito.lua
 shift
 set $INVOKE_DIR $MOAI_SDK_HOME $MOAI_CMD $@
-
-echo    "         MOAI SDK location: $MOAI_SDK_HOME"
-echo    "      MOAI binary location: $MOAI_SDK_BIN"
-echo -n "    pito toolbelt location: " && which pito 
-echo
 
 pushd $MOAI_SDK_HOME/util > /dev/null
 $MOAI_SDK_BIN pito.lua $@

--- a/util/pito
+++ b/util/pito
@@ -22,7 +22,7 @@ then
 
     if [ -e $bin_build_script ] 
     then
-        echo "Will use the $bin_build_script to build the util/moai binary for use by moaiutil..."
+        echo "Will use the $bin_build_script to build the util/moai binary for use by pito..."
         $bin_build_script
     else
         echo "Could not determine which script to use to build util/moai binary .. aborting"
@@ -32,22 +32,22 @@ then
     echo "Need to confirm local moai binary was built ..."
     if [ -f $MOAI_SDK_BIN ]
     then
-        echo "Continuing moaiutil execution..."
+        echo "Continuing pito execution..."
     else
         echo "Something went wrong with building util/moai .. exiting!"
         exit 1
     fi
 fi
 
-# call moaiutil.lua
+# call pito.lua
 shift
 set $INVOKE_DIR $MOAI_SDK_HOME $MOAI_CMD $@
 
 echo    "         MOAI SDK location: $MOAI_SDK_HOME"
 echo    "      MOAI binary location: $MOAI_SDK_BIN"
-echo -n "moaiutil toolbelt location: " && which moaiutil 
+echo -n "    pito toolbelt location: " && which pito 
 echo
 
 pushd $MOAI_SDK_HOME/util > /dev/null
-$MOAI_SDK_BIN moaiutil.lua $@
+$MOAI_SDK_BIN pito.lua $@
 popd > /dev/null

--- a/util/pito.bat
+++ b/util/pito.bat
@@ -5,7 +5,7 @@ set INVOKE_DIR=%CD%
 set SDK_HOME=%SCRIPT_DIR%\..\
 set MOAI_CMD=%1
 
-rem Moaiutil scripts assume moaiutil is on the path
+rem pito scripts assume pito is on the path
 set PATH=%PATH%;%SCRIPT_DIR%
 
 set args=%INVOKE_DIR% %SDK_HOME% %MOAI_CMD%
@@ -19,7 +19,7 @@ if "%~1" neq "" (
    goto :parse
 )
 pushd %SCRIPT_DIR% 
-moai moaiutil.lua %args%
+moai pito.lua %args%
 popd 
 
 endlocal

--- a/util/pito.lua
+++ b/util/pito.lua
@@ -11,6 +11,11 @@ MOAI_CMD        = arg [ 3 ]
 SCRIPT_DIR      = string.format ( '%sutil/%s/', MOAI_SDK_HOME, MOAI_CMD or "help" )
 
 local usageText={}
+usageText["wut"] = [[
+    pito wut
+        Contemplate your pito.
+]]
+
 usageText["environment"] = [[
     pito environment 
         This command will give you the needed environment variables to use pito.

--- a/util/pito.lua
+++ b/util/pito.lua
@@ -12,7 +12,7 @@ SCRIPT_DIR      = string.format ( '%sutil/%s/', MOAI_SDK_HOME, MOAI_CMD or "help
 
 local usageText={}
 usageText["environment"] = [[
-    Cmd: pito environment 
+    pito environment 
         This command will give you the needed environment variables to use pito.
         Example:
             /absolute/path/to/moai_sdk/util/pito environment
@@ -20,7 +20,7 @@ usageText["environment"] = [[
 ]]
 
 usageText["init"] = [[
-    Cmd: pito init
+    pito init
         Run from your project folder to initialize a pito-managed set of host projects.
         Creates a hostconfig.lua file, which you must edit to describe your MOAI project.
         Example:
@@ -30,7 +30,7 @@ usageText["init"] = [[
 ]]
 
 usageText["host"] = [[
-    Cmd: pito host <subcommand> <args>
+    pito host <subcommand> <args>
         Subcommands:
             host list - Lists available hosts
             host init - Creates a template host config file used by subsequent commands
@@ -47,12 +47,12 @@ usageText["host"] = [[
 ]]
 
 usageText["make-lua-docs"] = [[
-    Cmd: pito make-lua-docs 
+    pito make-lua-docs 
         Creates compact documentation for the Lua-side of the MOAI API.
 ]]
 
 usageText["make-cpp-docs"] = [[
-    Cmd: pito make-cpp-docs
+    pito make-cpp-docs
         Creates compact documentation from the MOAI C/C++ codebase.
         Example:    
             cd newMOAIProject && pito make-cpp-docs
@@ -60,7 +60,7 @@ usageText["make-cpp-docs"] = [[
 ]]
 
 usageText["package-cmake-sdk"] = [[
-    Cmd: pito package-cmake-sdk
+    pito package-cmake-sdk
         Creates a distributable SDK based on cmake-driven MOAI build.
         Example:
             cd newMOAIProject && pito package-cmake-sdk
@@ -68,22 +68,22 @@ usageText["package-cmake-sdk"] = [[
 ]]
 
 usageText["package-sdk"] = [[
-    Cmd: pito package-sdk
+    pito package-sdk
         Create the standard release of the MOAI SDK.
 ]]
 
 usageText["run-samples"] = [[
-    Cmd: pito run-samples
+    pito run-samples
         Run the MOAI samples.
 ]]
 
 usageText["run-tests"] = [[
-    Cmd: pito run-tests
+    pito run-tests
         Run the Test suite.
 ]]
 
 usageText["sdk-version"] = [[
-    Cmd: pito sdk-version
+    pito sdk-version
         Obtain the MOAI SDK Version info for the current configuration.
 ]]
 

--- a/util/pito.lua
+++ b/util/pito.lua
@@ -12,25 +12,25 @@ SCRIPT_DIR      = string.format ( '%sutil/%s/', MOAI_SDK_HOME, MOAI_CMD or "help
 
 local usageText={}
 usageText["environment"] = [[
-    Cmd: moaiutil environment 
-        This command will give you the needed environment variables to use moaiutil.
+    Cmd: pito environment 
+        This command will give you the needed environment variables to use pito.
         Example:
-            /absolute/path/to/moai_sdk/util/moaiutil environment
+            /absolute/path/to/moai_sdk/util/pito environment
             (Follow instructions)
 ]]
 
 usageText["init"] = [[
-    Cmd: moaiutil init
-        Run from your project folder to initialize a moaiutil-managed set of host projects.
+    Cmd: pito init
+        Run from your project folder to initialize a pito-managed set of host projects.
         Creates a hostconfig.lua file, which you must edit to describe your MOAI project.
         Example:
             mkdir newMOAIProject && cd newMOAIProject   # use the toolbelt in a new project
-            moaiutil init 
+            pito init 
             vi hostconfig.lua                           #&etc.
 ]]
 
 usageText["host"] = [[
-    Cmd: moaiutil host <subcommand> <args>
+    Cmd: pito host <subcommand> <args>
         Subcommands:
             host list - Lists available hosts
             host init - Creates a template host config file used by subsequent commands
@@ -41,54 +41,54 @@ usageText["host"] = [[
             host create <hostname> - Creates the host in the hosts folder (removing old 
                                      host) based on latest config settings.
         Example:
-            cd newMOAIProject && moaiutil host create ios && \
-                                 moaiutil host create android-studio && \
-                                 moaiutil host create host osx-app && #etc.
+            cd newMOAIProject && pito host create ios && \
+                                 pito host create android-studio && \
+                                 pito host create host osx-app && #etc.
 ]]
 
 usageText["make-lua-docs"] = [[
-    Cmd: moaiutil make-lua-docs 
+    Cmd: pito make-lua-docs 
         Creates compact documentation for the Lua-side of the MOAI API.
 ]]
 
 usageText["make-cpp-docs"] = [[
-    Cmd: moaiutil make-cpp-docs
+    Cmd: pito make-cpp-docs
         Creates compact documentation from the MOAI C/C++ codebase.
         Example:    
-            cd newMOAIProject && moaiutil make-cpp-docs
+            cd newMOAIProject && pito make-cpp-docs
             find moai-sdk/ #&etc.
 ]]
 
 usageText["package-cmake-sdk"] = [[
-    Cmd: moaiutil package-cmake-sdk
+    Cmd: pito package-cmake-sdk
         Creates a distributable SDK based on cmake-driven MOAI build.
         Example:
-            cd newMOAIProject && moaiutil package-cmake-sdk
+            cd newMOAIProject && pito package-cmake-sdk
             find moai-sdk/ #&etc.
 ]]
 
 usageText["package-sdk"] = [[
-    Cmd: moaiutil package-sdk
+    Cmd: pito package-sdk
         Create the standard release of the MOAI SDK.
 ]]
 
 usageText["run-samples"] = [[
-    Cmd: moaiutil run-samples
+    Cmd: pito run-samples
         Run the MOAI samples.
 ]]
 
 usageText["run-tests"] = [[
-    Cmd: moaiutil run-tests
+    Cmd: pito run-tests
         Run the Test suite.
 ]]
 
 usageText["sdk-version"] = [[
-    Cmd: moaiutil sdk-version
+    Cmd: pito sdk-version
         Obtain the MOAI SDK Version info for the current configuration.
 ]]
 
 function usage(subSection)
-    print ("MOAI Utility Toolbelt - ", subSection or "general usage:")
+    print ("pito - the MOAI toolbelt - ", subSection or "general usage:")
     if (subSection) and (usageText[subSection])  then
         print(usageText[subSection])
     else

--- a/util/run-tests/main.lua
+++ b/util/run-tests/main.lua
@@ -109,7 +109,7 @@ end
 ----------------------------------------------------------------
 execute = function ( mode )
 
-	os.execute ( string.format ( 'moaiutil run-tests -b %s', mode ))
+	os.execute ( string.format ( 'pito run-tests -b %s', mode ))
 
 	if mode == 'test' then
 		if MOAIFileSystem.checkFileExists ( TEST_LOG_FILENAME ) then


### PR DESCRIPTION
pito:  https://en.wiktionary.org/wiki/pito

It means 'navel' in Rapa Nui (the language of Easter Island), as well as a few other excellent things in other languages.  Its a nice name for this tool, since all good things start at the navel, with beer, a flute, &etc.

I think we could also consider it an acronym of sorts, for "Put IT On" .. as in 'put it on this host" ..

In any case, this PR renames moaiutil to pito and updates everything in MOAI to use it.
