### PR TITLE
Android binary builds

### DIFF
--- a/ant/libmoai/jni/Android.mk
+++ b/ant/libmoai/jni/Android.mk
@@ -9,6 +9,7 @@
 	include $(CLEAR_VARS)
 	
 	MOAI_SDK_HOME	:= $(abspath ../../../)
+	
 	MY_ARM_MODE		:= arm
 	MY_ARM_ARCH		:= armeabi-v7a arm64-v8a x86
 
@@ -41,14 +42,14 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/tlsf-2.0
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/zlib-1.2.3
 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-contrib.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-expat.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-json.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-lua.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-sfmt.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-sqlite.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-tinyxml.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-zlib.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-contrib.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-expat.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-json.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-lua.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-sfmt.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-sqlite.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-tinyxml.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-zlib.mk
 
 #================================================================#
 # moai core
@@ -59,10 +60,10 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/src
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/src/config-default
 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-core.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-vfs.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-core.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-util.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-core.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-vfs.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-core.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-util.mk
 
 #================================================================#
 # moai modules
@@ -72,13 +73,13 @@
 	# ADCOLONY
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-adcolony.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-adcolony.mk
 
 	#--------------------------------------------------------------#
 	# ANDROID
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-android.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-android.mk
 
 	#--------------------------------------------------------------#
 	# BOX2D
@@ -91,14 +92,14 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/box2d-2.3.0/Box2D/Dynamics
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/box2d-2.3.0/Box2D/Dynamics/Contacts
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/box2d-2.3.0/Box2D/Dynamics/Joints
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-box2d.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-box2d.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-box2d.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-box2d.mk
 
 	#--------------------------------------------------------------#
 	# CHARTBOOST
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-chartboost.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-chartboost.mk
 
 	#--------------------------------------------------------------#
 	# CRYPTO
@@ -107,30 +108,30 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/openssl-1.0.0m/include
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/openssl-1.0.0m
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/openssl-1.0.0m/crypto
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-a.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-b.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-c.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-d.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-crypto.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-crypto.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-crypto-a.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-crypto-b.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-crypto-c.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-crypto-d.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-crypto.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-crypto.mk
 
 	#--------------------------------------------------------------#
 	# FACEBOOK
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-facebook.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-facebook.mk
 
 	#--------------------------------------------------------------#
 	# FLURRY
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-flurry.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-flurry.mk
 
 	#--------------------------------------------------------------#
 	# GOOGLE_PLAY_SERVICES
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-google-play-services.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-google-play-services.mk
 
 	#--------------------------------------------------------------#
 	# HTTP_CLIENT
@@ -140,45 +141,45 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/curl-7.19.7/include-android
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/openssl-1.0.0m/include-android
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/openssl-1.0.0m/include
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-c-ares.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-curl.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-ssl.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-http-client.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-c-ares.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-curl.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-ssl.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-http-client.mk
 
 	#--------------------------------------------------------------#
 	# HTTP_SERVER
 
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/mongoose
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-mongoose.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-http-server.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-mongoose.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-http-server.mk
 
 	#--------------------------------------------------------------#
 	# IMAGE_JPG
 
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/jpeg-8c
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-jpg.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-jpg.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-jpg.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-image-jpg.mk
 
 	#--------------------------------------------------------------#
 	# IMAGE_PNG
 
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/lpng140
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-png.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-png.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-png.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-image-png.mk
 
 	#--------------------------------------------------------------#
 	# IMAGE_PVR
 
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/libpvr-3.4
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-pvr.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-pvr.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-pvr.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-image-pvr.mk
 
 	#--------------------------------------------------------------#
 	# IMAGE_WEBP
 
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-webp.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-webp.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-webp.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-image-webp.mk
 
 	#--------------------------------------------------------------#
 	# LUAEXT
@@ -189,7 +190,7 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/luasocket-2.0.2/src
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/luasocket-2.0.2-embed/src
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/luasql-2.2.0/src
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-luaext.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-luaext.mk
 
 	#--------------------------------------------------------------#
 	# SIM
