### PR TITLE
Revert "MOAIGraphicsProp: Invoke draw with proper index"

### DIFF
--- a/src/moai-sim/MOAIGraphicsProp.cpp
+++ b/src/moai-sim/MOAIGraphicsProp.cpp
@@ -87,7 +87,7 @@ void MOAIGraphicsProp::MOAIDrawable_Draw ( int subPrimID ) {
 	this->LoadVertexTransform ();
 	this->LoadUVTransform ();
 	
-	this->mDeck->Draw ( this->mIndex );
+	this->mDeck->Draw ( this->mIndex - 1 );
 	
 	this->PopGfxState ();
 }


### PR DESCRIPTION
This reverts commit d503653496fff0205bddc6665a7b6d1a43835ca1.