### PR TITLE
add argument to iOS  build to skip final host builds

### DIFF
--- a/util/build/build-ios-device.sh
+++ b/util/build/build-ios-device.sh
@@ -5,6 +5,8 @@ set -e # exit on error
 pushd $(dirname "${0}")/../../xcode > /dev/null
 
 xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme libmoai-ios-all -sdk iphoneos || exit 1
-xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios -sdk iphoneos || exit 1
+if [ ! "$1"=="justlibs" ]; then
+   xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios -sdk iphoneos || exit 1
+fi
 
 popd > /dev/null

--- a/util/build/build-ios-simulator.sh
+++ b/util/build/build-ios-simulator.sh
@@ -5,6 +5,9 @@ set -e # exit on error
 pushd $(dirname "${0}")/../../xcode > /dev/null
 
 xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme libmoai-ios-all -sdk iphonesimulator || exit 1
-xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios -sdk iphonesimulator || exit 1
+
+if [ ! "$1"=="justlibs" ]; then
+	xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios -sdk iphonesimulator || exit 1
+fi
 
 popd > /dev/null

--- a/util/build/build-ios.sh
+++ b/util/build/build-ios.sh
@@ -2,8 +2,8 @@
 
 set -e # exit on error
 
-./build-ios-simulator.sh || exit 1
-./build-ios-device.sh || exit 1
+./build-ios-simulator.sh $1 || exit 1
+./build-ios-device.sh $1 || exit 1
 
 pushd $(dirname "${0}")/../../xcode > /dev/null
 
@@ -13,7 +13,9 @@ IOS_LIB=../lib/ios
 # package libmoai ios
 
 pushd ./build/Build/Products/Release-iphoneos/ > /dev/null
-rm -rf "../Release-universal" # clean out the old dir (if any)
+if [ -d "../Release-universal" ]; then
+   rm -rf "../Release-universal" # clean out the old dir (if any)
+fi
 mkdir -p "../Release-universal" # make the new dir
 for f in *.a
 do
@@ -27,14 +29,17 @@ do
 done
 popd > /dev/null
 
-rm -rf $IOS_LIB
+if [ -d  "$IOS_LIB" ]; then
+  rm -rf $IOS_LIB
+fi
 mkdir -p $IOS_LIB
 cp -a ./build/Build/Products/Release-universal/*.a $IOS_LIB
 
 #---------------------------------------------------------------
 # build ios static
-xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios-static -sdk iphonesimulator || exit 1
-xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios-static -sdk iphoneos || exit 1
-
+if [ ! "$1"=="justlibs" ]; then
+  xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios-static -sdk iphonesimulator || exit 1
+  xcodebuild -derivedDataPath build -configuration Release -workspace moai.xcworkspace -scheme moai-ios-static -sdk iphoneos || exit 1
+fi
 
 popd > /dev/null


### PR DESCRIPTION
Sometimes we just want the libs (for custom host projects) so it is good to be able to just build libmoai and not moai-ios.

Includes small fixes to script to guard against errors on removal of non existent directories.