@@ -201,22 +202,22 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/freetype-2.4.4/src
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/freetype-2.4.4/config
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/libtess2/Include
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-freetype.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-tess.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-gfx.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-sim.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-freetype.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-tess.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-gfx.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-sim.mk
 
 	#--------------------------------------------------------------#
 	# TAPJOY
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-tapjoy.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-tapjoy.mk
 
 	#--------------------------------------------------------------#
 	# TWITTER
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-twitter.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-twitter.mk
 
 	#--------------------------------------------------------------#
 	# UNTZ
@@ -228,16 +229,16 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/libvorbis-1.3.2/include
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/libvorbis-1.3.2/lib
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/libogg-1.2.2/include
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-ogg.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-vorbis.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-untz.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-untz.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-ogg.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-vorbis.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-untz.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-untz.mk
 
 	#--------------------------------------------------------------#
 	# VUNGLE
 
 	MY_HEADER_SEARCH_PATHS += 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-vungle.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-vungle.mk
 
 
 #================================================================#
@@ -245,4 +246,9 @@
 #================================================================#
 
 	include libraries.mk
-	include $(MY_INCLUDES)
+  ifdef USE_PREBUILT
+   include $(MOAI_SDK_HOME)/libmoai/jni/prebuiltcore.mk
+   include $(MOAI_SDK_HOME)/libmoai/jni/prebuilt.mk
+  else
+	 include $(MY_INCLUDES)
+  endif

--- a/util/ant-libmoai/Android.mk
+++ b/util/ant-libmoai/Android.mk
@@ -9,6 +9,7 @@
 	include $(CLEAR_VARS)
 	
 	MOAI_SDK_HOME	:= $(abspath @MOAI_SDK_HOME@)
+	
 	MY_ARM_MODE		:= @MY_ARM_MODE@
 	MY_ARM_ARCH		:= @MY_ARM_ARCH@
 
@@ -41,14 +42,14 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/tlsf-2.0
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/3rdparty/zlib-1.2.3
 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-contrib.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-expat.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-json.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-lua.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-sfmt.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-sqlite.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-tinyxml.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-zlib.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-contrib.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-expat.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-json.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-lua.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-sfmt.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-sqlite.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-tinyxml.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/3rdparty-zlib.mk
 
 #================================================================#
 # moai core
