### PR TITLE
Fix Texture Memory reporting

### DIFF
--- a/src/moai-sim/MOAIGfxMgr.cpp
+++ b/src/moai-sim/MOAIGfxMgr.cpp
@@ -359,7 +359,7 @@ void MOAIGfxMgr::ReportTextureAlloc ( cc8* name, size_t size ) {
 
 	this->mTextureMemoryUsage += size;
 	float mb = ( float )this->mTextureMemoryUsage / 1024.0f / 1024.0f;
-	MOAILogF ( 0, ZLLog::LOG_STATUS, MOAILogMessages::MOAITexture_MemoryUse_SDFS, "+", size, mb, name );
+	MOAILogF ( 0, ZLLog::LOG_STATUS, MOAILogMessages::MOAITexture_MemoryUse_SDFS, "+", size/1024, mb, name );
 }
 
 //----------------------------------------------------------------//
@@ -367,7 +367,7 @@ void MOAIGfxMgr::ReportTextureFree ( cc8* name, size_t size ) {
 
 	this->mTextureMemoryUsage -= size;
 	float mb = ( float )this->mTextureMemoryUsage / 1024.0f / 1024.0f;
-	MOAILogF ( 0, ZLLog::LOG_STATUS, MOAILogMessages::MOAITexture_MemoryUse_SDFS, "-", size, mb, name );
+	MOAILogF ( 0, ZLLog::LOG_STATUS, MOAILogMessages::MOAITexture_MemoryUse_SDFS, "-", size/1024, mb, name );
 }
 
 //----------------------------------------------------------------//

--- a/src/moai-sim/MOAISingleTexture.cpp
+++ b/src/moai-sim/MOAISingleTexture.cpp
@@ -287,7 +287,7 @@ bool MOAISingleTexture::CreateTextureFromImage ( MOAIImage& srcImage ) {
 		}
 	}
 	
-	//MOAIGfxMgr::Get ().ReportTextureAlloc ( this->mDebugName, this->mTextureSize );
+	MOAIGfxMgr::Get ().ReportTextureAlloc ( this->mDebugName, this->mTextureSize );
 	
 	return true;
 }


### PR DESCRIPTION
Uncomment missing ReportTextureAlloc to balance numbers, Divide size by 1024 to match MOAITexture_MemoryUse_SDFS format with k(bytes)