### PR TITLE
Add gamepad support to SDL host

### DIFF
--- a/src/moai-sim/MOAIJoystickSensor.h
+++ b/src/moai-sim/MOAIJoystickSensor.h
@@ -18,6 +18,10 @@ private:
 
 	float mX;
 	float mY;
+	// WHICH JOYSTICK IS IT?
+	int		mWhich;
+	// 1-BUTTON_DOWN, 2-BUTTON_UP, 3-AXIS, 4-NUM_JOYS, 5-JOY_ADD, 6-JOY_REMOVE, 7-NAME, 8-NUM_AXIS, 9-NUM_BUTTONS, 10-NUM_BALLS
+	int		mEvent; 
 	
 	MOAILuaStrongRef	mOnStick;
 
@@ -30,7 +34,7 @@ public:
 	DECL_LUA_FACTORY ( MOAIJoystickSensor )
 
 	//----------------------------------------------------------------//
-	static void			EnqueueJoystickEvent	( u8 deviceID, u8 sensorID, float x, float y );
+	static void			EnqueueJoystickEvent	( u8 deviceID, u8 sensorID, float x, float y, int which, int event );
 						MOAIJoystickSensor		();
 						~MOAIJoystickSensor		();
 	void				ParseEvent				( ZLStream& eventStream );


### PR DESCRIPTION
WARNING: this was prematurely posted, not a complete patch, do not approve
Adding gamepad support to the SDL host.
Requires two new paramaters to EnqueueJoystickEvent
Tested on Win/OSX/Linux, +Steam.
Be sure to include "gamecontrollerdb.txt" from the SDL library beside your deployed executable.