@@ -59,10 +60,10 @@
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/src
 	MY_HEADER_SEARCH_PATHS += $(MOAI_SDK_HOME)/src/config-default
 
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-core.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-vfs.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-core.mk
-	MY_INCLUDES += $(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-util.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-core.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/zl-vfs.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-core.mk
+	MY_INCLUDES += $(MOAI_MODULES)/modules/moai-util.mk
 
 #================================================================#
 # moai modules
@@ -75,4 +76,9 @@
 #================================================================#
 
 	include libraries.mk
-	include $(MY_INCLUDES)
+  ifdef USE_PREBUILT
+   include $(MOAI_SDK_HOME)/libmoai/jni/prebuiltcore.mk
+   include $(MOAI_SDK_HOME)/libmoai/jni/prebuilt.mk
+  else
+	 include $(MY_INCLUDES)
+  endif

--- a/util/ant-libmoai/MoaiTarget.mk
+++ b/util/ant-libmoai/MoaiTarget.mk
@@ -10,17 +10,23 @@ include $(CLEAR_VARS)
 LOCAL_MODULE 		:= @LIB_NAME@
 LOCAL_LDLIBS 		:= -llog -lGLESv1_CM -lGLESv2
 
+#Disable Modules Below
 @AKU_PREPROCESSOR@
 
+
+#remove unused libraries from this list (be sure to disable the aku flag above too)
+#these libraries will never be optimised out by the linker so need to be removed from this list when not in use.
+@STATIC_JNI_LIBRARIES@
+
 LOCAL_CFLAGS		:= $(MY_LOCAL_CFLAGS) -DAKU_WITH_PLUGINS=1 -include $(MOAI_SDK_HOME)/src/zl-vfs/zl_replace.h
-LOCAL_C_INCLUDES 	:= $(MY_HEADER_SEARCH_PATHS)
+LOCAL_C_INCLUDES 	:= $(LOCAL_PATH)/src $(MY_HEADER_SEARCH_PATHS)
 
 LOCAL_SRC_FILES 	+= src/jni.cpp
-LOCAL_SRC_FILES 	+= $(wildcard $(MOAI_SDK_HOME)/src/host-modules/*.cpp)
+LOCAL_SRC_FILES 	+= $(wildcard $(LOCAL_PATH)/src/host-modules/*.cpp)
 LOCAL_SRC_FILES 	+= src/aku_plugins.cpp
 
-LOCAL_STATIC_LIBRARIES := @STATIC_LIBRARIES@ libmoai-util libmoai-core libzl-core libcontrib libexpat libjson liblua libsfmt libsqlite libtinyxml libzl-vfs libzlib libcpufeatures
-LOCAL_WHOLE_STATIC_LIBRARIES := @WHOLE_STATIC_LIBRARIES@ libmoai-core
+LOCAL_STATIC_LIBRARIES := $(LOCAL_STATIC_JNI_LIBRARIES)  @STATIC_LIBRARIES@ libmoai-util libmoai-core libzl-core libcontrib libexpat libjson liblua libsfmt libsqlite libtinyxml libzl-vfs libzlib libcpufeatures
+LOCAL_WHOLE_STATIC_LIBRARIES := @WHOLE_STATIC_LIBRARIES@ libmoai-core libmoai-android
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/util/ant-libmoai/config.lua
+++ b/util/ant-libmoai/config.lua
@@ -39,7 +39,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-adcolony.mk',
+			'$(MOAI_MODULES)/modules/moai-adcolony.mk',
 		},
 		
 		JAVA = {
@@ -60,7 +60,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-android.mk',
+			'$(MOAI_MODULES)/modules/moai-android.mk',
 		},
 		
 		JAVA = {
@@ -89,8 +89,8 @@ MODULES = {
 		},
 	
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-box2d.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-box2d.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-box2d.mk',
+			'$(MOAI_MODULES)/modules/moai-box2d.mk',
 		},
 		
 		JAVA = {
@@ -109,7 +109,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-chartboost.mk',
+			'$(MOAI_MODULES)/modules/moai-chartboost.mk',
 		},
 		
 		JAVA = {
@@ -130,7 +130,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-crittercism.mk',
+			'$(MOAI_MODULES)/modules/moai-crittercism.mk',
 		},
 		
 		JAVA = {
@@ -155,12 +155,12 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-a.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-b.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-c.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-crypto-d.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-crypto.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-crypto.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-crypto-a.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-crypto-b.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-crypto-c.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-crypto-d.mk',
+			'$(MOAI_MODULES)/modules/zl-crypto.mk',
+			'$(MOAI_MODULES)/modules/moai-crypto.mk',
 		},
 		
 		JAVA = {
@@ -179,7 +179,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-facebook.mk',
+			'$(MOAI_MODULES)/modules/moai-facebook.mk',
 		},
 		
 		JAVA = {
@@ -201,7 +201,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-flurry.mk',
+			'$(MOAI_MODULES)/modules/moai-flurry.mk',
 		},
 		
 		JAVA = {
@@ -225,7 +225,7 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-fmod-ex.mk',
+			'$(MOAI_MODULES)/modules/moai-fmod-ex.mk',
 		},
 		
 		JAVA = {
@@ -238,14 +238,14 @@ MODULES = {
 	----------------------------------------------------------------
 	GOOGLE_PLAY_SERVICES = {
 		
-		PREPROCESSOR_FLAG = 'AKU_WITH_ANDROID_GOOGLE_PLAY',
+		PREPROCESSOR_FLAG = 'AKU_WITH_ANDROID_GOOGLE_PLAY_SERVICES',
 		NAMESPACE = 'com.moaisdk.googleplayservices',
 	
 		HEADER_SEARCH_PATHS = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-google-play-services.mk',
+			'$(MOAI_MODULES)/modules/moai-google-play-services.mk',
 		},
 		
 		JAVA = {
@@ -293,10 +293,10 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-c-ares.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-curl.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-ssl.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-http-client.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-c-ares.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-curl.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-ssl.mk',
+			'$(MOAI_MODULES)/modules/moai-http-client.mk',
 		},
 		
 		JAVA = {
@@ -316,8 +316,8 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-mongoose.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-http-server.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-mongoose.mk',
+			'$(MOAI_MODULES)/modules/moai-http-server.mk',
 		},
 		
 		JAVA = {
@@ -337,8 +337,8 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-jpg.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-jpg.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-jpg.mk',
+			'$(MOAI_MODULES)/modules/moai-image-jpg.mk',
 		},
 		
 		JAVA = {
@@ -358,8 +358,8 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-png.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-png.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-png.mk',
+			'$(MOAI_MODULES)/modules/moai-image-png.mk',
 		},
 		
 		JAVA = {
@@ -379,8 +379,8 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-pvr.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-pvr.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-pvr.mk',
+			'$(MOAI_MODULES)/modules/moai-image-pvr.mk',
 		},
 		
 		JAVA = {
@@ -400,8 +400,8 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-webp.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-image-webp.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-webp.mk',
+			'$(MOAI_MODULES)/modules/moai-image-webp.mk',
 		},
 		
 		JAVA = {
@@ -426,7 +426,7 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-luaext.mk',
+			'$(MOAI_MODULES)/modules/moai-luaext.mk',
 		},
 		
 		JAVA = {
@@ -452,10 +452,10 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-freetype.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-tess.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/zl-gfx.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-sim.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-freetype.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-tess.mk',
+			'$(MOAI_MODULES)/modules/zl-gfx.mk',
+			'$(MOAI_MODULES)/modules/moai-sim.mk',
 		},
 		
 		JAVA = {
@@ -474,7 +474,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-tapjoy.mk',
+			'$(MOAI_MODULES)/modules/moai-tapjoy.mk',
 		},
 		
 		JAVA = {
@@ -495,7 +495,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-twitter.mk',
+			'$(MOAI_MODULES)/modules/moai-twitter.mk',
 		},
 		
 		JAVA = {
@@ -521,10 +521,10 @@ MODULES = {
 		},
 		
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-ogg.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-vorbis.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/3rdparty-untz.mk',
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-untz.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-ogg.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-vorbis.mk',
+			'$(MOAI_MODULES)/modules/3rdparty-untz.mk',
+			'$(MOAI_MODULES)/modules/moai-untz.mk',
 		},
 		
 		JAVA = {
@@ -543,7 +543,7 @@ MODULES = {
 		},
 
 		MAKE = {
-			'$(MOAI_SDK_HOME)/util/ant-libmoai/modules/moai-vungle.mk',
+			'$(MOAI_MODULES)/modules/moai-vungle.mk',
 		},
 		
 		JAVA = {

--- a/util/ant-libmoai/main.lua
+++ b/util/ant-libmoai/main.lua
@@ -537,7 +537,7 @@ for k, path in pairs ( FOLDERS ) do
 		FOLDERS [ k ] = path
 
 		if path ~= INVOKE_DIR then
-		--	MOAIFileSystem.deleteDirectory ( path, true )
+			MOAIFileSystem.deleteDirectory ( path, true )
 			MOAIFileSystem.affirmPath ( path )
 		end
 	end

--- a/util/ant-libmoai/prebuiltcore.mk
+++ b/util/ant-libmoai/prebuiltcore.mk
@@ -1,0 +1,61 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmoai-util
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libmoai-util.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libexpat
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libexpat.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libsfmt
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libsfmt.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libcontrib
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libcontrib.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libsqlite
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libsqlite.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libtinyxml
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libtinyxml.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libzl-core
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libzl-core.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libzl-vfs
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libzl-vfs.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libzlib
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libzlib.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmoai-core
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libmoai-core.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libjson
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/libjson.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := liblua
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../obj/local/$(TARGET_ARCH_ABI)/liblua.a
+include $(PREBUILT_STATIC_LIBRARY)
+


### PR DESCRIPTION
The goal of this was to allow the main mk file for android builds able to handle prebuilt static libs (for quick custom host builds), this is done by having an optional "USE_PREBUILT" define that will include a mk file containing the prebuilt_static_library definitions, this file is generated by the ant-libmoai util script.

Also removes hardcoded path for $(MOAI_SDK_HOME)/util/ant-libmoai/ with a global defined by the script for $(MOAI_MODULES)

Splits libraries that have a java module apart so that they can be optionally removed easily in the mk file and not linked (they export jni stuff so are never eliminated by the linker )

These changes shouldn't impact default usage but @joshlytle might want to double check before merge.
