### PR TITLE
fixed broken zlib compilation after upgrade to zlib-1.2.11

### DIFF
--- a/cmake/cmake/third-party/zlib/CMakeLists.txt
+++ b/cmake/cmake/third-party/zlib/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required ( VERSION 2.8.5 )
 project ( zlib )
 
-set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/zlib-1.2.8/" )
-set ( ZLIB_INCLUDES "${MOAI_ROOT}/3rdparty/zlib-1.2.8/" )
+set ( CMAKE_CURRENT_SOURCE_DIR "${MOAI_ROOT}/3rdparty/zlib-1.2.11/" )
+set ( ZLIB_INCLUDES "${MOAI_ROOT}/3rdparty/zlib-1.2.11/" )
 
 file ( GLOB ZLIB_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.c" )
 file ( GLOB ZLIB_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h" )

--- a/src/zl-gfx/ZLGfx.cpp
+++ b/src/zl-gfx/ZLGfx.cpp
@@ -45,7 +45,7 @@ ZLGfxListener::~ZLGfxListener () {
 ZLGfxHandle ZLGfx::CreateBuffer () {
 
 	#if defined( MOAI_OS_ANDROID ) || defined( MOAI_OS_HTML )
-		return ZLGfxHandle ( ZLGfxResource::EMPTY, 0, ZLGfxResource::NOT_ALLOCATED );
+		return ZLGfxHandle ( ZLGfxResource::NONE, 0, ZLGfxResource::NOT_ALLOCATED );
 	#else
 		ZLGfxHandle handle ( ZLGfxResource::BUFFER, 0, ZLGfxResource::PENDING_ALLOCATION );
 		this->AllocateResource ( *handle.mResource, 0 );


### PR DESCRIPTION
Fixes this error when compiling for Android, as discussed in slack. 

```
You have called ADD_LIBRARY for library zlib without any source files. This typically indicates a problem with your CMakeLists.txt file
-- Configuring done
CMake Error: CMake can not determine linker language for target: zlib
```