### PR TITLE
Free the newly allocated string, not the local buffer

### DIFF
--- a/src/zl-util/STLString.cpp
+++ b/src/zl-util/STLString.cpp
@@ -209,7 +209,7 @@ void STLString::write_var ( cc8* format, va_list args ) {
 	this->append ( buffer );
 	
 	if ( buffer != str ) {
-		free ( buffer );
+		free ( str );
 	}
 }
 


### PR DESCRIPTION
This code only happens when the newly formatted string is larger than the size of the local buffer (1024 bytes).  I uncovered the issue when I did a very long print from lua code.