### PR TITLE
fix broken libmoai cmake android studio project after PI-develop merge

### DIFF
--- a/cmake/cmake/third-party/expat/CMakeLists.txt
+++ b/cmake/cmake/third-party/expat/CMakeLists.txt
@@ -8,8 +8,8 @@ if ( BUILD_WINDOWS )
   set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_MEMMOVE=1 -DXML_DTD" )
 endif (BUILD_WINDOWS)
 
-if ( BUILD_ANDROID ) 
-	set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_MEMMOVE=1 " )
+if ( BUILD_ANDROID )
+	set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_MEMMOVE=1 -DXML_DEV_URANDOM" )
 endif (BUILD_ANDROID )
 
 if ( BUILD_HTML )
@@ -28,7 +28,7 @@ target_include_directories (expat PUBLIC "$<BUILD_INTERFACE:${EXPAT_INCLUDES}>"
 target_compile_definitions (expat PUBLIC "XML_STATIC")
 set_target_properties( expat PROPERTIES FOLDER Third-Party )
 install(TARGETS expat EXPORT libmoai ARCHIVE DESTINATION lib)
-install(FILES 
+install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}expat.h
   ${CMAKE_CURRENT_SOURCE_DIR}expat_external.h
   DESTINATION include/expat


### PR DESCRIPTION
As discussed in Slack General, this is simply adding the fix from 

https://github.com/moai/moai-dev/commit/c572ee49aad168cda44856d52218142a5467d676 

Into the cmake file for expat as well, allowing the full android host that compiles libmoai to work again.