### PR TITLE
Fix for gfx state bug (black textures)

### DIFF
--- a/src/moai-sim/MOAIGfxDevice.cpp
+++ b/src/moai-sim/MOAIGfxDevice.cpp
@@ -372,6 +372,7 @@ void MOAIGfxDevice::ResetState () {
 
 	// turn off texture
 	this->mTextureUnits [ 0 ] = 0;
+	this->mCurrentTexture = 0;
 	
 	// turn off blending
 	zglDisable ( ZGL_PIPELINE_BLEND );


### PR DESCRIPTION
Bug is revealed only when disabling debug draw on layer. 
