### PR TITLE
Update Android host to work with new sdk

### DIFF
--- a/src/moai-android/java/src/com/moaisdk/core/MoaiActivity.java
+++ b/src/moai-android/java/src/com/moaisdk/core/MoaiActivity.java
@@ -34,8 +34,8 @@ import android.widget.LinearLayout;
 // Moai
 import com.moaisdk.core.*;
 
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import java.net.URLConnection;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import android.os.AsyncTask;
 import android.net.Uri;

--- a/src/moai-android/java/src/com/moaisdk/core/MoaiLocalNotificationReceiver.java
+++ b/src/moai-android/java/src/com/moaisdk/core/MoaiLocalNotificationReceiver.java
@@ -75,10 +75,16 @@ public class MoaiLocalNotificationReceiver extends BroadcastReceiver {
 
 		    PendingIntent contentIntent = PendingIntent.getActivity ( context, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT );
 
-		    NotificationManager notificationManager = ( NotificationManager ) context.getSystemService ( Context.NOTIFICATION_SERVICE );
-		    Notification notification = new Notification ( icon, message, System.currentTimeMillis ()); 
-		    notification.setLatestEventInfo ( context, title, message, contentIntent );
-		    notification.flags |= Notification.FLAG_AUTO_CANCEL;
+			NotificationManager notificationManager = ( NotificationManager ) context.getSystemService ( Context.NOTIFICATION_SERVICE );
+			// Notification notification = new Notification ( icon, message, System.currentTimeMillis ());
+			Notification.Builder notificationBuilder = new Notification.Builder(context);
+			notificationBuilder.setSmallIcon(icon);
+			notificationBuilder.setContentTitle(title);
+			notificationBuilder.setContentText(message);
+			notificationBuilder.setContentIntent(contentIntent);
+			notificationBuilder.setAutoCancel(true);
+
+			Notification notification = notificationBuilder.build();
 
 			String tag = intent.getStringExtra ( "collapse_key" );
 			int id = ( intent.getStringExtra ( "id" ) != null ) ? Integer.parseInt ( intent.getStringExtra ( "id" )) : 1;


### PR DESCRIPTION
The current Android host template does not build with newer Android SDK.

* Use Notificaiton.Builder instead of instantiating notifications
directly
* Replace HttpGet and DefaultHttpClient with HttpURLConnection (seems
like it's not used anyway)

Now it builds successfully with SDK version 25.