### PR TITLE
Changes to allow Android targets to run on WearOS

### DIFF
--- a/android-studio/app/build.gradle
+++ b/android-studio/app/build.gradle
@@ -25,6 +25,16 @@ android {
         exclude 'META-INF/LICENSE.txt'
     }
 
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'armeabi', 'armeabi-v7a', 'x86_64', 'arm64-v8a'
+            universalApk true
+        }
+    }
+
 }
 
 if (hasProperty('luaRoot')) {

--- a/android-studio/app/src/main/AndroidManifest.xml
+++ b/android-studio/app/src/main/AndroidManifest.xml
@@ -46,4 +46,6 @@
 
     <uses-feature android:name="android.hardware.screen.landscape" android:required="true" />
     <uses-feature android:name="android.hardware.touchscreen.multitouch" android:required="true" />
+    <uses-feature android:name="android.hardware.type.watch" />
+
 </manifest>

--- a/android-studio/libmoai/build.gradle
+++ b/android-studio/libmoai/build.gradle
@@ -15,12 +15,18 @@ android {
             }
         }
         ndk {
-            // Specifies the ABI configurations of your native
-            // libraries Gradle should build and package with your APK.
-            abiFilters 'x86'//, 'x86_64', 'armeabi-v7a'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a'
 
         }
 
+        splits {
+            abi {
+                enable true
+                reset()
+                include 'x86', 'armeabi', 'armeabi-v7a', 'x86_64', 'arm64-v8a'
+                universalApk true
+            }
+        }
 
     }
     buildTypes {
@@ -34,6 +40,17 @@ android {
             path new File(moaiSdkRoot).canonicalPath + '/cmake/cmake/hosts/host-android/CMakeLists.txt'
         }
     }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'armeabi-v7a', 'x86_64', 'arm64-v8a'
+
+            universalApk true
+        }
+    }
+
 }
 
 dependencies {

--- a/src/moai-android/java/build.gradle
+++ b/src/moai-android/java/build.gradle
@@ -23,6 +23,15 @@ android {
             java.srcDirs += 'src'
         }
     }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'armeabi', 'armeabi-v7a', 'x86_64', 'arm64-v8a'
+            universalApk true
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Testing Android targets on WearOS - works fine with these changes on Mobivoi Ticwatch (Android 8.0.0 API 26)