### PR TITLE
issue when building on ubuntu

### DIFF
--- a/src/moai-sim/MOAIImage.cpp
+++ b/src/moai-sim/MOAIImage.cpp
@@ -1,12 +1,11 @@
 // Copyright (c) 2010-2011 Zipline Games, Inc. All Rights Reserved.
 // http://getmoai.com
 
+#define PNG_SKIP_SETJMP_CHECK
 #include "pch.h"
-
 #if AKU_WITH_IMAGE_PNG
   #include <png.h>
 #endif
-
 #include <moai-sim/MOAIImage.h>
 #include <moai-sim/MOAIImageFormatMgr.h>
 #include <moai-sim/MOAIImageLoadTask.h>


### PR DESCRIPTION
Hey,
   Tried building on ubuntu 14.04 but failed with error 
checking types of args and return type for recvfrom... In file included from /usr/include/png.h:526:0,
                 from /home/travis/build/moaiforge/moai-sdk/src/moai-sim/MOAIImage.cpp:7:
/usr/include/pngconf.h:371:12: error: ‘**pngconf’ does not name a type
/usr/include/pngconf.h:372:12: error: ‘__dont**’ does not name a type`

Seen it also on some linux Travis builds.

This PR tries to fix this,  but I don;t think it's the best solution as I'm not too familiar with C/C++

Sebi
